### PR TITLE
feat(infra): nix sub-agent proxy on NodePort 30402, fixes #86

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -140,6 +140,31 @@ export ANTHROPIC_BASE_URL=http://localhost:4000
 
 The proxy never stores API keys — it forwards `x-api-key` from the calling agent to Anthropic unchanged. The `Authorization: Bearer` header is the proxy access token only and is stripped before forwarding.
 
+## Sub-agent Proxy (Nix)
+
+Nix (the NAS Claude Code agent) uses two proxy instances to separate main session traces from sub-agent traces:
+
+| Proxy | NodePort | AGENTWEAVE_AGENT_ID | Purpose |
+|---|---|---|---|
+| agentweave-proxy-nodeport | 30400 | nix-v1 | Main session |
+| agentweave-proxy-nix-subagent-nodeport | 30402 | nix-subagent-v1 | Sub-agents (worktree agents) |
+
+When spawning Claude Code sub-agents, set:
+
+```bash
+export ANTHROPIC_BASE_URL=http://192.168.1.70:30402/v1
+```
+
+This ensures sub-agent traces are tagged with `nix-subagent-v1` and can be filtered separately in the dashboard.
+
+### Deploy sub-agent proxy
+
+```bash
+kubectl apply -f deploy/k8s/nix-subagent-proxy-configmap.yaml
+kubectl apply -f deploy/k8s/nix-subagent-proxy-deployment.yaml
+kubectl apply -f deploy/k8s/nix-subagent-proxy-service.yaml
+```
+
 ## Update configmap
 
 ```bash

--- a/deploy/k8s/nix-subagent-proxy-configmap.yaml
+++ b/deploy/k8s/nix-subagent-proxy-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentweave-proxy-nix-subagent
+  namespace: agentweave
+data:
+  AGENTWEAVE_AGENT_ID: "nix-subagent-v1"
+  AGENTWEAVE_OTLP_ENDPOINT: "http://tempo.monitoring.svc.cluster.local:4318"

--- a/deploy/k8s/nix-subagent-proxy-deployment.yaml
+++ b/deploy/k8s/nix-subagent-proxy-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentweave-proxy-nix-subagent
+  namespace: agentweave
+  labels:
+    app: agentweave-proxy-nix-subagent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentweave-proxy-nix-subagent
+  template:
+    metadata:
+      labels:
+        app: agentweave-proxy-nix-subagent
+    spec:
+      containers:
+        - name: proxy
+          image: localhost:5000/agentweave-proxy:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - configMapRef:
+                name: agentweave-proxy-nix-subagent
+          # No AGENTWEAVE_PROXY_TOKEN — sub-agent proxy is LAN-only (NodePort 30402).
+          # Claude Code sub-agents use ANTHROPIC_BASE_URL directly without custom auth headers.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"

--- a/deploy/k8s/nix-subagent-proxy-service.yaml
+++ b/deploy/k8s/nix-subagent-proxy-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentweave-proxy-nix-subagent-nodeport
+  namespace: agentweave
+spec:
+  type: NodePort
+  selector:
+    app: agentweave-proxy-nix-subagent
+  ports:
+    - port: 4000
+      targetPort: 4000
+      nodePort: 30402


### PR DESCRIPTION
## Summary
- Deploy a dedicated sub-agent proxy (`agentweave-proxy-nix-subagent`) on NodePort 30402 with `AGENTWEAVE_AGENT_ID=nix-subagent-v1`
- Separate ConfigMap, Deployment, and Service manifests following the existing proxy-max pattern
- Updated `deploy/k8s/README.md` with Sub-agent Proxy (Nix) section and `TOOLS.md` with proxy port reference

## Test plan
- [x] `kubectl apply` all three manifests — created successfully
- [x] `kubectl rollout status` — deployment rolled out successfully
- [ ] Verify sub-agent traces appear with `nix-subagent-v1` agent ID in Grafana/Tempo
- [ ] Confirm main session traces still use `nix-v1` on port 30400

🤖 Generated with [Claude Code](https://claude.com/claude-code)