### PR TITLE
feat(examples): framework integration examples — LangGraph, CrewAI, AutoGen, OpenAI Agents SDK

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,53 @@
+# AgentWeave Framework Integration Examples
+
+These examples show how to add **AgentWeave observability** to popular agent
+frameworks with **zero code changes** to the agent itself.
+
+Every example uses **proxy mode**: point your LLM client's `base_url` at the
+AgentWeave proxy and every request is automatically traced, token-counted and
+costed.
+
+## Quick start
+
+```bash
+# 1. Start the AgentWeave proxy (runs on port 4000)
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+
+# 2. Export your LLM API key
+export OPENAI_API_KEY=sk-...
+
+# 3. Run any example
+cd examples/langgraph
+pip install -r requirements.txt
+python langgraph_example.py
+```
+
+Traces are emitted via OTLP and visible in Grafana Tempo, Jaeger, Langfuse, or
+any OpenTelemetry-compatible backend.
+
+## Examples
+
+| Framework | Directory | Description |
+|-----------|-----------|-------------|
+| [LangGraph](langgraph/) | `examples/langgraph/` | Stateful graph agent with proxy and optional decorator mode |
+| [CrewAI](crewai/) | `examples/crewai/` | Multi-agent crew with proxy-based tracing |
+| [AutoGen](autogen/) | `examples/autogen/` | Conversable agents with proxy-based tracing |
+| [OpenAI Agents SDK](openai-agents-sdk/) | `examples/openai-agents-sdk/` | OpenAI Agents SDK with proxy-based tracing |
+
+## How proxy mode works
+
+```
+Your Agent ──base_url=http://localhost:4000/v1──> AgentWeave Proxy :4000
+                                                        │
+                                                  auto-detects provider
+                                                  extracts token counts
+                                                  computes cost (USD)
+                                                  emits OTel spans
+                                                        │
+                                                        ▼
+                                                  upstream LLM API
+                                                  (OpenAI / Anthropic / Google)
+```
+
+Replace `http://localhost:4000/v1` with your proxy endpoint if deployed
+elsewhere (e.g. `http://192.168.1.70:30400/v1`).

--- a/examples/autogen/README.md
+++ b/examples/autogen/README.md
@@ -1,0 +1,31 @@
+# AutoGen + AgentWeave
+
+A minimal AutoGen agent with AgentWeave tracing via **proxy mode** — no code
+changes to the agent itself.
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+```
+
+## How to run
+
+```bash
+# 1. Start the AgentWeave proxy
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+
+# 2. Run the example
+python autogen_example.py
+```
+
+## What you see after running
+
+- An assistant agent answers a question via a conversable-agent exchange.
+- Traces appear in your OTLP backend (Tempo, Jaeger, Langfuse, etc.) with:
+  - LLM call spans including model, token counts, and cost
+  - Automatic provider detection (OpenAI)
+
+Replace `AGENTWEAVE_PROXY_URL` with your proxy endpoint if it is not
+`http://localhost:4000/v1`.

--- a/examples/autogen/autogen_example.py
+++ b/examples/autogen/autogen_example.py
@@ -1,0 +1,54 @@
+"""AutoGen + AgentWeave — proxy mode.
+
+Point AutoGen's LLM config at the AgentWeave proxy so every inference call is
+automatically traced, token-counted, and costed.
+"""
+
+import asyncio
+import os
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.messages import TextMessage
+from autogen_core import CancellationToken
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+
+# ---------------------------------------------------------------------------
+# Proxy mode — set base_url in the model client
+# ---------------------------------------------------------------------------
+
+PROXY_URL = os.environ.get("AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1")
+
+model_client = OpenAIChatCompletionClient(
+    model="gpt-4o-mini",
+    base_url=PROXY_URL,
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+# ---------------------------------------------------------------------------
+# Define agent
+# ---------------------------------------------------------------------------
+
+agent = AssistantAgent(
+    name="assistant",
+    model_client=model_client,
+    system_message="You are a helpful assistant. Answer questions concisely.",
+)
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    question = "What are three benefits of distributed tracing for AI agents?"
+    print(f"Question: {question}\n")
+
+    response = await agent.on_messages(
+        [TextMessage(content=question, source="user")],
+        CancellationToken(),
+    )
+    print(f"Answer: {response.chat_message.content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/autogen/requirements.txt
+++ b/examples/autogen/requirements.txt
@@ -1,0 +1,3 @@
+autogen-agentchat>=0.4.0
+autogen-ext[openai]>=0.4.0
+agentweave

--- a/examples/crewai/README.md
+++ b/examples/crewai/README.md
@@ -1,0 +1,31 @@
+# CrewAI + AgentWeave
+
+A minimal CrewAI crew with AgentWeave tracing via **proxy mode** — no code
+changes to the crew itself.
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+```
+
+## How to run
+
+```bash
+# 1. Start the AgentWeave proxy
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+
+# 2. Run the example
+python crew_example.py
+```
+
+## What you see after running
+
+- A two-agent crew (researcher + writer) collaborates to produce a summary.
+- Traces appear in your OTLP backend (Tempo, Jaeger, Langfuse, etc.) with:
+  - LLM call spans for each agent's inference, including token counts and cost
+  - Automatic provider detection (OpenAI)
+
+Replace `AGENTWEAVE_PROXY_URL` with your proxy endpoint if it is not
+`http://localhost:4000/v1`.

--- a/examples/crewai/crew_example.py
+++ b/examples/crewai/crew_example.py
@@ -1,0 +1,71 @@
+"""CrewAI + AgentWeave — proxy mode.
+
+Point CrewAI's LLM at the AgentWeave proxy so every inference call is
+automatically traced, token-counted, and costed.
+"""
+
+import os
+
+from crewai import Agent, Task, Crew, LLM
+
+# ---------------------------------------------------------------------------
+# Proxy mode — configure the LLM to route through AgentWeave
+# ---------------------------------------------------------------------------
+
+PROXY_URL = os.environ.get("AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1")
+
+llm = LLM(
+    model="openai/gpt-4o-mini",
+    base_url=PROXY_URL,
+    api_key=os.environ["OPENAI_API_KEY"],
+)
+
+# ---------------------------------------------------------------------------
+# Define agents
+# ---------------------------------------------------------------------------
+
+researcher = Agent(
+    role="Researcher",
+    goal="Find key facts about a topic",
+    backstory="You are a diligent research assistant who gathers concise facts.",
+    llm=llm,
+    verbose=True,
+)
+
+writer = Agent(
+    role="Writer",
+    goal="Write a short summary from research notes",
+    backstory="You are a skilled writer who turns research into clear summaries.",
+    llm=llm,
+    verbose=True,
+)
+
+# ---------------------------------------------------------------------------
+# Define tasks
+# ---------------------------------------------------------------------------
+
+research_task = Task(
+    description="Research the topic: 'Benefits of open-source observability'. List 3 key points.",
+    expected_output="A bullet list of 3 key facts about open-source observability.",
+    agent=researcher,
+)
+
+writing_task = Task(
+    description="Using the research provided, write a concise 2-sentence summary.",
+    expected_output="A 2-sentence summary of the research.",
+    agent=writer,
+)
+
+# ---------------------------------------------------------------------------
+# Run the crew
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    crew = Crew(
+        agents=[researcher, writer],
+        tasks=[research_task, writing_task],
+        verbose=True,
+    )
+
+    result = crew.kickoff()
+    print(f"\n--- Final Output ---\n{result}")

--- a/examples/crewai/requirements.txt
+++ b/examples/crewai/requirements.txt
@@ -1,0 +1,2 @@
+crewai>=0.80.0
+agentweave

--- a/examples/langgraph/README.md
+++ b/examples/langgraph/README.md
@@ -1,0 +1,36 @@
+# LangGraph + AgentWeave
+
+A minimal LangGraph agent with AgentWeave tracing via **proxy mode** — no code
+changes to the agent itself.
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+```
+
+## How to run
+
+```bash
+# 1. Start the AgentWeave proxy
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+
+# 2. Run the example
+python langgraph_example.py
+```
+
+## What you see after running
+
+- The agent answers a question using a simple tool-calling graph.
+- Traces appear in your OTLP backend (Tempo, Jaeger, Langfuse, etc.) with:
+  - LLM call spans including model, token counts, and cost
+  - Automatic provider detection (OpenAI)
+
+Replace `AGENTWEAVE_PROXY_URL` with your proxy endpoint if it is not
+`http://localhost:4000/v1`.
+
+## Decorator mode (optional)
+
+The example also includes a decorator-mode variant that gives you explicit
+control over span names and nesting. See the `run_with_decorators()` function.

--- a/examples/langgraph/langgraph_example.py
+++ b/examples/langgraph/langgraph_example.py
@@ -1,0 +1,114 @@
+"""LangGraph + AgentWeave — proxy mode and optional decorator mode.
+
+Proxy mode (default): point ChatOpenAI at the AgentWeave proxy.
+Decorator mode: wrap graph nodes with AgentWeave decorators for fine control.
+"""
+
+import os
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import StateGraph, START, END
+from langgraph.prebuilt import ToolNode
+from langchain_core.tools import tool
+from typing import Annotated, TypedDict
+from langgraph.graph.message import add_messages
+
+
+# ---------------------------------------------------------------------------
+# Proxy mode — just change base_url, zero code changes to the agent
+# ---------------------------------------------------------------------------
+
+PROXY_URL = os.environ.get("AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1")
+
+llm = ChatOpenAI(
+    model="gpt-4o-mini",
+    openai_api_key=os.environ["OPENAI_API_KEY"],
+    openai_api_base=PROXY_URL,
+)
+
+
+# -- Simple tool ---------------------------------------------------------- #
+
+@tool
+def word_count(text: str) -> int:
+    """Count the number of words in a text."""
+    return len(text.split())
+
+
+# -- Graph state ---------------------------------------------------------- #
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+# -- Graph construction --------------------------------------------------- #
+
+tools = [word_count]
+llm_with_tools = llm.bind_tools(tools)
+
+
+def agent_node(state: State):
+    return {"messages": [llm_with_tools.invoke(state["messages"])]}
+
+
+def should_continue(state: State):
+    last = state["messages"][-1]
+    if last.tool_calls:
+        return "tools"
+    return END
+
+
+graph = StateGraph(State)
+graph.add_node("agent", agent_node)
+graph.add_node("tools", ToolNode(tools))
+graph.add_edge(START, "agent")
+graph.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+graph.add_edge("tools", "agent")
+
+app = graph.compile()
+
+
+# ---------------------------------------------------------------------------
+# Decorator mode (optional) — explicit spans around each graph invocation
+# ---------------------------------------------------------------------------
+
+def run_with_decorators():
+    """Shows how to combine proxy mode with AgentWeave decorators."""
+    from agentweave import AgentWeaveConfig
+    from agentweave.decorators import trace_agent
+
+    AgentWeaveConfig.setup(
+        agent_id="langgraph-example",
+        agent_model="gpt-4o-mini",
+        otel_endpoint=os.environ.get(
+            "AGENTWEAVE_OTLP_ENDPOINT", "http://localhost:4318"
+        ),
+    )
+
+    @trace_agent(name="langgraph_agent", captures_input=True, captures_output=True)
+    def traced_run(question: str) -> str:
+        result = app.invoke({"messages": [("user", question)]})
+        return result["messages"][-1].content
+
+    answer = traced_run(
+        "How many words are in the sentence: 'The quick brown fox jumps over the lazy dog'?"
+    )
+    print(f"\n[decorator mode] Answer: {answer}")
+    AgentWeaveConfig.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Main — proxy-only by default
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import sys
+
+    question = "How many words are in the sentence: 'The quick brown fox jumps over the lazy dog'?"
+    print(f"Question: {question}\n")
+
+    result = app.invoke({"messages": [("user", question)]})
+    print(f"Answer: {result['messages'][-1].content}")
+
+    if "--decorators" in sys.argv:
+        run_with_decorators()

--- a/examples/langgraph/requirements.txt
+++ b/examples/langgraph/requirements.txt
@@ -1,0 +1,3 @@
+langgraph>=0.2.0
+langchain-openai>=0.2.0
+agentweave

--- a/examples/openai-agents-sdk/README.md
+++ b/examples/openai-agents-sdk/README.md
@@ -1,0 +1,31 @@
+# OpenAI Agents SDK + AgentWeave
+
+A minimal OpenAI Agents SDK agent with AgentWeave tracing via **proxy mode** —
+no code changes to the agent itself.
+
+## Prerequisites
+
+```bash
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+```
+
+## How to run
+
+```bash
+# 1. Start the AgentWeave proxy
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+
+# 2. Run the example
+python agents_example.py
+```
+
+## What you see after running
+
+- An agent with a tool summarizes a piece of text.
+- Traces appear in your OTLP backend (Tempo, Jaeger, Langfuse, etc.) with:
+  - LLM call spans including model, token counts, and cost
+  - Automatic provider detection (OpenAI)
+
+Replace `AGENTWEAVE_PROXY_URL` with your proxy endpoint if it is not
+`http://localhost:4000/v1`.

--- a/examples/openai-agents-sdk/agents_example.py
+++ b/examples/openai-agents-sdk/agents_example.py
@@ -1,0 +1,71 @@
+"""OpenAI Agents SDK + AgentWeave — proxy mode.
+
+Point the AsyncOpenAI client at the AgentWeave proxy so every inference call is
+automatically traced, token-counted, and costed.
+"""
+
+import asyncio
+import os
+
+from openai import AsyncOpenAI
+from agents import Agent, Runner, function_tool, ModelSettings
+from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
+
+# ---------------------------------------------------------------------------
+# Proxy mode — set base_url on the AsyncOpenAI client
+# ---------------------------------------------------------------------------
+
+PROXY_URL = os.environ.get("AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1")
+
+client = AsyncOpenAI(
+    api_key=os.environ["OPENAI_API_KEY"],
+    base_url=PROXY_URL,
+)
+
+# ---------------------------------------------------------------------------
+# Define a simple tool
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+def summarize_text(text: str) -> str:
+    """Return a one-sentence summary of the given text."""
+    # The LLM will call this tool; we return a mock summary for demonstration.
+    words = text.split()
+    return f"Summary ({len(words)} words): {' '.join(words[:10])}..."
+
+
+# ---------------------------------------------------------------------------
+# Define the agent
+# ---------------------------------------------------------------------------
+
+model = OpenAIChatCompletionsModel(model="gpt-4o-mini", openai_client=client)
+
+agent = Agent(
+    name="Summarizer",
+    instructions="You are a helpful assistant that summarizes text. Use the summarize_text tool when asked to summarize.",
+    tools=[summarize_text],
+    model=model,
+)
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    prompt = (
+        "Please summarize the following text: "
+        "'Distributed tracing helps developers understand how requests flow "
+        "through microservices. It captures timing, errors, and metadata at "
+        "each hop, making it easier to debug latency issues and identify "
+        "bottlenecks in complex systems.'"
+    )
+    print(f"Prompt: {prompt}\n")
+
+    result = await Runner.run(agent, prompt)
+    print(f"Answer: {result.final_output}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/openai-agents-sdk/requirements.txt
+++ b/examples/openai-agents-sdk/requirements.txt
@@ -1,0 +1,2 @@
+openai-agents>=0.1.0
+agentweave


### PR DESCRIPTION
## Summary
- Add `examples/` directory with minimal working integrations for **LangGraph**, **CrewAI**, **AutoGen**, and **OpenAI Agents SDK**
- Each example uses **proxy mode** (point `base_url` at AgentWeave proxy) for zero-code tracing
- LangGraph example additionally demonstrates **decorator mode** for fine-grained span control
- Every framework folder includes a runnable Python script, `requirements.txt`, and `README.md`

Fixes #51

## Test plan
- [ ] Verify each example runs with `agentweave proxy start` and a valid `OPENAI_API_KEY`
- [ ] Confirm traces appear in Tempo/Jaeger with correct span attributes
- [ ] Check LangGraph `--decorators` flag produces nested agent spans
- [ ] Review READMEs for accuracy and completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)