### PR TITLE
feat: session/project/turn context propagation

### DIFF
--- a/deploy/grafana/agentweave-overview.json
+++ b/deploy/grafana/agentweave-overview.json
@@ -47,6 +47,24 @@
             }
           ],
           "hide": 0
+        },
+        {
+          "name": "project",
+          "label": "Project",
+          "type": "custom",
+          "query": ".*",
+          "current": {
+            "text": "All",
+            "value": ".*"
+          },
+          "options": [
+            {
+              "text": "All",
+              "value": ".*",
+              "selected": true
+            }
+          ],
+          "hide": 0
         }
       ]
     },
@@ -597,6 +615,187 @@
               ]
             }
           ]
+        }
+      },
+      {
+        "id": 8,
+        "title": "Session Explorer",
+        "type": "table",
+        "gridPos": {
+          "x": 0,
+          "y": 24,
+          "w": 24,
+          "h": 10
+        },
+        "datasource": {
+          "type": "tempo",
+          "uid": "cffj9et53r9j4f"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "cffj9et53r9j4f"
+            },
+            "queryType": "traceql",
+            "query": "{ resource.service.name = \"agentweave-proxy\" && span.prov.session.id != \"\" && span.prov.project =~ \"${project}\" }",
+            "tableType": "traces",
+            "limit": 100,
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "frameIndex": 0,
+          "showHeader": true
+        },
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "align": "auto"
+            }
+          }
+        }
+      },
+      {
+        "id": 9,
+        "title": "Project Rollup",
+        "type": "barchart",
+        "gridPos": {
+          "x": 0,
+          "y": 34,
+          "w": 12,
+          "h": 8
+        },
+        "datasource": {
+          "type": "tempo",
+          "uid": "cffj9et53r9j4f"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "cffj9et53r9j4f"
+            },
+            "queryType": "traceql",
+            "query": "{ resource.service.name = \"agentweave-proxy\" && span.prov.project != \"\" }",
+            "tableType": "traces",
+            "limit": 500,
+            "refId": "A"
+          }
+        ],
+        "transformations": [
+          {
+            "id": "groupBy",
+            "options": {
+              "fields": {
+                "prov.project": {
+                  "aggregations": [],
+                  "operation": "groupby"
+                },
+                "traceID": {
+                  "aggregations": [
+                    "count"
+                  ],
+                  "operation": "aggregate"
+                }
+              }
+            }
+          },
+          {
+            "id": "organize",
+            "options": {
+              "renameByName": {
+                "prov.project": "Project",
+                "traceID (count)": "Calls"
+              }
+            }
+          },
+          {
+            "id": "sortBy",
+            "options": {
+              "fields": [
+                {
+                  "displayName": "Calls",
+                  "desc": true
+                }
+              ]
+            }
+          }
+        ],
+        "options": {
+          "xField": "Project",
+          "orientation": "auto",
+          "fillOpacity": 80,
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "lineWidth": 1,
+              "fillOpacity": 80
+            }
+          }
+        }
+      },
+      {
+        "id": 10,
+        "title": "Turn Depth Histogram",
+        "type": "histogram",
+        "gridPos": {
+          "x": 12,
+          "y": 34,
+          "w": 12,
+          "h": 8
+        },
+        "datasource": {
+          "type": "tempo",
+          "uid": "cffj9et53r9j4f"
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "tempo",
+              "uid": "cffj9et53r9j4f"
+            },
+            "queryType": "traceql",
+            "query": "{ resource.service.name = \"agentweave-proxy\" && span.prov.session.turn > 0 && span.prov.project =~ \"${project}\" }",
+            "tableType": "traces",
+            "limit": 500,
+            "refId": "A"
+          }
+        ],
+        "options": {
+          "bucketSize": 1,
+          "combine": false,
+          "fillOpacity": 80,
+          "gradientMode": "none",
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single"
+          }
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "lineWidth": 1
+            }
+          }
         }
       }
     ]

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -65,6 +65,9 @@ _SKIP_HEADERS_ALWAYS = {
     "host", "content-length", "transfer-encoding", "connection",
     "x-agentweave-agent-id",
     "x-agentweave-agent-model",
+    "x-agentweave-session-id",
+    "x-agentweave-project",
+    "x-agentweave-turn",
 }
 
 # Runtime auth token. Set AGENTWEAVE_PROXY_TOKEN or --auth-token.
@@ -186,6 +189,16 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         or model
     )
 
+    session_id = request.headers.get("x-agentweave-session-id")
+    project = request.headers.get("x-agentweave-project")
+    turn: int | None = None
+    turn_raw = request.headers.get("x-agentweave-turn")
+    if turn_raw is not None:
+        try:
+            turn = int(turn_raw)
+        except (ValueError, TypeError):
+            logger.warning("x-agentweave-turn is not a valid integer: %r", turn_raw)
+
     forward_headers = {
         k: v for k, v in request.headers.items()
         if k.lower() not in _SKIP_HEADERS_ALWAYS
@@ -211,6 +224,9 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         agent_id=agent_id,
         agent_model=agent_model,
         path=path,
+        session_id=session_id,
+        project=project,
+        turn=turn,
     )
 
     if is_stream:
@@ -226,12 +242,14 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
 async def _request_and_trace(
     upstream_url: str, method: str, headers: dict, body: dict, body_bytes: bytes,
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
+    session_id: str | None = None, project: str | None = None, turn: int | None = None,
 ) -> JSONResponse:
     tracer = get_tracer()
     with tracer.start_as_current_span(f"{schema.SPAN_PREFIX_LLM}.{model}") as span:
         _set_request_attrs(span, model=model, provider=provider,
                            agent_id=agent_id, agent_model=agent_model,
-                           path=path, body=body)
+                           path=path, body=body,
+                           session_id=session_id, project=project, turn=turn)
         start = time.perf_counter()
         try:
             async with httpx.AsyncClient(timeout=300) as client:
@@ -256,12 +274,14 @@ async def _request_and_trace(
 async def _stream_and_trace(
     upstream_url: str, method: str, headers: dict, body: dict, body_bytes: bytes,
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
+    session_id: str | None = None, project: str | None = None, turn: int | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     span = tracer.start_span(f"{schema.SPAN_PREFIX_LLM}.{model}")
     _set_request_attrs(span, model=model, provider=provider,
                        agent_id=agent_id, agent_model=agent_model,
-                       path=path, body=body)
+                       path=path, body=body,
+                       session_id=session_id, project=project, turn=turn)
 
     input_tokens = output_tokens = 0
     stop_reason = None
@@ -532,6 +552,7 @@ def _maybe_set_response_preview(span: Any, text: str) -> None:
 def _set_request_attrs(
     span: Any, model: str, provider: str, agent_id: str, agent_model: str,
     path: str, body: dict,
+    session_id: str | None = None, project: str | None = None, turn: int | None = None,
 ) -> None:
     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
     span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
@@ -540,6 +561,13 @@ def _set_request_attrs(
     span.set_attribute(schema.PROV_AGENT_MODEL, agent_model)
     span.set_attribute(schema.PROV_WAS_ASSOCIATED_WITH, agent_id)
     span.set_attribute("http.route", f"/{path}")
+
+    if session_id is not None:
+        span.set_attribute(schema.PROV_SESSION_ID, session_id)
+    if project is not None:
+        span.set_attribute(schema.PROV_PROJECT, project)
+    if turn is not None:
+        span.set_attribute(schema.PROV_SESSION_TURN, turn)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -41,6 +41,11 @@ PROV_AGENT_ID = "prov.agent.id"
 PROV_AGENT_MODEL = "prov.agent.model"
 PROV_AGENT_VERSION = "prov.agent.version"
 
+# prov:Session — session and project context propagated via proxy headers
+PROV_SESSION_ID = "prov.session.id"
+PROV_PROJECT = "prov.project"
+PROV_SESSION_TURN = "prov.session.turn"
+
 # prov:wasGeneratedBy — output linked to producing activity
 PROV_WAS_GENERATED_BY = "prov.wasGeneratedBy"
 

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -478,6 +478,19 @@ class TestHeaderForwarding:
         assert "authorization" not in result
         assert result["x-api-key"] == "sk-ant-123"
 
+    def test_session_headers_stripped(self):
+        headers = {
+            "x-agentweave-session-id": "sess-123",
+            "x-agentweave-project": "launchpad",
+            "x-agentweave-turn": "5",
+            "x-api-key": "sk-ant-123",
+        }
+        result = self._filter_headers(headers, token_set=False)
+        assert "x-agentweave-session-id" not in result
+        assert "x-agentweave-project" not in result
+        assert "x-agentweave-turn" not in result
+        assert result["x-api-key"] == "sk-ant-123"
+
     def test_auth_forwarded_when_no_proxy_token(self):
         headers = {
             "authorization": "Bearer sk-ant-123",
@@ -485,3 +498,47 @@ class TestHeaderForwarding:
         }
         result = self._filter_headers(headers, token_set=False)
         assert result["authorization"] == "Bearer sk-ant-123"
+
+
+# ---------------------------------------------------------------------------
+# Session context
+# ---------------------------------------------------------------------------
+
+
+class TestSessionContext:
+    """Verify session/project/turn attributes are set on spans."""
+
+    def _call(self, monkeypatch, session_id=None, project=None, turn=None):
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+            session_id=session_id, project=project, turn=turn,
+        )
+        return span
+
+    def test_all_set(self, monkeypatch):
+        span = self._call(monkeypatch, session_id="sess-abc", project="launchpad", turn=3)
+        assert span.attrs["prov.session.id"] == "sess-abc"
+        assert span.attrs["prov.project"] == "launchpad"
+        assert span.attrs["prov.session.turn"] == 3
+
+    def test_partial_set(self, monkeypatch):
+        span = self._call(monkeypatch, session_id="sess-xyz")
+        assert span.attrs["prov.session.id"] == "sess-xyz"
+        assert "prov.project" not in span.attrs
+        assert "prov.session.turn" not in span.attrs
+
+    def test_none_set(self, monkeypatch):
+        span = self._call(monkeypatch)
+        assert "prov.session.id" not in span.attrs
+        assert "prov.project" not in span.attrs
+        assert "prov.session.turn" not in span.attrs
+
+    def test_turn_is_int(self, monkeypatch):
+        span = self._call(monkeypatch, turn=7)
+        assert span.attrs["prov.session.turn"] == 7
+        assert isinstance(span.attrs["prov.session.turn"], int)

--- a/sdk/python/tests/test_schema.py
+++ b/sdk/python/tests/test_schema.py
@@ -44,6 +44,11 @@ class TestProvAttributes:
         assert schema.SPAN_PREFIX_TOOL == "tool"
         assert schema.SPAN_PREFIX_AGENT == "agent"
 
+    def test_session_attributes(self):
+        assert schema.PROV_SESSION_ID == "prov.session.id"
+        assert schema.PROV_PROJECT == "prov.project"
+        assert schema.PROV_SESSION_TURN == "prov.session.turn"
+
     def test_all_prov_attributes_start_with_prov(self):
         """All PROV_ constants should have values starting with 'prov.'."""
         for attr_name in dir(schema):


### PR DESCRIPTION
## Summary
- Extracts optional `X-AgentWeave-Session-Id`, `X-AgentWeave-Project`, and `X-AgentWeave-Turn` headers into `prov.session.id`, `prov.project`, and `prov.session.turn` span attributes
- Attributes are omitted when headers are absent (no "unknown" pollution in Grafana)
- Turn is stored as `int` for native histogram/percentile queries in Tempo
- Adds 3 new Grafana panels: Session Explorer (table), Project Rollup (bar chart), Turn Depth Histogram

Closes #12

## Changed files
- `sdk/python/agentweave/schema.py` — 3 new `PROV_SESSION_*` / `PROV_PROJECT` constants
- `sdk/python/agentweave/proxy.py` — header extraction, skip-list, param threading through `_request_and_trace` / `_stream_and_trace` / `_set_request_attrs`
- `sdk/python/tests/test_proxy.py` — `TestSessionContext` (4 cases) + header strip test
- `sdk/python/tests/test_schema.py` — `test_session_attributes`
- `deploy/grafana/agentweave-overview.json` — `project` template var + 3 panels

## Next steps
Client-side (OpenClaw / PiMono) needs to start sending the 3 headers to populate spans.

## Test plan
- [x] `pytest tests/test_schema.py tests/test_proxy.py -v` — 60/60 pass
- [ ] Manual curl with session headers → verify spans in Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)