### PR TITLE
feat: add OpenAI upstream support to proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ graph LR
         AN[api.anthropic.com]
         GO["generativelanguage
         .googleapis.com"]
+        OA[api.openai.com]
     end
 
     subgraph Observability
@@ -49,11 +50,11 @@ graph LR
 
     A1 -- "ANTHROPIC_BASE_URL" --> P
     A2 -- "GOOGLE_GENAI_BASE_URL" --> P
-    A3 -. "auto_instrument() or
-    @trace_llm decorator" .-> OT
+    A3 -- "OPENAI_BASE_URL" --> P
 
     P -- "/v1/messages" --> AN
     P -- "/v1beta/models/*" --> GO
+    P -- "/v1/chat/completions" --> OA
     P -- "OTel spans" --> OT
     OT --> GR
 ```
@@ -201,6 +202,7 @@ agentweave proxy start --port 4000 --endpoint http://localhost:4318 --agent-id m
 # Point agents at the proxy — no code changes needed
 export ANTHROPIC_BASE_URL=http://localhost:4000
 export GOOGLE_GENAI_BASE_URL=http://localhost:4000
+export OPENAI_BASE_URL=http://localhost:4000
 ```
 
 One port, all providers. Every LLM call gets a span automatically.

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -1,17 +1,20 @@
 """AgentWeave Multi-Provider AI Proxy.
 
-Intercepts requests to Anthropic and Google Gemini APIs, emits an OTel span
-per call with token counts, model, stop reason, and latency, then forwards
-the response transparently to the caller.
+Intercepts requests to Anthropic, Google Gemini, and OpenAI APIs, emits an
+OTel span per call with token counts, model, stop reason, and latency, then
+forwards the response transparently to the caller.
 
 Provider is detected automatically from the request path:
   /v1/messages              → Anthropic  (api.anthropic.com)
   /v1beta/models/...        → Google     (generativelanguage.googleapis.com)
   /v1/models/...            → Google     (generativelanguage.googleapis.com)
+  /v1/chat/completions      → OpenAI     (api.openai.com)
+  /v1/completions           → OpenAI     (api.openai.com)
+  /v1/embeddings            → OpenAI     (api.openai.com)
 
 Works for both streaming and non-streaming requests. Zero code changes needed
-in calling agents — just point ANTHROPIC_BASE_URL / GOOGLE_GENAI_BASE_URL at
-this proxy.
+in calling agents — just point ANTHROPIC_BASE_URL / GOOGLE_GENAI_BASE_URL /
+OPENAI_BASE_URL at this proxy.
 
 Usage::
 
@@ -23,6 +26,9 @@ Usage::
     # Google / Gemini agents (pi-mono / Max)
     export GOOGLE_GENAI_BASE_URL=http://localhost:4000
     # or set in Google SDK: genai.configure(client_options={"api_endpoint": "localhost:4000"})
+
+    # OpenAI agents
+    export OPENAI_BASE_URL=http://localhost:4000
 
     # Tag calls by agent
     # X-AgentWeave-Agent-Id: max-v1
@@ -52,6 +58,7 @@ logger = logging.getLogger("agentweave.proxy")
 # --- Upstream base URLs ---
 _ANTHROPIC_BASE = "https://api.anthropic.com"
 _GOOGLE_BASE = "https://generativelanguage.googleapis.com"
+_OPENAI_BASE = "https://api.openai.com"
 
 # Headers always stripped before forwarding (hop-by-hop + proxy-specific)
 _SKIP_HEADERS_ALWAYS = {
@@ -69,7 +76,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 
 app = FastAPI(
     title="AgentWeave Proxy",
-    description="Multi-provider AI observability proxy (Anthropic + Google Gemini)",
+    description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
     version="0.2.0",
 )
 
@@ -100,17 +107,27 @@ def _check_auth(request: Request) -> JSONResponse | None:
 # Provider detection
 # ---------------------------------------------------------------------------
 
+_OPENAI_PATHS = {"v1/chat/completions", "v1/completions", "v1/embeddings"}
+
+
 def _detect_provider(path: str) -> str:
-    """Return 'google' or 'anthropic' based on the request path."""
+    """Return 'google', 'openai', or 'anthropic' based on the request path."""
     if path.startswith("v1beta/") or (
         path.startswith("v1/") and "/models/" in path
     ):
         return "google"
+    if path in _OPENAI_PATHS:
+        return "openai"
     return "anthropic"
 
 
 def _upstream_url(provider: str, path: str, query_string: str) -> str:
-    base = _GOOGLE_BASE if provider == "google" else _ANTHROPIC_BASE
+    if provider == "google":
+        base = _GOOGLE_BASE
+    elif provider == "openai":
+        base = _OPENAI_BASE
+    else:
+        base = _ANTHROPIC_BASE
     url = f"{base}/{path}"
     if query_string:
         url += f"?{query_string}"
@@ -191,7 +208,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     )
 
     if is_stream:
-        media = "text/event-stream" if provider == "anthropic" else "application/json"
+        media = "application/json" if provider == "google" else "text/event-stream"
         return StreamingResponse(_stream_and_trace(**kwargs), media_type=media)
     return await _request_and_trace(**kwargs)
 
@@ -261,6 +278,10 @@ async def _stream_and_trace(
 
                         if provider == "anthropic":
                             input_tokens, output_tokens, stop_reason = _parse_anthropic_sse(
+                                line, input_tokens, output_tokens, stop_reason
+                            )
+                        elif provider == "openai":
+                            input_tokens, output_tokens, stop_reason = _parse_openai_sse(
                                 line, input_tokens, output_tokens, stop_reason
                             )
                         else:  # google
@@ -358,6 +379,31 @@ def _parse_google_stream(
     return input_tokens, output_tokens, stop_reason
 
 
+def _parse_openai_sse(
+    line: str, input_tokens: int, output_tokens: int, stop_reason: str | None
+) -> tuple[int, int, str | None]:
+    if not line.startswith("data: "):
+        return input_tokens, output_tokens, stop_reason
+    payload = line[6:]
+    if payload == "[DONE]":
+        return input_tokens, output_tokens, stop_reason
+    try:
+        chunk = json.loads(payload)
+        # Token usage from final chunk (when stream_options.include_usage=true)
+        usage = chunk.get("usage")
+        if usage:
+            input_tokens = usage.get("prompt_tokens", input_tokens)
+            output_tokens = usage.get("completion_tokens", output_tokens)
+        choices = chunk.get("choices", [])
+        if choices:
+            reason = choices[0].get("finish_reason")
+            if reason:
+                stop_reason = reason
+    except (json.JSONDecodeError, KeyError, IndexError):
+        pass
+    return input_tokens, output_tokens, stop_reason
+
+
 # ---------------------------------------------------------------------------
 # Response attribute extractors
 # ---------------------------------------------------------------------------
@@ -367,6 +413,8 @@ def _extract_and_set_response(
 ) -> None:
     if provider == "google":
         _set_google_response_attrs(span, data, elapsed_ms)
+    elif provider == "openai":
+        _set_openai_response_attrs(span, data, elapsed_ms)
     else:
         _set_anthropic_response_attrs(span, data, elapsed_ms)
 
@@ -426,11 +474,42 @@ def _anthropic_response_text(data: dict) -> str:
     return ""
 
 
+def _set_openai_response_attrs(span: Any, data: dict, elapsed_ms: int) -> None:
+    usage = data.get("usage", {})
+    pt = usage.get("prompt_tokens", 0)
+    ct = usage.get("completion_tokens", 0)
+    tt = usage.get("total_tokens", pt + ct)
+    span.set_attribute(schema.PROV_LLM_PROMPT_TOKENS, pt)
+    span.set_attribute(schema.PROV_LLM_COMPLETION_TOKENS, ct)
+    span.set_attribute(schema.PROV_LLM_TOTAL_TOKENS, tt)
+    choices = data.get("choices", [])
+    stop = None
+    if choices:
+        stop = choices[0].get("finish_reason")
+        if stop:
+            span.set_attribute(schema.PROV_LLM_STOP_REASON, stop)
+    span.set_attribute("agentweave.latency_ms", elapsed_ms)
+    _maybe_set_response_preview(span, _openai_response_text(data))
+
+    # OTel gen_ai.* dual-emit
+    span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
+    span.set_attribute(schema.GEN_AI_USAGE_OUTPUT_TOKENS, ct)
+    if stop:
+        span.set_attribute(schema.GEN_AI_RESPONSE_FINISH_REASONS, [stop])
+
+
 def _google_response_text(data: dict) -> str:
     try:
         return (
             data["candidates"][0]["content"]["parts"][0].get("text", "")
         )
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+
+def _openai_response_text(data: dict) -> str:
+    try:
+        return data["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError):
         return ""
 
@@ -501,7 +580,7 @@ def run(host: str = "0.0.0.0", port: int = 4000) -> None:
     """Start the proxy server (called from CLI)."""
     import uvicorn
     logger.info(f"AgentWeave proxy listening on {host}:{port}")
-    logger.info("Providers: anthropic (/v1/messages), google (/v1beta/models/...)")
+    logger.info("Providers: anthropic (/v1/messages), google (/v1beta/models/...), openai (/v1/chat/completions)")
     uvicorn.run(app, host=host, port=port, log_level="info")
 
 

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1,0 +1,126 @@
+"""Tests for the AgentWeave proxy — provider detection and OpenAI parsers."""
+
+from agentweave.proxy import (
+    _detect_provider,
+    _openai_response_text,
+    _parse_openai_sse,
+    _set_openai_response_attrs,
+)
+
+
+class TestDetectProvider:
+    """Provider detection from request path."""
+
+    def test_openai_chat_completions(self):
+        assert _detect_provider("v1/chat/completions") == "openai"
+
+    def test_openai_completions(self):
+        assert _detect_provider("v1/completions") == "openai"
+
+    def test_openai_embeddings(self):
+        assert _detect_provider("v1/embeddings") == "openai"
+
+    def test_anthropic_messages(self):
+        assert _detect_provider("v1/messages") == "anthropic"
+
+    def test_google_v1beta(self):
+        assert _detect_provider("v1beta/models/gemini-2.5-pro:generateContent") == "google"
+
+    def test_google_v1_models(self):
+        assert _detect_provider("v1/models/gemini-2.5-pro:generateContent") == "google"
+
+    def test_anthropic_fallback(self):
+        assert _detect_provider("v1/unknown/path") == "anthropic"
+
+
+class _FakeSpan:
+    """Minimal span stub that records set_attribute calls."""
+
+    def __init__(self):
+        self.attrs: dict = {}
+
+    def set_attribute(self, key: str, value):
+        self.attrs[key] = value
+
+
+class TestSetOpenaiResponseAttrs:
+    """Verify _set_openai_response_attrs populates correct span attributes."""
+
+    def test_basic(self):
+        span = _FakeSpan()
+        data = {
+            "choices": [{"message": {"content": "hello"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        _set_openai_response_attrs(span, data, elapsed_ms=42)
+        assert span.attrs["prov.llm.prompt_tokens"] == 10
+        assert span.attrs["prov.llm.completion_tokens"] == 5
+        assert span.attrs["prov.llm.total_tokens"] == 15
+        assert span.attrs["prov.llm.stop_reason"] == "stop"
+        assert span.attrs["agentweave.latency_ms"] == 42
+        # gen_ai.* dual-emit
+        assert span.attrs["gen_ai.usage.input_tokens"] == 10
+        assert span.attrs["gen_ai.usage.output_tokens"] == 5
+        assert span.attrs["gen_ai.response.finish_reasons"] == ["stop"]
+
+    def test_no_choices(self):
+        span = _FakeSpan()
+        data = {"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}}
+        _set_openai_response_attrs(span, data, elapsed_ms=10)
+        assert span.attrs["prov.llm.prompt_tokens"] == 1
+        assert "prov.llm.stop_reason" not in span.attrs
+
+
+class TestOpenaiResponseText:
+    """Verify text extraction from OpenAI response format."""
+
+    def test_normal(self):
+        data = {"choices": [{"message": {"content": "Hi there"}}]}
+        assert _openai_response_text(data) == "Hi there"
+
+    def test_empty_choices(self):
+        assert _openai_response_text({"choices": []}) == ""
+
+    def test_missing_keys(self):
+        assert _openai_response_text({}) == ""
+
+
+class TestParseOpenaiSse:
+    """Verify streaming SSE token accumulation and finish_reason."""
+
+    def test_usage_chunk(self):
+        line = 'data: {"usage": {"prompt_tokens": 20, "completion_tokens": 8}}'
+        inp, out, stop = _parse_openai_sse(line, 0, 0, None)
+        assert inp == 20
+        assert out == 8
+        assert stop is None
+
+    def test_finish_reason(self):
+        line = 'data: {"choices": [{"finish_reason": "stop", "delta": {"content": ""}}]}'
+        inp, out, stop = _parse_openai_sse(line, 0, 0, None)
+        assert stop == "stop"
+
+    def test_done_sentinel(self):
+        line = "data: [DONE]"
+        inp, out, stop = _parse_openai_sse(line, 5, 3, "stop")
+        assert (inp, out, stop) == (5, 3, "stop")
+
+    def test_non_data_line(self):
+        line = "event: message"
+        inp, out, stop = _parse_openai_sse(line, 1, 2, None)
+        assert (inp, out, stop) == (1, 2, None)
+
+    def test_accumulation(self):
+        """Simulate a multi-chunk stream."""
+        inp, out, stop = 0, 0, None
+        lines = [
+            'data: {"choices": [{"delta": {"content": "Hi"}, "finish_reason": null}]}',
+            'data: {"choices": [{"delta": {"content": " there"}, "finish_reason": "stop"}]}',
+            'data: {"usage": {"prompt_tokens": 15, "completion_tokens": 4}}',
+            "data: [DONE]",
+        ]
+        for l in lines:
+            inp, out, stop = _parse_openai_sse(l, inp, out, stop)
+        assert inp == 15
+        assert out == 4
+        assert stop == "stop"


### PR DESCRIPTION
## Summary
- Adds OpenAI as a third upstream provider in the AgentWeave proxy, completing multi-provider support (Anthropic + Google Gemini + OpenAI)
- Detects `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings` paths and routes to `api.openai.com`
- Parses OpenAI response and streaming SSE formats for token counts, stop reason, and response preview with gen_ai.* dual-emit
- Adds 17 unit tests for provider detection and OpenAI parsers (58 total tests pass)
- Updates README mermaid diagram and proxy docs to include OpenAI

Closes #33

## Test plan
- [x] `cd sdk/python && python3 -m pytest tests/test_proxy.py -v` — 17 new tests pass
- [x] `cd sdk/python && python3 -m pytest -v` — all 58 tests pass
- [ ] Manual: set `OPENAI_BASE_URL=http://localhost:4000`, run an OpenAI SDK call, verify span in backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)