### PR TITLE
feat: Tempo MinIO migration manifests + monitoring infra-as-code

### DIFF
--- a/deploy/k8s/monitoring/README-tempo-minio-migration.md
+++ b/deploy/k8s/monitoring/README-tempo-minio-migration.md
@@ -1,0 +1,94 @@
+# Tempo MinIO Migration Runbook
+
+## Why
+
+Tempo's local storage backend has a known compaction bug that causes trace data
+corruption and eventual disk pressure under sustained write loads. Moving to
+MinIO (S3-compatible object storage) resolves this by offloading block storage
+to an object store, which Tempo's compactor handles reliably.
+
+Ref: AgentWeave issue #32
+
+## Prerequisites
+
+- `kubectl` access to the cluster
+- `monitoring` namespace exists
+- Tempo is currently running in the `monitoring` namespace
+
+## Migration Steps
+
+### 1. Deploy MinIO
+
+```bash
+kubectl apply -k deploy/k8s/monitoring/
+```
+
+### 2. Wait for MinIO to be ready
+
+```bash
+kubectl -n monitoring rollout status deployment/minio
+```
+
+### 3. Verify the init job created the bucket
+
+```bash
+kubectl -n monitoring wait --for=condition=complete job/minio-init-bucket --timeout=120s
+kubectl -n monitoring logs job/minio-init-bucket -c create-bucket
+```
+
+### 4. (Optional) Migrate existing trace blocks
+
+If you need to preserve existing local blocks, port-forward the MinIO console
+and use `mc mirror` to copy them into the `tempo` bucket:
+
+```bash
+# Port-forward MinIO API
+kubectl -n monitoring port-forward svc/minio 9000:9000 &
+
+# Configure mc alias
+mc alias set local http://localhost:9000 minioadmin minioadmin123
+
+# Copy existing blocks into MinIO
+mc mirror /var/tempo/blocks/ local/tempo/
+```
+
+### 5. Apply the new Tempo ConfigMap
+
+```bash
+kubectl -n monitoring apply -f deploy/k8s/monitoring/tempo-configmap-minio.yaml
+```
+
+If Tempo is currently using a ConfigMap named `tempo-config`, update the Tempo
+deployment to reference `tempo-config-minio` instead, or replace the existing
+ConfigMap contents.
+
+### 6. Restart Tempo
+
+```bash
+kubectl -n monitoring rollout restart deployment/tempo
+kubectl -n monitoring rollout status deployment/tempo
+```
+
+### 7. Verify
+
+```bash
+# Port-forward Tempo HTTP API
+kubectl -n monitoring port-forward svc/tempo 3200:3200 &
+
+# Check Tempo is healthy
+curl -s http://localhost:3200/ready
+
+# Check storage is working (should return 200)
+curl -s http://localhost:3200/status
+
+# Send a test trace and query it back to confirm end-to-end
+```
+
+## Rollback
+
+To revert to local storage, re-apply the original Tempo ConfigMap and restart:
+
+```bash
+kubectl -n monitoring apply -f <original-tempo-configmap.yaml>
+kubectl -n monitoring rollout restart deployment/tempo
+```

--- a/deploy/k8s/monitoring/kustomization.yaml
+++ b/deploy/k8s/monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - minio.yaml
+  - minio-init-job.yaml
+  - tempo-configmap-minio.yaml

--- a/deploy/k8s/monitoring/minio-init-job.yaml
+++ b/deploy/k8s/monitoring/minio-init-job.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-init-bucket
+  namespace: monitoring
+spec:
+  template:
+    metadata:
+      labels:
+        app: minio-init
+    spec:
+      initContainers:
+        - name: wait-for-minio
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Waiting for MinIO to be ready..."
+              until wget -qO- http://minio.monitoring.svc.cluster.local:9000/minio/health/live; do
+                echo "MinIO not ready, retrying in 3s..."
+                sleep 3
+              done
+              echo "MinIO is ready."
+      containers:
+        - name: create-bucket
+          image: minio/mc:RELEASE.2024-01-16T16-06-34Z
+          command:
+            - sh
+            - -c
+            - |
+              mc alias set local http://minio.monitoring.svc.cluster.local:9000 minioadmin minioadmin123
+              mc mb --ignore-existing local/tempo
+              echo "Bucket 'tempo' is ready."
+      restartPolicy: OnFailure
+  backoffLimit: 5

--- a/deploy/k8s/monitoring/minio.yaml
+++ b/deploy/k8s/monitoring/minio.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: monitoring
+type: Opaque
+data:
+  MINIO_ROOT_USER: bWluaW9hZG1pbg==
+  MINIO_ROOT_PASSWORD: bWluaW9hZG1pbjEyMw==
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: monitoring
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2024-01-16T16-07-38Z
+          args:
+            - "server"
+            - "/data"
+            - "--console-address"
+            - ":9001"
+          envFrom:
+            - secretRef:
+                name: minio-credentials
+          ports:
+            - name: api
+              containerPort: 9000
+            - name: console
+              containerPort: 9001
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 500m
+            requests:
+              memory: 256Mi
+              cpu: 100m
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: monitoring
+  labels:
+    app: minio
+spec:
+  type: ClusterIP
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: api
+    - name: console
+      port: 9001
+      targetPort: console

--- a/deploy/k8s/monitoring/tempo-configmap-minio.yaml
+++ b/deploy/k8s/monitoring/tempo-configmap-minio.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo-config-minio
+  namespace: monitoring
+data:
+  tempo.yaml: |
+    server:
+      http_listen_port: 3200
+
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: "0.0.0.0:4317"
+            http:
+              endpoint: "0.0.0.0:4318"
+
+    ingester:
+      trace_idle_period: 10s
+      max_block_bytes: 1048576
+      max_block_duration: 5m
+
+    compactor:
+      compaction:
+        block_retention: 48h
+
+    storage:
+      trace:
+        backend: s3
+        s3:
+          endpoint: minio.monitoring.svc.cluster.local:9000
+          bucket: tempo
+          access_key: minioadmin
+          secret_key: minioadmin123
+          insecure: true
+        wal:
+          path: /var/tempo/wal
+        local:
+          path: /var/tempo/blocks


### PR DESCRIPTION
Closes #32

## What
Full infra-as-code for the Tempo → MinIO migration, all under `deploy/k8s/monitoring/`:

| File | Purpose |
|------|---------|
| `minio.yaml` | MinIO deployment, service, secret, 20Gi PVC |
| `minio-init-job.yaml` | Creates `tempo` bucket on first deploy |
| `tempo-configmap-minio.yaml` | Updated Tempo config with S3 backend |
| `kustomization.yaml` | `kubectl apply -k deploy/k8s/monitoring/` entrypoint |
| `README-tempo-minio-migration.md` | Step-by-step migration runbook with rollback |

## Why
Local filesystem backend has a compaction bug: merged blocks get `meta.compacted.json` but the output block is missing `meta.json`, making historical traces invisible to search. See issue #32 for full investigation notes.

## How to apply
```bash
kubectl apply -k deploy/k8s/monitoring/
kubectl rollout restart deployment/tempo -n monitoring
```