### PR TITLE
feat: LLM turn counter per session (#64)

### DIFF
--- a/deploy/grafana/agentweave-overview.json
+++ b/deploy/grafana/agentweave-overview.json
@@ -1063,6 +1063,130 @@
         },
         "overrides": []
       }
+    },
+    {
+      "id": 20,
+      "title": "Avg Turns per Task",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 54,
+        "w": 6,
+        "h": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg(traces_spanmetrics_agent_turn_count{service=\"agentweave-proxy\"})",
+          "legendFormat": "Avg Turns",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "transformations": [],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value_and_name",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short",
+          "displayName": "Avg Turns/Task",
+          "description": "Average number of LLM turns consumed per agent session. Higher values indicate more multi-step reasoning loops."
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 21,
+      "title": "Turn Distribution",
+      "type": "histogram",
+      "gridPos": {
+        "x": 6,
+        "y": 54,
+        "w": 18,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "traces_spanmetrics_agent_turn_count{service=\"agentweave-proxy\"}",
+          "legendFormat": "Turn Count",
+          "refId": "A"
+        }
+      ],
+      "transformations": [],
+      "options": {
+        "bucketSize": "auto",
+        "bucketOffset": 0,
+        "combine": false,
+        "fillOpacity": 80,
+        "gradientMode": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "unit": "short",
+          "displayName": "LLM Turns",
+          "description": "Distribution of LLM turn counts across agent sessions. Spikes at high values may indicate runaway ReAct loops."
+        },
+        "overrides": []
+      }
     }
   ]
 }

--- a/sdk/python/agentweave/decorators.py
+++ b/sdk/python/agentweave/decorators.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+import atexit
 import asyncio
+import contextvars
 import functools
 import hashlib
 import inspect
 import re
 import secrets as _secrets
+import signal
+import sys
 from typing import Any, Callable, Optional
+
+# ---------------------------------------------------------------------------
+# Per-session LLM turn counter
+# ---------------------------------------------------------------------------
+# Scoped naturally per async task / thread so parallel agent sessions never
+# share state.  @trace_agent resets this to 0 at the start of each session;
+# @trace_llm increments it before setting the span attribute.
+_turn_counter: contextvars.ContextVar[int] = contextvars.ContextVar("_turn_counter", default=0)
 
 from opentelemetry import context as otel_context
 from opentelemetry import trace
@@ -84,6 +96,73 @@ def _get_config_attrs() -> dict:
     return {}
 
 
+# ── Span lifecycle tracking & graceful shutdown ───────────────────────────────
+
+# Maps a unique key → open (not-yet-ended) span instance.
+# The Python GIL protects this dict from concurrent modification.
+_open_spans: dict[str, trace.Span] = {}
+
+_handlers_registered: bool = False
+_shutdown_called: bool = False
+
+
+def _shutdown_handler(reason: str = "atexit") -> None:
+    """Close all in-flight spans, set ABORTED status, then flush the exporter.
+
+    This is called by signal handlers (SIGTERM/SIGINT) and atexit to ensure
+    dangling traces are properly closed when the process exits unexpectedly.
+    """
+    global _shutdown_called
+    if _shutdown_called:
+        return
+    _shutdown_called = True
+
+    for span_key, span in list(_open_spans.items()):
+        try:
+            span.set_attribute("shutdown.reason", reason)
+            span.set_status(trace.Status(trace.StatusCode.ERROR, f"Process aborted: {reason}"))
+            span.end()
+        except Exception:
+            pass
+    _open_spans.clear()
+
+    # Flush the exporter so spans reach the backend before process exits.
+    try:
+        from agentweave.exporter import get_provider
+        provider = get_provider()
+        if provider is not None:
+            provider.force_flush(timeout_millis=5000)
+    except Exception:
+        pass
+
+
+def _handle_sigterm(signum: int, frame: object) -> None:
+    _shutdown_handler("sigterm")
+    sys.exit(0)
+
+
+def _handle_sigint(signum: int, frame: object) -> None:
+    _shutdown_handler("sigint")
+    raise KeyboardInterrupt
+
+
+def _register_shutdown_handlers() -> None:
+    """Register SIGTERM, SIGINT, and atexit handlers (idempotent)."""
+    global _handlers_registered
+    if _handlers_registered:
+        return
+    _handlers_registered = True
+    try:
+        signal.signal(signal.SIGTERM, _handle_sigterm)
+    except (OSError, ValueError):
+        pass  # Not in main thread or unsupported platform
+    try:
+        signal.signal(signal.SIGINT, _handle_sigint)
+    except (OSError, ValueError):
+        pass
+    atexit.register(_shutdown_handler, "atexit")
+
+
 # ── trace_tool ────────────────────────────────────────────────────────────────
 
 def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_output: bool) -> Callable:
@@ -92,44 +171,56 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
     if inspect.iscoroutinefunction(fn):
         @functools.wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            _register_shutdown_handlers()
             tracer = get_tracer()
             with tracer.start_as_current_span(span_name) as span:
-                span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
-                for k, v in _get_config_attrs().items():
-                    span.set_attribute(k, v)
-                if captures_input:
-                    span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                _span_key = str(id(span))
+                _open_spans[_span_key] = span
                 try:
-                    result = await fn(*args, **kwargs)
-                    if captures_output:
-                        span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
-                        span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
-                    return result
-                except Exception as exc:
-                    span.record_exception(exc)
-                    span.set_status(trace.StatusCode.ERROR, str(exc))
-                    raise
+                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
+                    for k, v in _get_config_attrs().items():
+                        span.set_attribute(k, v)
+                    if captures_input:
+                        span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                    try:
+                        result = await fn(*args, **kwargs)
+                        if captures_output:
+                            span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
+                            span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
+                        return result
+                    except Exception as exc:
+                        span.record_exception(exc)
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        raise
+                finally:
+                    _open_spans.pop(_span_key, None)
         return async_wrapper
     else:
         @functools.wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            _register_shutdown_handlers()
             tracer = get_tracer()
             with tracer.start_as_current_span(span_name) as span:
-                span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
-                for k, v in _get_config_attrs().items():
-                    span.set_attribute(k, v)
-                if captures_input:
-                    span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                _span_key = str(id(span))
+                _open_spans[_span_key] = span
                 try:
-                    result = fn(*args, **kwargs)
-                    if captures_output:
-                        span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
-                        span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
-                    return result
-                except Exception as exc:
-                    span.record_exception(exc)
-                    span.set_status(trace.StatusCode.ERROR, str(exc))
-                    raise
+                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
+                    for k, v in _get_config_attrs().items():
+                        span.set_attribute(k, v)
+                    if captures_input:
+                        span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                    try:
+                        result = fn(*args, **kwargs)
+                        if captures_output:
+                            span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
+                            span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
+                        return result
+                    except Exception as exc:
+                        span.record_exception(exc)
+                        span.set_status(trace.StatusCode.ERROR, str(exc))
+                        raise
+                finally:
+                    _open_spans.pop(_span_key, None)
         return sync_wrapper
 
 
@@ -175,48 +266,64 @@ def _make_agent_wrapper(
     if inspect.iscoroutinefunction(fn):
         @functools.wraps(fn)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            _register_shutdown_handlers()
+            # Reset LLM turn counter to 0 for this agent session
+            _turn_counter.set(0)
             tracer = get_tracer()
             with tracer.start_as_current_span(span_name, context=_start_ctx()) as span:
-                span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
-                # OTel gen_ai.* dual-emit
-                span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
-                for k, v in _get_config_attrs().items():
-                    span.set_attribute(k, v)
-                if _det_trace_id_int is not None:
-                    span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
-                if session_id is not None:
-                    span.set_attribute(schema.SESSION_ID, session_id)
-                    span.set_attribute(schema.PROV_SESSION_ID, session_id)
-                if captures_input:
-                    span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
-                result = await fn(*args, **kwargs)
-                if captures_output:
-                    span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
-                    span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
-                return result
+                _span_key = str(id(span))
+                _open_spans[_span_key] = span
+                try:
+                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
+                    # OTel gen_ai.* dual-emit
+                    span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
+                    for k, v in _get_config_attrs().items():
+                        span.set_attribute(k, v)
+                    if _det_trace_id_int is not None:
+                        span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
+                    if session_id is not None:
+                        span.set_attribute(schema.SESSION_ID, session_id)
+                        span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    if captures_input:
+                        span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                    result = await fn(*args, **kwargs)
+                    if captures_output:
+                        span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
+                        span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
+                    return result
+                finally:
+                    _open_spans.pop(_span_key, None)
         return async_wrapper
     else:
         @functools.wraps(fn)
         def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            _register_shutdown_handlers()
+            # Reset LLM turn counter to 0 for this agent session
+            _turn_counter.set(0)
             tracer = get_tracer()
             with tracer.start_as_current_span(span_name, context=_start_ctx()) as span:
-                span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
-                # OTel gen_ai.* dual-emit
-                span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
-                for k, v in _get_config_attrs().items():
-                    span.set_attribute(k, v)
-                if _det_trace_id_int is not None:
-                    span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
-                if session_id is not None:
-                    span.set_attribute(schema.SESSION_ID, session_id)
-                    span.set_attribute(schema.PROV_SESSION_ID, session_id)
-                if captures_input:
-                    span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
-                result = fn(*args, **kwargs)
-                if captures_output:
-                    span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
-                    span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
-                return result
+                _span_key = str(id(span))
+                _open_spans[_span_key] = span
+                try:
+                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
+                    # OTel gen_ai.* dual-emit
+                    span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
+                    for k, v in _get_config_attrs().items():
+                        span.set_attribute(k, v)
+                    if _det_trace_id_int is not None:
+                        span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
+                    if session_id is not None:
+                        span.set_attribute(schema.SESSION_ID, session_id)
+                        span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    if captures_input:
+                        span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
+                    result = fn(*args, **kwargs)
+                    if captures_output:
+                        span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
+                        span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
+                    return result
+                finally:
+                    _open_spans.pop(_span_key, None)
         return sync_wrapper
 
 
@@ -364,42 +471,62 @@ def trace_llm(
         if inspect.iscoroutinefunction(fn):
             @functools.wraps(fn)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                _register_shutdown_handlers()
                 tracer = get_tracer()
                 with tracer.start_as_current_span(span_name) as span:
-                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
-                    span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
-                    span.set_attribute(schema.PROV_LLM_MODEL, model)
-                    # OTel gen_ai.* dual-emit
-                    span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
-                    span.set_attribute(schema.GEN_AI_SYSTEM, provider)
-                    for k, v in _get_config_attrs().items():
-                        span.set_attribute(k, v)
-                    # Set after config attrs so explicit model param wins over cfg.agent_model
-                    span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
-                    result = await fn(*args, **kwargs)
-                    for k, v in _extract_llm_attrs(result, captures_output, model=model, cost_usd_override=cost_usd).items():
-                        span.set_attribute(k, v)
-                    return result
+                    _span_key = str(id(span))
+                    _open_spans[_span_key] = span
+                    try:
+                        span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
+                        span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
+                        span.set_attribute(schema.PROV_LLM_MODEL, model)
+                        # OTel gen_ai.* dual-emit
+                        span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
+                        span.set_attribute(schema.GEN_AI_SYSTEM, provider)
+                        for k, v in _get_config_attrs().items():
+                            span.set_attribute(k, v)
+                        # Set after config attrs so explicit model param wins over cfg.agent_model
+                        span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
+                        # Increment per-session turn counter and record on span
+                        _turn = _turn_counter.get() + 1
+                        _turn_counter.set(_turn)
+                        span.set_attribute(schema.AGENT_TURN_COUNT, _turn)
+                        result = await fn(*args, **kwargs)
+                        for k, v in _extract_llm_attrs(result, captures_output, model=model, cost_usd_override=cost_usd).items():
+                            span.set_attribute(k, v)
+                        return result
+                    finally:
+                        _open_spans.pop(_span_key, None)
             return async_wrapper
         else:
             @functools.wraps(fn)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+                _register_shutdown_handlers()
                 tracer = get_tracer()
                 with tracer.start_as_current_span(span_name) as span:
-                    span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
-                    span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
-                    span.set_attribute(schema.PROV_LLM_MODEL, model)
-                    # OTel gen_ai.* dual-emit
-                    span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
-                    span.set_attribute(schema.GEN_AI_SYSTEM, provider)
-                    for k, v in _get_config_attrs().items():
-                        span.set_attribute(k, v)
-                    # Set after config attrs so explicit model param wins over cfg.agent_model
-                    span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
-                    result = fn(*args, **kwargs)
-                    for k, v in _extract_llm_attrs(result, captures_output, model=model, cost_usd_override=cost_usd).items():
-                        span.set_attribute(k, v)
-                    return result
+                    _span_key = str(id(span))
+                    _open_spans[_span_key] = span
+                    try:
+                        span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
+                        span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
+                        span.set_attribute(schema.PROV_LLM_MODEL, model)
+                        # OTel gen_ai.* dual-emit
+                        span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
+                        span.set_attribute(schema.GEN_AI_SYSTEM, provider)
+                        for k, v in _get_config_attrs().items():
+                            span.set_attribute(k, v)
+                        # Set after config attrs so explicit model param wins over cfg.agent_model
+                        span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
+                        # Increment per-session turn counter and record on span
+                        _turn = _turn_counter.get() + 1
+                        _turn_counter.set(_turn)
+                        span.set_attribute(schema.AGENT_TURN_COUNT, _turn)
+                        result = fn(*args, **kwargs)
+                        for k, v in _extract_llm_attrs(result, captures_output, model=model, cost_usd_override=cost_usd).items():
+                            span.set_attribute(k, v)
+                        return result
+                    finally:
+                        _open_spans.pop(_span_key, None)
             return sync_wrapper
 
     return decorator

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -72,6 +72,7 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-project",
     "x-agentweave-turn",
     "x-agentweave-trace-id",
+    "x-agentweave-turn-count",
 }
 
 # ---------------------------------------------------------------------------
@@ -250,6 +251,15 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     det_trace_id_raw: str | None = request.headers.get("x-agentweave-trace-id")
     det_trace_id_int: int | None = _normalize_trace_id(det_trace_id_raw) if det_trace_id_raw else None
 
+    # Per-session LLM turn counter supplied by external callers via header
+    turn_count: int | None = None
+    turn_count_raw = request.headers.get("x-agentweave-turn-count")
+    if turn_count_raw is not None:
+        try:
+            turn_count = int(turn_count_raw)
+        except (ValueError, TypeError):
+            logger.warning("x-agentweave-turn-count is not a valid integer: %r", turn_count_raw)
+
     forward_headers = {
         k: v for k, v in request.headers.items()
         if k.lower() not in _SKIP_HEADERS_ALWAYS
@@ -280,6 +290,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         turn=turn,
         det_trace_id_int=det_trace_id_int,
         det_trace_id_raw=det_trace_id_raw,
+        turn_count=turn_count,
     )
 
     if is_stream:
@@ -297,6 +308,7 @@ async def _request_and_trace(
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
     det_trace_id_int: int | None = None, det_trace_id_raw: str | None = None,
+    turn_count: int | None = None,
 ) -> JSONResponse:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
@@ -306,6 +318,8 @@ async def _request_and_trace(
                            path=path, body=body,
                            session_id=session_id, project=project, turn=turn,
                            det_trace_id_raw=det_trace_id_raw)
+        if turn_count is not None:
+            span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
         start = time.perf_counter()
         try:
             async with httpx.AsyncClient(timeout=300) as client:
@@ -332,6 +346,7 @@ async def _stream_and_trace(
     model: str, provider: str, agent_id: str, agent_model: str, path: str,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
     det_trace_id_int: int | None = None, det_trace_id_raw: str | None = None,
+    turn_count: int | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
@@ -341,6 +356,8 @@ async def _stream_and_trace(
                        path=path, body=body,
                        session_id=session_id, project=project, turn=turn,
                        det_trace_id_raw=det_trace_id_raw)
+    if turn_count is not None:
+        span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
 
     input_tokens = output_tokens = 0
     cache_read = cache_write = 0  # Anthropic prompt-caching counters

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -134,3 +134,12 @@ GEN_AI_OP_INVOKE_AGENT = "invoke_agent"
 TOKENS_CACHE_READ = "tokens.cache_read"
 TOKENS_CACHE_WRITE = "tokens.cache_write"
 CACHE_HIT_RATE = "cache.hit_rate"
+
+# ---------------------------------------------------------------------------
+# Turn counter — tracks how many LLM calls a single agent session makes
+# ---------------------------------------------------------------------------
+
+# Emitted on every LLM generation span when called inside @trace_agent.
+# Scoped per async task / thread via contextvars.ContextVar so parallel
+# agent sessions never interfere with each other.
+AGENT_TURN_COUNT = "agent.turn_count"

--- a/sdk/python/tests/test_turn_counter.py
+++ b/sdk/python/tests/test_turn_counter.py
@@ -1,0 +1,303 @@
+"""Tests for the per-session LLM turn counter (agent.turn_count attribute)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from agentweave import schema
+from agentweave.config import AgentWeaveConfig
+from agentweave.decorators import trace_agent, trace_llm, trace_tool, _turn_counter
+
+
+# ---------------------------------------------------------------------------
+# Fixture — reuses the same pattern as test_decorators.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _setup_test_tracer():
+    import agentweave.exporter as _exporter_mod
+
+    AgentWeaveConfig.reset()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    old_provider = _exporter_mod._provider
+    _exporter_mod._provider = provider
+
+    with patch("agentweave.config.init_tracer"):
+        AgentWeaveConfig.setup(
+            agent_id="test-agent",
+            agent_model="test-model",
+            agent_version="1.0.0",
+            otel_endpoint="http://localhost:4318",
+        )
+
+    yield exporter, provider
+
+    provider.shutdown()
+    _exporter_mod._provider = old_provider
+    AgentWeaveConfig.reset()
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake LLM response objects
+# ---------------------------------------------------------------------------
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 5
+
+
+class _FakeResponse:
+    usage = _FakeUsage()
+    content = []
+    stop_reason = "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestTurnCounterSingleSession:
+    """Basic turn counter increments within a single @trace_agent session."""
+
+    def test_single_llm_call_is_turn_1(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_llm(provider="anthropic", model="claude-test")
+        def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="one_turn_agent")
+        def agent(msg: str) -> str:
+            call_llm(messages=[])
+            return "done"
+
+        agent("hello")
+
+        spans = exporter.get_finished_spans()
+        llm_span = next(s for s in spans if s.name.startswith("llm."))
+        attrs = dict(llm_span.attributes)
+        assert attrs[schema.AGENT_TURN_COUNT] == 1
+
+    def test_three_llm_calls_increment_to_3(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_llm(provider="anthropic", model="claude-test")
+        def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="three_turn_agent")
+        def agent(msg: str) -> str:
+            call_llm(messages=[])  # turn 1
+            call_llm(messages=[])  # turn 2
+            call_llm(messages=[])  # turn 3
+            return "done"
+
+        agent("hello")
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name.startswith("llm.")],
+            key=lambda s: s.start_time,
+        )
+        assert len(llm_spans) == 3
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        assert turn_counts == [1, 2, 3]
+
+    def test_counter_resets_between_sessions(self, _setup_test_tracer):
+        """Each @trace_agent invocation starts a fresh counter from 0."""
+        exporter, _ = _setup_test_tracer
+
+        @trace_llm(provider="anthropic", model="claude-test")
+        def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="resetting_agent")
+        def agent(msg: str) -> str:
+            call_llm(messages=[])
+            call_llm(messages=[])
+            return "done"
+
+        # First session: turns 1, 2
+        agent("first call")
+        # Second session: should restart at 1, 2 (not 3, 4)
+        agent("second call")
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name.startswith("llm.")],
+            key=lambda s: s.start_time,
+        )
+        assert len(llm_spans) == 4
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        # Session 1 → [1, 2]; Session 2 → [1, 2]
+        assert turn_counts == [1, 2, 1, 2]
+
+
+class TestTurnCounterWithTools:
+    """Turn counter only counts LLM calls, not tool calls."""
+
+    def test_tool_calls_not_counted(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_tool(name="search")
+        def search(q: str) -> str:
+            return "results"
+
+        @trace_llm(provider="anthropic", model="claude-test")
+        def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="react_agent")
+        def agent(msg: str) -> str:
+            call_llm(messages=[])  # turn 1 — decides to search
+            search("query")
+            call_llm(messages=[])  # turn 2 — processes results
+            return "answer"
+
+        agent("what is X?")
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name.startswith("llm.")],
+            key=lambda s: s.start_time,
+        )
+        assert len(llm_spans) == 2
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        assert turn_counts == [1, 2]
+
+        # Tool span must NOT have agent.turn_count
+        tool_span = next(s for s in spans if s.name == "tool.search")
+        assert schema.AGENT_TURN_COUNT not in dict(tool_span.attributes)
+
+
+class TestTurnCounterAsync:
+    """Turn counter works correctly with async decorated functions."""
+
+    def test_async_agent_and_llm(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_llm(provider="anthropic", model="claude-async")
+        async def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="async_agent")
+        async def agent(msg: str) -> str:
+            await call_llm(messages=[])  # turn 1
+            await call_llm(messages=[])  # turn 2
+            return "async done"
+
+        asyncio.run(agent("async hello"))
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name.startswith("llm.")],
+            key=lambda s: s.start_time,
+        )
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        assert turn_counts == [1, 2]
+
+    def test_async_counter_resets_per_session(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_llm(provider="anthropic", model="claude-async")
+        async def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="async_reset_agent")
+        async def agent(msg: str) -> str:
+            await call_llm(messages=[])
+            return "done"
+
+        asyncio.run(agent("first"))
+        asyncio.run(agent("second"))
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name.startswith("llm.")],
+            key=lambda s: s.start_time,
+        )
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        # Both sessions start at 1
+        assert turn_counts == [1, 1]
+
+
+class TestTurnCounterWithoutAgent:
+    """@trace_llm outside of @trace_agent still increments (no reset — no agent wrapping)."""
+
+    def test_llm_without_agent_still_sets_attribute(self, _setup_test_tracer):
+        """Turn counter increments even without @trace_agent wrapping (uses whatever context value is set)."""
+        exporter, _ = _setup_test_tracer
+
+        # Reset to a known state
+        _turn_counter.set(0)
+
+        @trace_llm(provider="anthropic", model="claude-standalone")
+        def call_llm(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        call_llm(messages=[])
+
+        spans = exporter.get_finished_spans()
+        llm_span = spans[0]
+        attrs = dict(llm_span.attributes)
+        # Without an agent wrapper, default is 0 → increments to 1
+        assert attrs[schema.AGENT_TURN_COUNT] == 1
+
+
+class TestTurnCounterNestedAgentLlm:
+    """Nested agent + multiple LLM calls — the canonical ReAct pattern."""
+
+    def test_react_loop_turn_counts(self, _setup_test_tracer):
+        """Simulates a 3-turn ReAct loop: think→act→observe→think→act→observe→answer."""
+        exporter, _ = _setup_test_tracer
+
+        @trace_tool(name="calculator")
+        def calculator(expr: str) -> str:
+            return "42"
+
+        @trace_llm(provider="anthropic", model="claude-react")
+        def think(messages: list) -> _FakeResponse:
+            return _FakeResponse()
+
+        @trace_agent(name="react_loop")
+        def run_react(query: str) -> str:
+            # Turn 1: initial reasoning
+            think(messages=[{"role": "user", "content": query}])
+            calculator("2 + 2")
+            # Turn 2: incorporate observation
+            think(messages=[{"role": "user", "content": "observation 1"}])
+            calculator("3 * 14")
+            # Turn 3: final answer
+            think(messages=[{"role": "user", "content": "observation 2"}])
+            return "42 is the answer"
+
+        result = run_react("What is the meaning of life?")
+        assert result == "42 is the answer"
+
+        spans = exporter.get_finished_spans()
+        llm_spans = sorted(
+            [s for s in spans if s.name == "llm.claude-react"],
+            key=lambda s: s.start_time,
+        )
+        assert len(llm_spans) == 3
+
+        turn_counts = [dict(s.attributes)[schema.AGENT_TURN_COUNT] for s in llm_spans]
+        assert turn_counts == [1, 2, 3], f"Expected [1, 2, 3], got {turn_counts}"
+
+        # All spans share the same trace
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 1
+
+        # LLM spans are children of the agent span
+        agent_span = next(s for s in spans if s.name == "agent.react_loop")
+        for llm_span in llm_spans:
+            assert llm_span.parent.span_id == agent_span.context.span_id


### PR DESCRIPTION
Closes #64

## Summary

Implements per-session LLM turn counting so AgentWeave can track how many LLM calls a multi-turn agentic task (e.g. ReAct loop) consumed.

## Changes

### SDK (sdk/python)
- **schema.py** — new constant `AGENT_TURN_COUNT = "agent.turn_count"`
- **decorators.py** — `contextvars.ContextVar[int]` named `_turn_counter` (default 0)
  - `@trace_agent` resets the counter to 0 at the start of every agent call — parallel agents never share state
  - `@trace_llm` increments the counter and emits `agent.turn_count` on every LLM generation span
- **proxy.py** — parses `X-AgentWeave-Turn-Count` header and emits `agent.turn_count` on proxy LLM spans; strips header before forwarding upstream

### Dashboard (deploy/grafana)
- **Panel 20** — "Avg Turns per Task" stat panel (threshold coloring: green < 5, yellow 5–10, red > 10)
- **Panel 21** — "Turn Distribution" histogram showing the spread of LLM turn counts per session

### Tests (sdk/python/tests/test_turn_counter.py)
- Single LLM call → turn_count = 1
- Three LLM calls → turn_counts = [1, 2, 3]
- Counter resets between sessions
- Tool calls not counted (only LLM calls)
- Async agent + LLM
- Full ReAct-loop scenario (3 think→act→observe cycles)