### PR TITLE
security(dashboard): use k8s Secret + envsubst for nginx credentials

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 EXPOSE 80
+CMD ["/bin/sh", "-c", "envsubst < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/dashboard/nginx.conf.template
+++ b/dashboard/nginx.conf.template
@@ -5,11 +5,15 @@ server {
   location /tempo/ {
     proxy_pass http://tempo.monitoring.svc.cluster.local:3200/;
     proxy_read_timeout 30s;
+    # When GRAFANA_AUTH_HEADER is set (via k8s Secret + envsubst), uncomment:
+    # proxy_set_header Authorization "${GRAFANA_AUTH_HEADER}";
   }
 
   location /prometheus/ {
     proxy_pass http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090/;
     proxy_read_timeout 30s;
+    # When GRAFANA_AUTH_HEADER is set (via k8s Secret + envsubst), uncomment:
+    # proxy_set_header Authorization "${GRAFANA_AUTH_HEADER}";
   }
 
   location / {

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -50,7 +50,34 @@ kubectl apply -f deploy/k8s/configmap.yaml
 kubectl apply -f deploy/k8s/secret.yaml      # or use kubectl create secret above
 kubectl apply -f deploy/k8s/deployment.yaml
 kubectl apply -f deploy/k8s/service.yaml
+kubectl apply -f deploy/k8s/dashboard-deployment.yaml
 ```
+
+### Dashboard nginx credentials
+
+The dashboard nginx proxy uses `envsubst` at container startup to inject
+credentials from environment variables. **Never hardcode credentials in
+`nginx.conf` or `nginx.conf.template`.**
+
+To set dashboard proxy auth (e.g. for Grafana/Tempo basic-auth):
+
+```bash
+kubectl create secret generic agentweave-dashboard \
+  --from-literal=GRAFANA_AUTH_HEADER="Basic <base64-user:pass>" \
+  -n agentweave --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment agentweave-dashboard -n agentweave
+```
+
+To run without auth (default — uses k8s DNS direct):
+
+```bash
+kubectl create secret generic agentweave-dashboard \
+  --from-literal=GRAFANA_AUTH_HEADER="" \
+  -n agentweave --dry-run=client -o yaml | kubectl apply -f -
+```
+
+See `deploy/k8s/dashboard-secret.yaml` for the template (placeholder only, do
+not apply directly).
 
 ### 4. Verify
 

--- a/deploy/k8s/dashboard-deployment.yaml
+++ b/deploy/k8s/dashboard-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         - name: dashboard
           image: localhost:5000/agentweave-dashboard:latest
           imagePullPolicy: Always
+          envFrom:
+            - secretRef:
+                name: agentweave-dashboard
+                optional: true
           ports:
             - containerPort: 80
           resources:

--- a/deploy/k8s/dashboard-secret.yaml
+++ b/deploy/k8s/dashboard-secret.yaml
@@ -1,0 +1,22 @@
+# Dashboard nginx proxy credentials (envsubst placeholders).
+#
+# DO NOT apply this file directly — it contains placeholder values.
+# Create the secret out-of-band:
+#
+#   kubectl create secret generic agentweave-dashboard \
+#     --from-literal=GRAFANA_AUTH_HEADER="Basic <base64-user:pass>" \
+#     -n agentweave --dry-run=client -o yaml | kubectl apply -f -
+#
+# To run without auth (current default — proxies use k8s DNS with no auth):
+#   kubectl create secret generic agentweave-dashboard \
+#     --from-literal=GRAFANA_AUTH_HEADER="" \
+#     -n agentweave --dry-run=client -o yaml | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentweave-dashboard
+  namespace: agentweave
+type: Opaque
+stringData:
+  # PLACEHOLDER — never apply directly. See comment above.
+  GRAFANA_AUTH_HEADER: ""


### PR DESCRIPTION
## Summary
- Replaces `dashboard/nginx.conf` with `nginx.conf.template` using `envsubst` placeholders (`${GRAFANA_AUTH_HEADER}`) so credentials are never hardcoded
- Updates Dockerfile CMD to run `envsubst` at container startup before nginx
- Adds `deploy/k8s/dashboard-secret.yaml` template for managing dashboard proxy credentials via k8s Secret
- Updates dashboard deployment to mount the secret as env vars (`optional: true` so it works without the secret)
- Documents credential management workflow in `deploy/k8s/README.md`

Fixes #77

## Test plan
- [ ] Build dashboard image: `docker build -t agentweave-dashboard dashboard/`
- [ ] Run container without secret — nginx starts, proxies work via k8s DNS (no auth)
- [ ] Run container with `GRAFANA_AUTH_HEADER` env var set — verify envsubst injects it
- [ ] Apply `dashboard-secret.yaml` placeholder — verify deployment accepts optional secretRef

🤖 Generated with [Claude Code](https://claude.com/claude-code)