### PR TITLE
fix(bridge): session_id attribute + proxy URL injection for sub-agents (closes #130, closes #131)

### DIFF
--- a/plugins/openclaw-agentweave-bridge/openclaw.plugin.json
+++ b/plugins/openclaw-agentweave-bridge/openclaw.plugin.json
@@ -8,7 +8,8 @@
       "otlpEndpoint": { "type": "string" },
       "agentId": { "type": "string", "default": "nix-v1" },
       "project": { "type": "string" },
-      "enabled": { "type": "boolean", "default": true }
+      "enabled": { "type": "boolean", "default": true },
+      "proxyUrl": { "type": "string", "default": "http://192.168.1.70:30400/v1" }
     }
   }
 }

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -14,6 +14,7 @@ export interface BridgeConfig {
   agentId?: string
   project?: string
   enabled?: boolean
+  proxyUrl?: string
 }
 
 const activeTurns = new Map<string, ActiveTurn>()
@@ -77,6 +78,7 @@ export function createAgentWeaveBridgeService() {
         agentId: "nix-v1",
         project: "agentweave",
         enabled: true,
+        proxyUrl: "http://192.168.1.70:30400/v1",
         ...(pluginConfig?.config as Partial<BridgeConfig> ?? {}),
       }
 
@@ -101,6 +103,7 @@ export function createAgentWeaveBridgeService() {
 
               const tracer = trace.getTracer("openclaw-agentweave-bridge")
               const span = tracer.startSpan("openclaw.turn")
+              span.setAttribute("session_id", sessionId)
               span.setAttribute("session.id", sessionId)
               span.setAttribute("prov.session.id", sessionId)
               span.setAttribute("prov.agent.id", config.agentId ?? "nix-v1")
@@ -115,6 +118,7 @@ export function createAgentWeaveBridgeService() {
                 process.env.AGENTWEAVE_TRACEPARENT = carrier["traceparent"]
               }
               process.env.AGENTWEAVE_SESSION_ID = sessionId
+              process.env.ANTHROPIC_BASE_URL = config.proxyUrl ?? "http://192.168.1.70:30400/v1"
 
               activeTurns.set(sessionKey, { span, ctx: spanCtx })
               console.log("[agentweave-bridge] started root span for session:", sessionId)
@@ -135,6 +139,7 @@ export function createAgentWeaveBridgeService() {
               turn.span.end()
               activeTurns.delete(sessionKey)
               delete process.env.AGENTWEAVE_TRACEPARENT
+              delete process.env.ANTHROPIC_BASE_URL
               console.log("[agentweave-bridge] ended root span for session:", sessionKey)
               break
             }


### PR DESCRIPTION
Fixes two related bugs in the OpenClaw bridge plugin:\n\n**#130:** Adds `session_id` attribute to spans so the dashboard's session replay tab can find sessions by ID in Tempo.\n\n**#131:** Injects `ANTHROPIC_BASE_URL` into process.env on message.queued so sub-agents route through the AgentWeave proxy and get proper model/cost/token attribution.