### PR TITLE
feat: sub-agent attribution — parent session id + agent type headers

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -69,6 +69,8 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-session-id",
     "x-agentweave-project",
     "x-agentweave-turn",
+    "x-agentweave-parent-session-id",
+    "x-agentweave-agent-type",
 }
 
 # Runtime auth token. Set AGENTWEAVE_PROXY_TOKEN or --auth-token.
@@ -208,6 +210,9 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         except (ValueError, TypeError):
             logger.warning("x-agentweave-turn is not a valid integer: %r", turn_raw)
 
+    parent_session_id = request.headers.get("x-agentweave-parent-session-id")
+    agent_type = request.headers.get("x-agentweave-agent-type")
+
     forward_headers = {
         k: v for k, v in request.headers.items()
         if k.lower() not in _SKIP_HEADERS_ALWAYS
@@ -236,6 +241,8 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         session_id=session_id,
         project=project,
         turn=turn,
+        parent_session_id=parent_session_id,
+        agent_type=agent_type,
     )
 
     if is_stream:
@@ -252,13 +259,15 @@ async def _request_and_trace(
     upstream_url: str, method: str, headers: dict, body: dict, body_bytes: bytes,
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
 ) -> JSONResponse:
     tracer = get_tracer()
     with tracer.start_as_current_span(f"{schema.SPAN_PREFIX_LLM}.{model}") as span:
         _set_request_attrs(span, model=model, provider=provider,
                            agent_id=agent_id, agent_model=agent_model,
                            path=path, body=body,
-                           session_id=session_id, project=project, turn=turn)
+                           session_id=session_id, project=project, turn=turn,
+                           parent_session_id=parent_session_id, agent_type=agent_type)
         start = time.perf_counter()
         try:
             async with httpx.AsyncClient(timeout=300) as client:
@@ -284,13 +293,15 @@ async def _stream_and_trace(
     upstream_url: str, method: str, headers: dict, body: dict, body_bytes: bytes,
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     span = tracer.start_span(f"{schema.SPAN_PREFIX_LLM}.{model}")
     _set_request_attrs(span, model=model, provider=provider,
                        agent_id=agent_id, agent_model=agent_model,
                        path=path, body=body,
-                       session_id=session_id, project=project, turn=turn)
+                       session_id=session_id, project=project, turn=turn,
+                       parent_session_id=parent_session_id, agent_type=agent_type)
 
     input_tokens = output_tokens = 0
     stop_reason = None
@@ -566,6 +577,7 @@ def _set_request_attrs(
     span: Any, model: str, provider: str, agent_id: str, agent_model: str,
     path: str, body: dict,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
 ) -> None:
     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
     span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
@@ -581,6 +593,10 @@ def _set_request_attrs(
         span.set_attribute(schema.PROV_PROJECT, project)
     if turn is not None:
         span.set_attribute(schema.PROV_SESSION_TURN, turn)
+    if parent_session_id is not None:
+        span.set_attribute(schema.PROV_PARENT_SESSION_ID, parent_session_id)
+    if agent_type is not None:
+        span.set_attribute(schema.PROV_AGENT_TYPE, agent_type)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -45,6 +45,8 @@ PROV_AGENT_VERSION = "prov.agent.version"
 PROV_SESSION_ID = "prov.session.id"
 PROV_PROJECT = "prov.project"
 PROV_SESSION_TURN = "prov.session.turn"
+PROV_PARENT_SESSION_ID = "prov.parent.session.id"   # session that spawned this sub-agent
+PROV_AGENT_TYPE = "prov.agent.type"                  # "main" | "subagent" | "delegated"
 
 # prov:wasGeneratedBy — output linked to producing activity
 PROV_WAS_GENERATED_BY = "prov.wasGeneratedBy"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -593,3 +593,36 @@ class TestSessionContext:
         span = self._call(monkeypatch, turn=7)
         assert span.attrs["prov.session.turn"] == 7
         assert isinstance(span.attrs["prov.session.turn"], int)
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent attribution
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentAttribution:
+    """Verify parent session id and agent type attributes are set on spans."""
+
+    def _call(self, monkeypatch, parent_session_id=None, agent_type=None):
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+            parent_session_id=parent_session_id, agent_type=agent_type,
+        )
+        return span
+
+    def test_parent_session_id_recorded(self, monkeypatch):
+        span = self._call(monkeypatch, parent_session_id="parent-sess-42")
+        assert span.attrs["prov.parent.session.id"] == "parent-sess-42"
+
+    def test_agent_type_recorded(self, monkeypatch):
+        span = self._call(monkeypatch, agent_type="subagent")
+        assert span.attrs["prov.agent.type"] == "subagent"
+
+    def test_main_agent_no_parent(self, monkeypatch):
+        span = self._call(monkeypatch)
+        assert "prov.parent.session.id" not in span.attrs


### PR DESCRIPTION
Closes #15

## What changed

### `schema.py`
Two new span attribute constants:
- `PROV_PARENT_SESSION_ID = "prov.parent.session.id"` — the session that spawned this sub-agent
- `PROV_AGENT_TYPE = "prov.agent.type"` — `main` | `subagent` | `delegated`

### `proxy.py`
Reads two new request headers and records them as span attributes:
- `X-AgentWeave-Parent-Session-Id` → `prov.parent.session.id`
- `X-AgentWeave-Agent-Type` → `prov.agent.type`

Zero breaking changes — attributes are only written when headers are present.

---

## Setup Instructions

### Option A — Proxy (any framework, zero code changes)

Point your agent at the AgentWeave proxy and set the attribution headers per request or via env:

```bash
# Env vars picked up automatically by the proxy
export AGENTWEAVE_AGENT_ID="my-subagent-v1"
export AGENTWEAVE_SESSION_KEY="session-abc123"
export OPENAI_BASE_URL="http://localhost:4000"   # or your proxy address
```

For sub-agents spawned by a parent, inject the parent session at spawn time:

```python
import httpx

headers = {
    "X-AgentWeave-Agent-Id": "subagent-coder-v1",
    "X-AgentWeave-Parent-Session-Id": parent_session_id,   # from parent context
    "X-AgentWeave-Agent-Type": "subagent",                 # main | subagent | delegated
    "X-AgentWeave-Session-Key": current_session_key,
}
# Pass headers to your LLM client — they flow through the proxy transparently
client = openai.OpenAI(
    base_url="http://localhost:4000/v1",
    default_headers=headers,
)
```

### Option B — Python SDK (decorator-based, code instrumentation)

```python
from agentweave import trace_agent, trace_llm

@trace_agent(
    agent_id="subagent-coder-v1",
    parent_session_id=parent_session_id,   # new: links to parent trace
    agent_type="subagent",                  # new: "main" | "subagent" | "delegated"
)
def my_sub_agent(task: str):
    ...
```

> **Note:** SDK decorator support for `parent_session_id` / `agent_type` args is a follow-up — tracked in #15. The proxy path above works today.

### Option C — pi-mono / TypeScript SDK

```typescript
import { traceAgent } from "agentweave-sdk";

const agent = traceAgent({
  agentId: "subagent-ts-v1",
  parentSessionId: context.parentSessionId,
  agentType: "subagent",
});
```

---

## Querying in Grafana

Once headers are set, filter sub-agent calls in TraceQL:

```
# All sub-agent calls
{ prov.agent.type = "subagent" }

# Sub-agent calls spawned by a specific parent session
{ prov.agent.type = "subagent" && prov.parent.session.id = "session-abc123" }

# Compare main vs sub-agent token usage
{ prov.agent.type =~ "main|subagent" } | select(prov.llm.total_tokens, prov.agent.type)
```

---

## Tests
3 new tests in `TestSubAgentAttribution`:
- `test_parent_session_id_recorded`
- `test_agent_type_recorded`
- `test_main_agent_no_parent`

61/61 proxy tests pass.