### PR TITLE
feat: proxy OpenAI Responses API (/v1/responses)

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -11,6 +11,7 @@ Provider is detected automatically from the request path:
   /v1/chat/completions      → OpenAI     (api.openai.com)
   /v1/completions           → OpenAI     (api.openai.com)
   /v1/embeddings            → OpenAI     (api.openai.com)
+  /v1/responses             → OpenAI     (api.openai.com)  [Responses API]
 
 Works for both streaming and non-streaming requests. Zero code changes needed
 in calling agents — just point ANTHROPIC_BASE_URL / GOOGLE_GENAI_BASE_URL /
@@ -110,7 +111,7 @@ def _check_auth(request: Request) -> JSONResponse | None:
 # Provider detection
 # ---------------------------------------------------------------------------
 
-_OPENAI_PATHS = {"v1/chat/completions", "v1/completions", "v1/embeddings"}
+_OPENAI_PATHS = {"v1/chat/completions", "v1/completions", "v1/embeddings", "v1/responses"}
 
 
 def _detect_provider(path: str) -> str:
@@ -423,8 +424,10 @@ def _parse_openai_sse(
         # Token usage from final chunk (when stream_options.include_usage=true)
         usage = chunk.get("usage")
         if usage:
-            input_tokens = usage.get("prompt_tokens", input_tokens)
-            output_tokens = usage.get("completion_tokens", output_tokens)
+            # Chat completions: prompt_tokens/completion_tokens
+            # Responses API:    input_tokens/output_tokens
+            input_tokens = usage.get("prompt_tokens") or usage.get("input_tokens", input_tokens)
+            output_tokens = usage.get("completion_tokens") or usage.get("output_tokens", output_tokens)
         choices = chunk.get("choices", [])
         if choices:
             reason = choices[0].get("finish_reason")
@@ -507,8 +510,10 @@ def _anthropic_response_text(data: dict) -> str:
 
 def _set_openai_response_attrs(span: Any, data: dict, elapsed_ms: int) -> None:
     usage = data.get("usage", {})
-    pt = usage.get("prompt_tokens", 0)
-    ct = usage.get("completion_tokens", 0)
+    # Chat completions: prompt_tokens/completion_tokens
+    # Responses API:    input_tokens/output_tokens
+    pt = usage.get("prompt_tokens") or usage.get("input_tokens", 0)
+    ct = usage.get("completion_tokens") or usage.get("output_tokens", 0)
     tt = usage.get("total_tokens", pt + ct)
     span.set_attribute(schema.PROV_LLM_PROMPT_TOKENS, pt)
     span.set_attribute(schema.PROV_LLM_COMPLETION_TOKENS, ct)

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -39,6 +39,9 @@ class TestDetectProvider:
     def test_google_v1_models(self):
         assert _detect_provider("v1/models/gemini-2.5-pro:generateContent") == "google"
 
+    def test_openai_responses(self):
+        assert _detect_provider("v1/responses") == "openai"
+
     def test_anthropic_fallback(self):
         assert _detect_provider("v1/unknown/path") == "anthropic"
 
@@ -80,6 +83,23 @@ class TestSetOpenaiResponseAttrs:
         assert span.attrs["prov.llm.prompt_tokens"] == 1
         assert "prov.llm.stop_reason" not in span.attrs
 
+    def test_responses_api_token_shape(self):
+        """Responses API uses input_tokens/output_tokens instead of prompt_tokens/completion_tokens."""
+        span = _FakeSpan()
+        data = {
+            "id": "resp_abc123",
+            "output": [{"type": "message", "content": [{"type": "text", "text": "hi"}]}],
+            "usage": {"input_tokens": 25, "output_tokens": 12, "total_tokens": 37},
+        }
+        _set_openai_response_attrs(span, data, elapsed_ms=55)
+        assert span.attrs["prov.llm.prompt_tokens"] == 25
+        assert span.attrs["prov.llm.completion_tokens"] == 12
+        assert span.attrs["prov.llm.total_tokens"] == 37
+        assert span.attrs["agentweave.latency_ms"] == 55
+        # gen_ai.* dual-emit
+        assert span.attrs["gen_ai.usage.input_tokens"] == 25
+        assert span.attrs["gen_ai.usage.output_tokens"] == 12
+
 
 class TestOpenaiResponseText:
     """Verify text extraction from OpenAI response format."""
@@ -114,6 +134,13 @@ class TestParseOpenaiSse:
         line = "data: [DONE]"
         inp, out, stop = _parse_openai_sse(line, 5, 3, "stop")
         assert (inp, out, stop) == (5, 3, "stop")
+
+    def test_responses_api_usage_chunk(self):
+        """Responses API uses input_tokens/output_tokens in SSE usage chunks."""
+        line = 'data: {"usage": {"input_tokens": 30, "output_tokens": 15}}'
+        inp, out, stop = _parse_openai_sse(line, 0, 0, None)
+        assert inp == 30
+        assert out == 15
 
     def test_non_data_line(self):
         line = "event: message"


### PR DESCRIPTION
Closes #40

## Summary
- Adds `/v1/responses` to `_OPENAI_PATHS` so Responses API requests route to OpenAI instead of falling through to Anthropic
- Handles Responses API token field naming (`input_tokens`/`output_tokens`) alongside existing chat completions shape (`prompt_tokens`/`completion_tokens`) in both non-streaming and SSE streaming paths
- Adds tests for routing and token extraction from Responses API response shape

## Test plan
- [x] `test_openai_responses` — verifies `/v1/responses` routes to openai provider
- [x] `test_responses_api_token_shape` — verifies token extraction from Responses API shape (input_tokens/output_tokens)
- [x] `test_responses_api_usage_chunk` — verifies SSE streaming token extraction from Responses API shape
- [x] All 96 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)