### PR TITLE
fix: write model usage as span attributes for TraceQL dashboard

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -120,7 +120,7 @@ describe("createAgentWeaveBridgeService", () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("error.message", "context limit exceeded")
   })
 
-  it("adds model.usage event to active span with correct field names", () => {
+  it("adds model.usage event and span attributes to active span", () => {
     fire({ type: "message.queued", sessionKey: "sk-4", sessionId: "sess-d", channel: "cli", source: "user", ts: Date.now(), seq: 1 })
     fire({
       type: "model.usage",
@@ -143,6 +143,14 @@ describe("createAgentWeaveBridgeService", () => {
       "model.usage.cache_read_tokens": 200,
       "model.usage.cache_write_tokens": 100,
     }))
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.provider", "anthropic")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.model", "claude-sonnet-4-6")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("cost.usd", 0.015)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.prompt_tokens", 1000)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.completion_tokens", 500)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.cache_read_tokens", 200)
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.llm.cache_write_tokens", 100)
   })
 
   it("ignores model.usage for unknown sessionKey", () => {

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -317,15 +317,34 @@ export function createAgentWeaveBridgeService() {
               const sessionKey = e.sessionKey ?? ""
               const turn = activeTurns.get(sessionKey)
               if (!turn) break
+
+              const provider = e.provider ?? ""
+              const model = e.model ?? ""
+              const costUsd = e.costUsd ?? 0
+              const inputTokens = e.usage?.input ?? 0
+              const outputTokens = e.usage?.output ?? 0
+              const cacheReadTokens = e.usage?.cacheRead ?? 0
+              const cacheWriteTokens = e.usage?.cacheWrite ?? 0
+
+              // Keep event emission for event-level timelines/debugging.
               turn.span.addEvent("model.usage", {
-                "model.provider": e.provider ?? "",
-                "model.name": e.model ?? "",
-                "model.cost_usd": e.costUsd ?? 0,
-                "model.usage.input_tokens": e.usage?.input ?? 0,
-                "model.usage.output_tokens": e.usage?.output ?? 0,
-                "model.usage.cache_read_tokens": e.usage?.cacheRead ?? 0,
-                "model.usage.cache_write_tokens": e.usage?.cacheWrite ?? 0,
+                "model.provider": provider,
+                "model.name": model,
+                "model.cost_usd": costUsd,
+                "model.usage.input_tokens": inputTokens,
+                "model.usage.output_tokens": outputTokens,
+                "model.usage.cache_read_tokens": cacheReadTokens,
+                "model.usage.cache_write_tokens": cacheWriteTokens,
               })
+
+              // Also write span attributes so TraceQL select() can read model/cost/usage.
+              turn.span.setAttribute("prov.llm.provider", provider)
+              turn.span.setAttribute("prov.llm.model", model)
+              turn.span.setAttribute("cost.usd", costUsd)
+              turn.span.setAttribute("prov.llm.prompt_tokens", inputTokens)
+              turn.span.setAttribute("prov.llm.completion_tokens", outputTokens)
+              turn.span.setAttribute("prov.llm.cache_read_tokens", cacheReadTokens)
+              turn.span.setAttribute("prov.llm.cache_write_tokens", cacheWriteTokens)
               break
             }
           }


### PR DESCRIPTION
## Summary
Fixes issue #151 where dashboard showed unknown model / zero cost / zero tokens because usage data was only emitted as span events.

### What changed
- Updated `plugins/openclaw-agentweave-bridge/src/service.ts` `model.usage` handler to continue emitting the `model.usage` event **and** set equivalent span attributes:
  - `prov.llm.model`
  - `prov.llm.provider`
  - `cost.usd`
  - `prov.llm.prompt_tokens`
  - `prov.llm.completion_tokens`
  - `prov.llm.cache_read_tokens`
  - `prov.llm.cache_write_tokens`
- Updated bridge test to verify these attributes are written alongside the event.

### Notes
- Checked `sdk/python/agentweave/proxy.py`: it already writes model/token/cost values as span attributes and does not emit `model.usage` events there, so no proxy code change was required.

## Validation
- `cd sdk/python && python3 -m pytest tests/ -v`
  - Result: **395 passed, 1 warning**