### PR TITLE
feat: deterministic trace IDs (#62)

### DIFF
--- a/docs/deterministic-trace-ids.md
+++ b/docs/deterministic-trace-ids.md
@@ -1,0 +1,165 @@
+# Deterministic Trace IDs
+
+By default, AgentWeave generates a random trace ID for every agent invocation.
+This works well for one-shot requests, but causes a problem on **retries**: each
+attempt creates a new, unrelated trace, making it impossible to tell that three
+traces are all attempts of the same logical request.
+
+Deterministic trace IDs solve this. Supply the same ID on every attempt and your
+backend (Grafana, Datadog, Arize, …) can deduplicate — only the first successful
+trace is unique; retries land on top of it.
+
+---
+
+## SDK (Python) — `@trace_agent(traceId=...)`
+
+Pass `traceId` to `@trace_agent` to pin the root span to a known trace ID.
+All child spans (tool calls, LLM calls) automatically inherit it.
+
+### Valid 32-char hex string
+
+If you already have a UUID or hex token, strip the hyphens and pass it directly:
+
+```python
+from agentweave.decorators import trace_agent, trace_tool
+
+REQUEST_ID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"  # 32-char hex
+
+@trace_agent(traceId=REQUEST_ID)
+def handle(message: str) -> str:
+    return search(message)
+
+@trace_tool
+def search(query: str) -> str:
+    return "results"
+```
+
+Both the `agent.handle` span **and** the nested `tool.search` span will carry
+`trace_id = a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4`.
+
+### Arbitrary string (auto-hashed)
+
+If your ID is a human-readable string (e.g. `"order-abc123"`),
+AgentWeave SHA-256 hashes it to produce a stable 32-char hex trace ID.
+The original string is preserved in the `agentweave.trace_id` span attribute.
+
+```python
+from agentweave.decorators import trace_agent
+
+def process_order(order_id: str, attempt: int) -> str:
+    # Same order_id → same trace ID across all retries
+    @trace_agent(name="order_processor", traceId=f"order-{order_id}")
+    def _handle(msg: str) -> str:
+        return f"processed {msg}"
+
+    return _handle(f"attempt {attempt}")
+
+process_order("abc123", attempt=1)  # trace_id = sha256("order-abc123")[:32]
+process_order("abc123", attempt=2)  # same trace_id → deduplicable
+```
+
+### Dynamic `traceId` at call time
+
+`@trace_agent` sets `traceId` at decoration time. If you need a **per-call**
+deterministic ID, create the wrapper inside the request handler or pass the ID
+in via a closure:
+
+```python
+from agentweave.decorators import trace_agent
+
+def handle_request(request_id: str, message: str) -> str:
+    @trace_agent(name="my_agent", traceId=request_id)
+    def _handle(msg: str) -> str:
+        # your agent logic
+        return f"handled: {msg}"
+
+    return _handle(message)
+```
+
+---
+
+## Proxy — `X-AgentWeave-Trace-Id` header
+
+When routing LLM calls through the AgentWeave proxy, send the
+`X-AgentWeave-Trace-Id` header. The proxy sets the OTel trace ID on the span
+and stores the raw value in the `agentweave.trace_id` attribute.
+
+```bash
+curl http://localhost:4000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "X-AgentWeave-Agent-Id: my-agent" \
+  -H "X-AgentWeave-Trace-Id: order-abc123-attempt-1" \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+Retrying the same request with the same `X-AgentWeave-Trace-Id` value produces
+a span with the **same** OTel trace ID, so duplicate traces are easy to filter.
+
+### ID format rules (same as SDK)
+
+| Input | Behaviour |
+|-------|-----------|
+| 32-char hex string | Used directly as the OTel trace ID |
+| Any other string | SHA-256 hashed; first 32 hex chars used |
+| Header absent | Random trace ID (default behaviour) |
+
+The original header value is always stored as `agentweave.trace_id` on the span
+regardless of whether it was hashed.
+
+---
+
+## Deduplication strategies
+
+### Grafana / Tempo
+
+Filter on `agentweave.trace_id` to find all attempts:
+
+```logql
+{resource.service.name="my-agent"} | json | agentweave_trace_id = "order-abc123"
+```
+
+Or use the OTel trace ID directly — if you supplied a deterministic ID all
+attempts share the same trace ID and appear as a single trace in Tempo.
+
+### Arize / Phoenix
+
+Tag your rows with the deterministic trace ID and filter duplicates in the
+dataset view using `trace_id`.
+
+### Custom deduplication
+
+Every span carries:
+
+- `agentweave.trace_id` — the raw caller-supplied string (for human-readable lookup)
+- The standard OTel `trace_id` — normalized 128-bit int (32 hex chars) derived
+  from the above
+
+Store the first-seen `agentweave.trace_id` per request; ignore subsequent spans
+with the same value that arrive after a success.
+
+---
+
+## FAQ
+
+**Q: Does this affect span IDs?**  
+No. Only the trace ID is deterministic. Each span still gets a unique, random
+span ID.
+
+**Q: What if two different requests accidentally share the same `traceId`?**  
+Their spans will appear merged in the same trace view. Use request-scoped
+identifiers (e.g. `order_id + user_id`) rather than counters to avoid collisions.
+
+**Q: Is the `traceId` forwarded to the upstream LLM API?**  
+No. `X-AgentWeave-Trace-Id` is stripped by the proxy before forwarding, just
+like all other `X-AgentWeave-*` headers.
+
+**Q: Can I use UUIDs?**  
+Yes — strip the hyphens first:
+
+```python
+import uuid
+trace_id = uuid.uuid4().hex  # "550e8400e29b41d4a716446655440000" (32 hex chars)
+
+@trace_agent(traceId=trace_id)
+def handle(msg): ...
+```

--- a/sdk/python/tests/test_decorators.py
+++ b/sdk/python/tests/test_decorators.py
@@ -490,3 +490,127 @@ class TestTraceLlm:
         # Token counts on llm span
         llm_attrs = dict(llm_span.attributes)
         assert llm_attrs["prov.llm.total_tokens"] == 250
+
+class TestTraceAgentDeterministicTraceId:
+    """Tests for @trace_agent traceId parameter (deterministic trace IDs)."""
+
+    def test_valid_hex_trace_id(self, _setup_test_tracer):
+        """32-char hex traceId sets the OTel trace ID on the span."""
+        exporter, _ = _setup_test_tracer
+        hex_id = "a" * 32  # valid 32-char hex
+
+        @trace_agent(name="det_agent", traceId=hex_id)
+        def handle(msg: str) -> str:
+            return "ok"
+
+        handle("hi")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        actual_trace_id = format(span.context.trace_id, "032x")
+        assert actual_trace_id == hex_id
+        attrs = dict(span.attributes)
+        assert attrs[schema.AGENTWEAVE_TRACE_ID] == hex_id
+
+    def test_arbitrary_string_trace_id_is_hashed(self, _setup_test_tracer):
+        """Non-hex traceId is SHA-256 hashed to produce a valid OTel trace ID."""
+        import hashlib
+        exporter, _ = _setup_test_tracer
+        arbitrary_id = "order-abc123-attempt-1"
+
+        @trace_agent(name="hash_agent", traceId=arbitrary_id)
+        def handle(msg: str) -> str:
+            return "ok"
+
+        handle("hi")
+
+        spans = exporter.get_finished_spans()
+        span = spans[0]
+        expected_hex = hashlib.sha256(arbitrary_id.encode()).hexdigest()[:32]
+        assert format(span.context.trace_id, "032x") == expected_hex
+        attrs = dict(span.attributes)
+        assert attrs[schema.AGENTWEAVE_TRACE_ID] == arbitrary_id
+
+    def test_same_trace_id_across_retries(self, _setup_test_tracer):
+        """Two calls with the same traceId produce spans with identical trace IDs."""
+        exporter, _ = _setup_test_tracer
+        trace_id = "retry-request-unique-key-42"
+
+        @trace_agent(name="retry_agent", traceId=trace_id)
+        def handle(msg: str) -> str:
+            return "ok"
+
+        handle("first call")
+        handle("second call (retry)")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+        assert spans[0].context.trace_id == spans[1].context.trace_id
+
+    def test_no_trace_id_uses_random(self, _setup_test_tracer):
+        """Without traceId, two calls produce different trace IDs."""
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="random_agent")
+        def handle(msg: str) -> str:
+            return "ok"
+
+        handle("first call")
+        handle("second call")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+        assert spans[0].context.trace_id != spans[1].context.trace_id
+
+    def test_trace_id_propagates_to_child_spans(self, _setup_test_tracer):
+        """Child spans (e.g. tool calls) inherit the deterministic trace ID."""
+        exporter, _ = _setup_test_tracer
+        from agentweave.decorators import trace_tool
+        hex_id = "b" * 32
+
+        @trace_tool(name="child_tool")
+        def my_tool() -> str:
+            return "tool result"
+
+        @trace_agent(name="parent_agent", traceId=hex_id)
+        def handle(msg: str) -> str:
+            return my_tool()
+
+        handle("hi")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+        for span in spans:
+            assert format(span.context.trace_id, "032x") == hex_id
+
+    def test_async_agent_with_trace_id(self, _setup_test_tracer):
+        """traceId also works on async agents."""
+        exporter, _ = _setup_test_tracer
+        hex_id = "c" * 32
+
+        @trace_agent(name="async_det_agent", traceId=hex_id)
+        async def handle(msg: str) -> str:
+            return "async ok"
+
+        asyncio.run(handle("hi"))
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert format(spans[0].context.trace_id, "032x") == hex_id
+
+    def test_agentweave_trace_id_attribute_absent_without_trace_id(self, _setup_test_tracer):
+        """agentweave.trace_id attribute is only set when traceId is provided."""
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="no_trace_id_agent")
+        def handle(msg: str) -> str:
+            return "ok"
+
+        handle("hi")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert schema.AGENTWEAVE_TRACE_ID not in attrs
+
+

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -605,3 +605,84 @@ class TestSessionContext:
         span = self._call(monkeypatch)
         assert "session.id" not in span.attrs
         assert "prov.session.id" not in span.attrs
+
+
+
+# ---------------------------------------------------------------------------
+# Deterministic trace ID (_normalize_trace_id + _set_request_attrs)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeTraceId:
+    """Unit tests for the _normalize_trace_id helper."""
+
+    def test_valid_hex_32_chars(self):
+        from agentweave.proxy import _normalize_trace_id
+        hex_id = "a" * 32
+        assert _normalize_trace_id(hex_id) == int(hex_id, 16)
+
+    def test_mixed_case_hex(self):
+        from agentweave.proxy import _normalize_trace_id
+        hex_id = "A" * 16 + "b" * 16
+        assert _normalize_trace_id(hex_id) == int(hex_id, 16)
+
+    def test_arbitrary_string_is_hashed(self):
+        import hashlib
+        from agentweave.proxy import _normalize_trace_id
+        arbitrary = "order-abc123-attempt-1"
+        expected = int(hashlib.sha256(arbitrary.encode()).hexdigest()[:32], 16)
+        assert _normalize_trace_id(arbitrary) == expected
+
+    def test_same_input_same_output(self):
+        from agentweave.proxy import _normalize_trace_id
+        val = "order-abc123"
+        assert _normalize_trace_id(val) == _normalize_trace_id(val)
+
+    def test_empty_string_returns_none(self):
+        from agentweave.proxy import _normalize_trace_id
+        assert _normalize_trace_id("") is None
+
+    def test_whitespace_string_returns_none(self):
+        from agentweave.proxy import _normalize_trace_id
+        assert _normalize_trace_id("   ") is None
+
+    def test_too_short_hex_is_hashed(self):
+        """A hex string that is <32 chars should be hashed, not used directly."""
+        import hashlib
+        from agentweave.proxy import _normalize_trace_id
+        short_hex = "deadbeef"
+        expected = int(hashlib.sha256(short_hex.encode()).hexdigest()[:32], 16)
+        assert _normalize_trace_id(short_hex) == expected
+
+
+class TestDeterministicTraceIdHeader:
+    """Verify X-AgentWeave-Trace-Id is stripped from forwarded headers and sets span attribute."""
+
+    def test_trace_id_header_stripped(self):
+        """x-agentweave-trace-id must not be forwarded upstream."""
+        assert "x-agentweave-trace-id" in _SKIP_HEADERS_ALWAYS
+
+    def test_trace_id_attribute_set_on_span(self, monkeypatch):
+        """agentweave.trace_id attribute is set on the span when header is present."""
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+            det_trace_id_raw="order-abc123-attempt-1",
+        )
+        assert span.attrs["agentweave.trace_id"] == "order-abc123-attempt-1"
+
+    def test_trace_id_attribute_absent_when_not_provided(self, monkeypatch):
+        """agentweave.trace_id should not appear when header is absent."""
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+        )
+        assert "agentweave.trace_id" not in span.attrs


### PR DESCRIPTION
Closes #62

Rebased cleanly on top of #65 (session grouping). 122 tests passing.