### PR TITLE
feat(sdk,proxy): sub-agent attribution and parent-child trace linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,66 @@ def call_claude(messages: list) -> anthropic.Message: ...
 - `prov.llm.stop_reason`
 - `prov.llm.response_preview` (first 512 chars, when `captures_output=True`)
 
+## Sub-agent Attribution
+
+When agents delegate to sub-agents, use the sub-agent attribution parameters to link child sessions to their parent and distinguish agent roles in traces.
+
+### Python SDK
+
+```python
+# Main agent — tags itself as the root session
+@trace_agent(name="nix", session_id="sess-main-123", agent_type="main", turn_depth=1)
+def main_agent(msg: str) -> str:
+    return delegate_to_sub(msg)
+
+# Sub-agent — linked to parent session
+@trace_agent(name="max", parent_session_id="sess-main-123",
+             agent_type="subagent", turn_depth=2)
+def sub_agent(task: str) -> str:
+    return call_llm(task)
+```
+
+### Environment variable auto-detection
+
+Set `AGENTWEAVE_PARENT_SESSION_ID` and the SDK auto-populates `prov.parent.session.id`, defaults `agent_type` to `"subagent"`, and `turn_depth` to `2`:
+
+```bash
+export AGENTWEAVE_PARENT_SESSION_ID=sess-main-123
+```
+
+### Proxy headers
+
+When using the proxy, pass sub-agent context via HTTP headers:
+
+| Header | Span attribute | Example |
+|--------|---------------|---------|
+| `X-AgentWeave-Parent-Session-Id` | `prov.parent.session.id` | `sess-main-123` |
+| `X-AgentWeave-Agent-Type` | `prov.agent.type` | `subagent` |
+| `X-AgentWeave-Turn-Depth` | `prov.session.turn` | `2` |
+
+### TypeScript SDK
+
+```typescript
+import { traceAgent } from 'agentweave-sdk';
+
+const subAgent = traceAgent({
+  name: 'max',
+  parentSessionId: 'sess-main-123',
+  agentType: 'subagent',
+  turnDepth: 2,
+})(async (task: string) => {
+  return callLlm(task);
+});
+```
+
+### New span attributes
+
+| Attribute | Description |
+|---|---|
+| `prov.parent.session.id` | ID of the parent session that spawned this sub-agent |
+| `prov.agent.type` | `"main"`, `"subagent"`, or `"delegated"` |
+| `prov.session.turn` | Turn depth: 1 = main session, 2 = first-level sub-agent |
+
 ## PROV-O Attributes
 
 | Attribute | Description |

--- a/sdk/js/src/decorators.ts
+++ b/sdk/js/src/decorators.ts
@@ -123,11 +123,25 @@ export function traceTool(nameOrOpts?: string | { name?: string; capturesInput?:
 // traceAgent
 // ---------------------------------------------------------------------------
 
+export interface TraceAgentOptions {
+  name?: string;
+  sessionId?: string;
+  parentSessionId?: string;
+  agentType?: 'main' | 'subagent' | 'delegated';
+  turnDepth?: number;
+}
+
 export function traceAgent(name?: string): (fn: (...args: any[]) => any) => (...args: any[]) => any;
-export function traceAgent(opts: { name?: string }): (fn: (...args: any[]) => any) => (...args: any[]) => any;
-export function traceAgent(nameOrOpts?: string | { name?: string }) {
+export function traceAgent(opts: TraceAgentOptions): (fn: (...args: any[]) => any) => (...args: any[]) => any;
+export function traceAgent(nameOrOpts?: string | TraceAgentOptions) {
   const opts = typeof nameOrOpts === 'string' ? { name: nameOrOpts } : (nameOrOpts ?? {});
-  const { name } = opts;
+  const { name, sessionId, agentType, turnDepth } = opts;
+
+  // Resolve parent session: explicit param > env var
+  const parentSessionId = opts.parentSessionId || process.env.AGENTWEAVE_PARENT_SESSION_ID || undefined;
+  // Auto-infer defaults when parent session is set
+  const resolvedAgentType = agentType ?? (parentSessionId ? schema.AGENT_TYPE_SUBAGENT : undefined);
+  const resolvedTurnDepth = turnDepth ?? (parentSessionId ? 2 : undefined);
 
   return (fn: (...args: any[]) => any) => {
     const spanName = `${schema.SPAN_PREFIX_AGENT}.${name ?? fn.name}`;
@@ -136,6 +150,19 @@ export function traceAgent(nameOrOpts?: string | { name?: string }) {
         span.setAttribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN);
         for (const [k, v] of Object.entries(getConfigAttrs())) {
           span.setAttribute(k, v);
+        }
+        if (sessionId) {
+          span.setAttribute(schema.SESSION_ID, sessionId);
+          span.setAttribute(schema.PROV_SESSION_ID, sessionId);
+        }
+        if (parentSessionId) {
+          span.setAttribute(schema.PROV_PARENT_SESSION_ID, parentSessionId);
+        }
+        if (resolvedAgentType) {
+          span.setAttribute(schema.PROV_AGENT_TYPE, resolvedAgentType);
+        }
+        if (resolvedTurnDepth != null) {
+          span.setAttribute(schema.PROV_SESSION_TURN, resolvedTurnDepth);
         }
 
         const result = fn(...args);

--- a/sdk/js/src/index.ts
+++ b/sdk/js/src/index.ts
@@ -1,6 +1,7 @@
 export { AgentWeaveConfig } from './config';
 export { getTracer, withSpan, shutdownHandler } from './tracer';
 export { traceTool, traceAgent, traceLlm } from './decorators';
+export type { TraceAgentOptions } from './decorators';
 export * from './schema';
 
 // ── Graceful shutdown: register Node.js signal handlers ──────────────────────

--- a/sdk/js/src/schema.ts
+++ b/sdk/js/src/schema.ts
@@ -25,6 +25,21 @@ export const PROV_AGENT_ID = 'prov.agent.id';
 export const PROV_AGENT_MODEL = 'prov.agent.model';
 export const PROV_AGENT_VERSION = 'prov.agent.version';
 
+// prov:Session -- session and project context
+export const PROV_SESSION_ID = 'prov.session.id';
+export const PROV_PROJECT = 'prov.project';
+export const PROV_SESSION_TURN = 'prov.session.turn';
+export const SESSION_ID = 'session.id';
+
+// Sub-agent attribution -- parent-child trace linking (issue #15)
+export const PROV_PARENT_SESSION_ID = 'prov.parent.session.id';
+export const PROV_AGENT_TYPE = 'prov.agent.type';
+
+// Agent type constants
+export const AGENT_TYPE_MAIN = 'main';
+export const AGENT_TYPE_SUBAGENT = 'subagent';
+export const AGENT_TYPE_DELEGATED = 'delegated';
+
 // prov:wasGeneratedBy -- output linked to producing activity
 export const PROV_WAS_GENERATED_BY = 'prov.wasGeneratedBy';
 

--- a/sdk/js/tests/decorators.test.ts
+++ b/sdk/js/tests/decorators.test.ts
@@ -90,6 +90,92 @@ describe('traceAgent', () => {
   });
 });
 
+describe('traceAgent — sub-agent attribution', () => {
+  it('sets parent session ID, agent type, and turn depth', async () => {
+    const tracedFn = traceAgent({
+      name: 'subAgent',
+      parentSessionId: 'sess-parent-123',
+      agentType: 'subagent',
+      turnDepth: 2,
+    })(async (arg: string) => arg);
+
+    const result = await tracedFn('hello');
+    expect(result).toBe('hello');
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0].name).toBe('agent.subAgent');
+    expect(spans[0].attributes[schema.PROV_PARENT_SESSION_ID]).toBe('sess-parent-123');
+    expect(spans[0].attributes[schema.PROV_AGENT_TYPE]).toBe('subagent');
+    expect(spans[0].attributes[schema.PROV_SESSION_TURN]).toBe(2);
+  });
+
+  it('auto-defaults to subagent type when parentSessionId is set', async () => {
+    const tracedFn = traceAgent({
+      name: 'autoSubAgent',
+      parentSessionId: 'sess-parent-auto',
+    })(async () => 'ok');
+
+    await tracedFn();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].attributes[schema.PROV_PARENT_SESSION_ID]).toBe('sess-parent-auto');
+    expect(spans[0].attributes[schema.PROV_AGENT_TYPE]).toBe('subagent');
+    expect(spans[0].attributes[schema.PROV_SESSION_TURN]).toBe(2);
+  });
+
+  it('sets session ID on agent span', async () => {
+    const tracedFn = traceAgent({
+      name: 'sessionAgent',
+      sessionId: 'conv-abc123',
+    })(async () => 'ok');
+
+    await tracedFn();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].attributes[schema.SESSION_ID]).toBe('conv-abc123');
+    expect(spans[0].attributes[schema.PROV_SESSION_ID]).toBe('conv-abc123');
+  });
+
+  it('does not set sub-agent attrs when not provided', async () => {
+    const tracedFn = traceAgent('plainAgent')(async () => 'ok');
+    await tracedFn();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].attributes[schema.PROV_PARENT_SESSION_ID]).toBeUndefined();
+    expect(spans[0].attributes[schema.PROV_AGENT_TYPE]).toBeUndefined();
+  });
+
+  it('sets delegated agent type with custom turn depth', async () => {
+    const tracedFn = traceAgent({
+      name: 'delegatedAgent',
+      parentSessionId: 'sess-parent-del',
+      agentType: 'delegated',
+      turnDepth: 3,
+    })(async () => 'ok');
+
+    await tracedFn();
+
+    const spans = exporter.getFinishedSpans();
+    expect(spans[0].attributes[schema.PROV_AGENT_TYPE]).toBe('delegated');
+    expect(spans[0].attributes[schema.PROV_SESSION_TURN]).toBe(3);
+  });
+
+  it('reads AGENTWEAVE_PARENT_SESSION_ID from env var', async () => {
+    process.env.AGENTWEAVE_PARENT_SESSION_ID = 'sess-env-parent';
+    try {
+      const tracedFn = traceAgent({ name: 'envAgent' })(async () => 'ok');
+      await tracedFn();
+
+      const spans = exporter.getFinishedSpans();
+      expect(spans[0].attributes[schema.PROV_PARENT_SESSION_ID]).toBe('sess-env-parent');
+      expect(spans[0].attributes[schema.PROV_AGENT_TYPE]).toBe('subagent');
+    } finally {
+      delete process.env.AGENTWEAVE_PARENT_SESSION_ID;
+    }
+  });
+});
+
 describe('traceLlm', () => {
   it('creates a span with provider/model and extracts token counts', async () => {
     const tracedFn = traceLlm({

--- a/sdk/python/agentweave/decorators.py
+++ b/sdk/python/agentweave/decorators.py
@@ -251,17 +251,40 @@ def _make_agent_wrapper(
     fn: Callable, name: str, captures_input: bool, captures_output: bool,
     trace_id: Optional[str] = None,
     session_id: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+    agent_type: Optional[str] = None,
+    turn_depth: Optional[int] = None,
 ) -> Callable:
     span_name = f"{schema.SPAN_PREFIX_AGENT}.{name}"
 
     # Pre-compute the deterministic context once at decoration time (if provided)
     _det_trace_id_int = _normalize_trace_id(trace_id) if trace_id else None
 
+    # Resolve sub-agent attribution: explicit params take precedence, then env var
+    import os as _os
+    _parent_session_id = parent_session_id or _os.environ.get("AGENTWEAVE_PARENT_SESSION_ID") or None
+    _agent_type = agent_type
+    _turn_depth = turn_depth
+    # Auto-infer agent_type and turn_depth when parent session is set via env var
+    if _parent_session_id and _agent_type is None:
+        _agent_type = schema.AGENT_TYPE_SUBAGENT
+    if _parent_session_id and _turn_depth is None:
+        _turn_depth = 2  # default: first-level sub-agent
+
     def _start_ctx() -> Any:
         """Return an OTel context to use when starting the root agent span."""
         if _det_trace_id_int is not None:
             return _context_for_trace_id(_det_trace_id_int)
         return None  # let OTel use the ambient context
+
+    def _set_subagent_attrs(span: Any) -> None:
+        """Set sub-agent attribution attributes on the span."""
+        if _parent_session_id is not None:
+            span.set_attribute(schema.PROV_PARENT_SESSION_ID, _parent_session_id)
+        if _agent_type is not None:
+            span.set_attribute(schema.PROV_AGENT_TYPE, _agent_type)
+        if _turn_depth is not None:
+            span.set_attribute(schema.PROV_SESSION_TURN, _turn_depth)
 
     if inspect.iscoroutinefunction(fn):
         @functools.wraps(fn)
@@ -284,6 +307,7 @@ def _make_agent_wrapper(
                     if session_id is not None:
                         span.set_attribute(schema.SESSION_ID, session_id)
                         span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    _set_subagent_attrs(span)
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     result = await fn(*args, **kwargs)
@@ -315,6 +339,7 @@ def _make_agent_wrapper(
                     if session_id is not None:
                         span.set_attribute(schema.SESSION_ID, session_id)
                         span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    _set_subagent_attrs(span)
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     result = fn(*args, **kwargs)
@@ -329,7 +354,10 @@ def _make_agent_wrapper(
 
 def trace_agent(fn: Optional[Callable] = None, *, name: Optional[str] = None, context=None,
                 captures_input: bool = False, captures_output: bool = False,
-                traceId: Optional[str] = None, session_id: Optional[str] = None):
+                traceId: Optional[str] = None, session_id: Optional[str] = None,
+                parent_session_id: Optional[str] = None,
+                agent_type: Optional[str] = None,
+                turn_depth: Optional[int] = None):
     """Trace an agent turn. Supports bare @trace_agent or @trace_agent(name=...).
 
     Pass ``traceId`` to pin the root span to a deterministic trace ID so that
@@ -340,8 +368,17 @@ def trace_agent(fn: Optional[Callable] = None, *, name: Optional[str] = None, co
     (and ``prov.session.id`` for backward compatibility) so it can be used as
     a filterable dimension in Grafana / Tempo.
 
-    - If *traceId* is already a valid 32-char hex string it is used directly.
-    - Otherwise it is SHA-256 hashed to produce a valid OTel trace ID.
+    **Sub-agent attribution** (issue #15):
+
+    Pass ``parent_session_id`` to link this sub-agent to its parent session.
+    Pass ``agent_type`` to tag the agent role (``"main"``, ``"subagent"``, or
+    ``"delegated"``).  Pass ``turn_depth`` to indicate the nesting level
+    (1 = main session, 2 = first-level sub-agent, etc.).
+
+    If the ``AGENTWEAVE_PARENT_SESSION_ID`` environment variable is set, it is
+    used as the default ``parent_session_id``.  When a parent session is
+    detected (explicit or env var), ``agent_type`` defaults to ``"subagent"``
+    and ``turn_depth`` defaults to ``2``.
 
     Usage::
         @trace_agent
@@ -350,15 +387,13 @@ def trace_agent(fn: Optional[Callable] = None, *, name: Optional[str] = None, co
         @trace_agent(name="nix")
         def handle(msg): ...
 
-        # Deterministic trace ID — safe to retry without creating duplicate traces
-        @trace_agent(traceId="order-abc123-attempt-1")
+        # Sub-agent linked to parent session
+        @trace_agent(name="max", parent_session_id="sess-parent-123",
+                     agent_type="subagent", turn_depth=2)
         def handle(msg): ...
 
-        @trace_agent(traceId="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")  # 32-char hex
-        def handle(msg): ...
-
-        # Session grouping — all spans from this call share session.id
-        @trace_agent(session_id="conv-abc123")
+        # Auto-detect via env var: AGENTWEAVE_PARENT_SESSION_ID=sess-parent-123
+        @trace_agent(name="max")
         def handle(msg): ...
     """
     if callable(fn):
@@ -370,6 +405,9 @@ def trace_agent(fn: Optional[Callable] = None, *, name: Optional[str] = None, co
             captures_input, captures_output,
             trace_id=traceId,
             session_id=session_id,
+            parent_session_id=parent_session_id,
+            agent_type=agent_type,
+            turn_depth=turn_depth,
         )
 
     return decorator

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -73,6 +73,9 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-turn",
     "x-agentweave-trace-id",
     "x-agentweave-turn-count",
+    "x-agentweave-parent-session-id",
+    "x-agentweave-agent-type",
+    "x-agentweave-turn-depth",
 }
 
 # ---------------------------------------------------------------------------
@@ -260,6 +263,17 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         except (ValueError, TypeError):
             logger.warning("x-agentweave-turn-count is not a valid integer: %r", turn_count_raw)
 
+    # Sub-agent attribution headers (issue #15)
+    parent_session_id: str | None = request.headers.get("x-agentweave-parent-session-id")
+    agent_type: str | None = request.headers.get("x-agentweave-agent-type")
+    turn_depth: int | None = None
+    turn_depth_raw = request.headers.get("x-agentweave-turn-depth")
+    if turn_depth_raw is not None:
+        try:
+            turn_depth = int(turn_depth_raw)
+        except (ValueError, TypeError):
+            logger.warning("x-agentweave-turn-depth is not a valid integer: %r", turn_depth_raw)
+
     forward_headers = {
         k: v for k, v in request.headers.items()
         if k.lower() not in _SKIP_HEADERS_ALWAYS
@@ -291,6 +305,9 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         det_trace_id_int=det_trace_id_int,
         det_trace_id_raw=det_trace_id_raw,
         turn_count=turn_count,
+        parent_session_id=parent_session_id,
+        agent_type=agent_type,
+        turn_depth=turn_depth,
     )
 
     if is_stream:
@@ -309,6 +326,8 @@ async def _request_and_trace(
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
     det_trace_id_int: int | None = None, det_trace_id_raw: str | None = None,
     turn_count: int | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
+    turn_depth: int | None = None,
 ) -> JSONResponse:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
@@ -317,7 +336,9 @@ async def _request_and_trace(
                            agent_id=agent_id, agent_model=agent_model,
                            path=path, body=body,
                            session_id=session_id, project=project, turn=turn,
-                           det_trace_id_raw=det_trace_id_raw)
+                           det_trace_id_raw=det_trace_id_raw,
+                           parent_session_id=parent_session_id,
+                           agent_type=agent_type, turn_depth=turn_depth)
         if turn_count is not None:
             span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
         start = time.perf_counter()
@@ -347,6 +368,8 @@ async def _stream_and_trace(
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
     det_trace_id_int: int | None = None, det_trace_id_raw: str | None = None,
     turn_count: int | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
+    turn_depth: int | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
@@ -355,7 +378,9 @@ async def _stream_and_trace(
                        agent_id=agent_id, agent_model=agent_model,
                        path=path, body=body,
                        session_id=session_id, project=project, turn=turn,
-                       det_trace_id_raw=det_trace_id_raw)
+                       det_trace_id_raw=det_trace_id_raw,
+                       parent_session_id=parent_session_id,
+                       agent_type=agent_type, turn_depth=turn_depth)
     if turn_count is not None:
         span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
 
@@ -705,6 +730,8 @@ def _set_request_attrs(
     path: str, body: dict,
     session_id: str | None = None, project: str | None = None, turn: int | None = None,
     det_trace_id_raw: str | None = None,
+    parent_session_id: str | None = None, agent_type: str | None = None,
+    turn_depth: int | None = None,
 ) -> None:
     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
     span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
@@ -723,6 +750,14 @@ def _set_request_attrs(
         span.set_attribute(schema.PROV_SESSION_TURN, turn)
     if det_trace_id_raw is not None:
         span.set_attribute(schema.AGENTWEAVE_TRACE_ID, det_trace_id_raw)
+
+    # Sub-agent attribution (issue #15)
+    if parent_session_id is not None:
+        span.set_attribute(schema.PROV_PARENT_SESSION_ID, parent_session_id)
+    if agent_type is not None:
+        span.set_attribute(schema.PROV_AGENT_TYPE, agent_type)
+    if turn_depth is not None:
+        span.set_attribute(schema.PROV_SESSION_TURN, turn_depth)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -46,6 +46,15 @@ PROV_SESSION_ID = "prov.session.id"
 PROV_PROJECT = "prov.project"
 PROV_SESSION_TURN = "prov.session.turn"
 
+# Sub-agent attribution — parent-child trace linking (issue #15)
+PROV_PARENT_SESSION_ID = "prov.parent.session.id"  # ID of parent session that spawned this sub-agent
+PROV_AGENT_TYPE = "prov.agent.type"                 # "main" | "subagent" | "delegated"
+
+# Agent type constants
+AGENT_TYPE_MAIN = "main"
+AGENT_TYPE_SUBAGENT = "subagent"
+AGENT_TYPE_DELEGATED = "delegated"
+
 # session.id — canonical session attribute (dual-emitted alongside prov.session.id)
 # Set via @trace_agent(session_id=...) or X-AgentWeave-Session-Id proxy header.
 SESSION_ID = "session.id"

--- a/sdk/python/tests/test_decorators.py
+++ b/sdk/python/tests/test_decorators.py
@@ -491,6 +491,104 @@ class TestTraceLlm:
         llm_attrs = dict(llm_span.attributes)
         assert llm_attrs["prov.llm.total_tokens"] == 250
 
+class TestTraceAgentSubAgentAttribution:
+    """Tests for @trace_agent sub-agent attribution (issue #15)."""
+
+    def test_parent_session_id_sets_attribute(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="sub_agent", parent_session_id="sess-parent-123")
+        def handle(msg: str) -> str:
+            return "response"
+
+        handle("hello")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert attrs[schema.PROV_PARENT_SESSION_ID] == "sess-parent-123"
+        # Should auto-default to "subagent" type and turn_depth=2
+        assert attrs[schema.PROV_AGENT_TYPE] == "subagent"
+        assert attrs[schema.PROV_SESSION_TURN] == 2
+
+    def test_explicit_agent_type_and_turn_depth(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="delegated_agent", parent_session_id="sess-parent-456",
+                     agent_type="delegated", turn_depth=3)
+        def handle(msg: str) -> str:
+            return "response"
+
+        handle("hello")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert attrs[schema.PROV_PARENT_SESSION_ID] == "sess-parent-456"
+        assert attrs[schema.PROV_AGENT_TYPE] == "delegated"
+        assert attrs[schema.PROV_SESSION_TURN] == 3
+
+    def test_main_agent_type_without_parent(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="main_agent", agent_type="main", turn_depth=1)
+        def handle(msg: str) -> str:
+            return "response"
+
+        handle("hello")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert schema.PROV_PARENT_SESSION_ID not in attrs
+        assert attrs[schema.PROV_AGENT_TYPE] == "main"
+        assert attrs[schema.PROV_SESSION_TURN] == 1
+
+    def test_env_var_auto_populates_parent_session(self, _setup_test_tracer, monkeypatch):
+        exporter, _ = _setup_test_tracer
+        monkeypatch.setenv("AGENTWEAVE_PARENT_SESSION_ID", "sess-env-parent")
+
+        @trace_agent(name="env_sub_agent")
+        def handle(msg: str) -> str:
+            return "response"
+
+        handle("hello")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert attrs[schema.PROV_PARENT_SESSION_ID] == "sess-env-parent"
+        assert attrs[schema.PROV_AGENT_TYPE] == "subagent"
+        assert attrs[schema.PROV_SESSION_TURN] == 2
+
+    def test_no_subagent_attrs_when_not_provided(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="plain_agent")
+        def handle(msg: str) -> str:
+            return "response"
+
+        handle("hello")
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert schema.PROV_PARENT_SESSION_ID not in attrs
+        assert schema.PROV_AGENT_TYPE not in attrs
+
+    def test_async_agent_with_parent_session(self, _setup_test_tracer):
+        exporter, _ = _setup_test_tracer
+
+        @trace_agent(name="async_sub", parent_session_id="sess-async-parent",
+                     agent_type="subagent", turn_depth=2)
+        async def handle(msg: str) -> str:
+            return "async response"
+
+        import asyncio
+        asyncio.run(handle("hi"))
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert attrs[schema.PROV_PARENT_SESSION_ID] == "sess-async-parent"
+        assert attrs[schema.PROV_AGENT_TYPE] == "subagent"
+        assert attrs[schema.PROV_SESSION_TURN] == 2
+
+
 class TestTraceAgentDeterministicTraceId:
     """Tests for @trace_agent traceId parameter (deterministic trace IDs)."""
 

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -614,6 +614,54 @@ class TestSessionContext:
 # ---------------------------------------------------------------------------
 
 
+class TestSubAgentAttributionHeaders:
+    """Verify sub-agent attribution headers are read, set on spans, and stripped from forwarding (issue #15)."""
+
+    def _call(self, monkeypatch, parent_session_id=None, agent_type=None, turn_depth=None):
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="sub-agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+            parent_session_id=parent_session_id,
+            agent_type=agent_type,
+            turn_depth=turn_depth,
+        )
+        return span
+
+    def test_all_subagent_attrs_set(self, monkeypatch):
+        span = self._call(monkeypatch, parent_session_id="sess-parent-123",
+                          agent_type="subagent", turn_depth=2)
+        assert span.attrs["prov.parent.session.id"] == "sess-parent-123"
+        assert span.attrs["prov.agent.type"] == "subagent"
+        assert span.attrs["prov.session.turn"] == 2
+
+    def test_delegated_agent_type(self, monkeypatch):
+        span = self._call(monkeypatch, parent_session_id="sess-parent-456",
+                          agent_type="delegated", turn_depth=3)
+        assert span.attrs["prov.parent.session.id"] == "sess-parent-456"
+        assert span.attrs["prov.agent.type"] == "delegated"
+        assert span.attrs["prov.session.turn"] == 3
+
+    def test_no_subagent_attrs_when_not_provided(self, monkeypatch):
+        span = self._call(monkeypatch)
+        assert "prov.parent.session.id" not in span.attrs
+        assert "prov.agent.type" not in span.attrs
+
+    def test_partial_subagent_attrs(self, monkeypatch):
+        span = self._call(monkeypatch, parent_session_id="sess-parent-789")
+        assert span.attrs["prov.parent.session.id"] == "sess-parent-789"
+        assert "prov.agent.type" not in span.attrs
+
+    def test_subagent_headers_stripped_from_forwarding(self):
+        """Sub-agent headers must be in _SKIP_HEADERS_ALWAYS."""
+        assert "x-agentweave-parent-session-id" in _SKIP_HEADERS_ALWAYS
+        assert "x-agentweave-agent-type" in _SKIP_HEADERS_ALWAYS
+        assert "x-agentweave-turn-depth" in _SKIP_HEADERS_ALWAYS
+
+
 class TestNormalizeTraceId:
     """Unit tests for the _normalize_trace_id helper."""
 


### PR DESCRIPTION
## Summary
- Add `prov.parent.session.id`, `prov.agent.type` span attributes and `AGENT_TYPE_*` constants to Python + TypeScript SDKs
- Extend `@trace_agent` / `traceAgent` with `parent_session_id`, `agent_type`, `turn_depth` params; auto-populate from `AGENTWEAVE_PARENT_SESSION_ID` env var
- Proxy reads `X-AgentWeave-Parent-Session-Id`, `X-AgentWeave-Agent-Type`, `X-AgentWeave-Turn-Depth` headers and sets span attributes
- 17 new tests (11 Python, 6 TypeScript) covering decorator params, env var auto-detection, proxy header extraction and stripping
- README updated with "Sub-agent Attribution" section including usage examples

Fixes #15

## Test plan
- [x] All 196 Python tests pass (`pytest sdk/python -v`)
- [ ] TypeScript tests pass (`cd sdk/js && npm ci && npx jest --verbose`) — npm not available in CI-less env; tests follow existing patterns and are syntactically verified
- [x] Proxy strips new headers from upstream forwarding (`_SKIP_HEADERS_ALWAYS`)
- [x] Env var `AGENTWEAVE_PARENT_SESSION_ID` auto-populates parent session, agent type, and turn depth

🤖 Generated with [Claude Code](https://claude.com/claude-code)