### PR TITLE
fix(plugin): use sessionKey in message.processed log (#106)

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -135,7 +135,7 @@ export function createAgentWeaveBridgeService() {
               turn.span.end()
               activeTurns.delete(sessionKey)
               delete process.env.AGENTWEAVE_TRACEPARENT
-              console.log("[agentweave-bridge] ended root span for session:", e.sessionId)
+              console.log("[agentweave-bridge] ended root span for session:", sessionKey)
               break
             }
 


### PR DESCRIPTION
## Summary

- One-line fix: `message.processed` diagnostic event has `sessionKey` but not `sessionId`. The log was reading `e.sessionId` → always `undefined`.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)