### PR TITLE
feat(proxy): POST /session endpoint for per-spawn session attribution, fixes #89

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -117,6 +117,15 @@ def _context_for_trace_id(trace_id_int: int):
 # Empty = open mode (dev/localhost only).
 _PROXY_TOKEN: str | None = os.getenv("AGENTWEAVE_PROXY_TOKEN") or None
 
+# Global session context — set at startup from env, overrideable via POST /session
+_session_context: dict[str, str] = {
+    k: v for k, v in {
+        "prov.session.id": os.getenv("AGENTWEAVE_SESSION_ID", ""),
+        "prov.parent.session.id": os.getenv("AGENTWEAVE_PARENT_SESSION_ID", ""),
+        "prov.task.label": os.getenv("AGENTWEAVE_TASK_LABEL", ""),
+    }.items() if v
+}
+
 # Gemini model name from URL, e.g. /v1beta/models/gemini-2.5-pro:generateContent
 _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 
@@ -204,6 +213,24 @@ def _is_streaming(provider: str, path: str, body: dict) -> bool:
 async def health() -> dict:
     """Liveness/readiness probe — no auth required."""
     return {"status": "ok", "version": app.version}
+
+
+@app.post("/session", include_in_schema=True)
+async def set_session_context(body: dict):
+    """Override the global session context for all subsequent spans."""
+    global _session_context
+    _session_context = {k: v for k, v in {
+        "prov.session.id": body.get("session_id", ""),
+        "prov.parent.session.id": body.get("parent_session_id", ""),
+        "prov.task.label": body.get("task_label", ""),
+    }.items() if v}
+    return {"ok": True, "context": _session_context}
+
+
+@app.get("/session", include_in_schema=True)
+async def get_session_context():
+    """Return the current global session context."""
+    return _session_context
 
 
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"], response_model=None)
@@ -772,6 +799,10 @@ def _set_request_attrs(
     span.set_attribute(schema.GEN_AI_SYSTEM, provider)
     span.set_attribute(schema.GEN_AI_REQUEST_MODEL, agent_model)
     span.set_attribute(schema.GEN_AI_AGENT_NAME, agent_id)
+
+    # Apply global session context (env-var defaults overrideable via POST /session)
+    for k, v in _session_context.items():
+        span.set_attribute(k, v)
 
     # Only fall back to cfg.agent_id if no per-request agent_id was provided via header
     if not agent_id:

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -49,6 +49,7 @@ PROV_SESSION_TURN = "prov.session.turn"
 # Sub-agent attribution — parent-child trace linking (issue #15)
 PROV_PARENT_SESSION_ID = "prov.parent.session.id"  # ID of parent session that spawned this sub-agent
 PROV_AGENT_TYPE = "prov.agent.type"                 # "main" | "subagent" | "delegated"
+PROV_TASK_LABEL = "prov.task.label"                 # human-readable task label for session
 
 # Agent type constants
 AGENT_TYPE_MAIN = "main"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -723,6 +723,98 @@ class TestSubAgentAttributionHeaders:
         assert "x-agentweave-turn-depth" in _SKIP_HEADERS_ALWAYS
 
 
+class TestSessionEndpoint:
+    """POST /session stores context, GET /session returns it, env-var fallback works."""
+
+    def test_post_session_stores_context(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        client = TestClient(app)
+        resp = client.post("/session", json={
+            "session_id": "sess-001",
+            "parent_session_id": "sess-parent-001",
+            "task_label": "build dashboard",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["context"]["prov.session.id"] == "sess-001"
+        assert data["context"]["prov.parent.session.id"] == "sess-parent-001"
+        assert data["context"]["prov.task.label"] == "build dashboard"
+
+    def test_get_session_returns_current_context(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        client = TestClient(app)
+        # Set context first
+        client.post("/session", json={"session_id": "sess-get-test"})
+        resp = client.get("/session")
+        assert resp.status_code == 200
+        assert resp.json()["prov.session.id"] == "sess-get-test"
+
+    def test_empty_values_excluded(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        client = TestClient(app)
+        resp = client.post("/session", json={
+            "session_id": "sess-only",
+            "parent_session_id": "",
+            "task_label": "",
+        })
+        data = resp.json()
+        assert "prov.session.id" in data["context"]
+        assert "prov.parent.session.id" not in data["context"]
+        assert "prov.task.label" not in data["context"]
+
+    def test_env_var_fallback_at_startup(self, monkeypatch):
+        """AGENTWEAVE_SESSION_ID env var populates _session_context at module reload."""
+        import importlib
+        monkeypatch.setenv("AGENTWEAVE_SESSION_ID", "env-sess-42")
+        monkeypatch.setenv("AGENTWEAVE_PARENT_SESSION_ID", "")
+        monkeypatch.setenv("AGENTWEAVE_TASK_LABEL", "")
+        importlib.reload(proxy_module)
+        assert proxy_module._session_context.get("prov.session.id") == "env-sess-42"
+        assert "prov.parent.session.id" not in proxy_module._session_context
+        assert "prov.task.label" not in proxy_module._session_context
+        # Clean up: reload without env var to restore original state
+        monkeypatch.delenv("AGENTWEAVE_SESSION_ID")
+        importlib.reload(proxy_module)
+
+    def test_session_context_applied_to_spans(self, monkeypatch):
+        """After POST /session, _set_request_attrs applies context attrs to spans."""
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        # Set the global context
+        monkeypatch.setattr(proxy_module, "_session_context", {
+            "prov.session.id": "ctx-sess-99",
+            "prov.task.label": "run tests",
+        })
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+        )
+        assert span.attrs["prov.session.id"] == "ctx-sess-99"
+        assert span.attrs["prov.task.label"] == "run tests"
+        assert "prov.parent.session.id" not in span.attrs
+        # Restore
+        monkeypatch.setattr(proxy_module, "_session_context", {})
+
+    def test_empty_context_no_blank_attrs(self, monkeypatch):
+        """When _session_context is empty, no blank attributes end up on spans."""
+        from agentweave.config import AgentWeaveConfig
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        monkeypatch.setattr(proxy_module, "_session_context", {})
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+        )
+        assert "prov.task.label" not in span.attrs
+
+
 class TestNormalizeTraceId:
     """Unit tests for the _normalize_trace_id helper."""
 


### PR DESCRIPTION
## Summary
- Add global `_session_context` dict populated at startup from env vars (`AGENTWEAVE_SESSION_ID`, `AGENTWEAVE_PARENT_SESSION_ID`, `AGENTWEAVE_TASK_LABEL`), overrideable via `POST /session`
- Add `POST /session` and `GET /session` endpoints to the proxy for runtime session context management
- Apply session context attributes (`prov.session.id`, `prov.parent.session.id`, `prov.task.label`) to every span via `_set_request_attrs`
- Add `PROV_TASK_LABEL` constant to schema.py
- Add 6 tests covering POST/GET endpoints, env-var fallback, span attribution, and empty-value exclusion

## Test plan
- [x] `POST /session` stores context and returns it in response
- [x] `GET /session` returns current context
- [x] Empty values are excluded (no blank attributes on spans)
- [x] `AGENTWEAVE_SESSION_ID` env var is read at module startup
- [x] Session context attributes are applied to spans
- [x] Empty context produces no spurious span attributes
- [x] All 96 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)