### PR TITLE
fix(pricing): cover OpenAI/Codex gpt-5.x model aliases

### DIFF
--- a/sdk/python/agentweave/pricing.py
+++ b/sdk/python/agentweave/pricing.py
@@ -65,6 +65,11 @@ _DEFAULT_PRICING: dict[str, _PriceEntry] = {
     # ── OpenAI ───────────────────────────────────────────────────────────────
     "gpt-4o":                     (2.50, 10.00),
     "gpt-4o-mini":                (0.15,  0.60),
+
+    # OpenAI/Codex aliases used in AgentWeave/OpenClaw dogfood
+    "gpt-5.3":                    (2.50, 10.00),
+    "gpt-5.3-codex":              (2.50, 10.00),
+    "gpt-5.4":                    (2.50, 10.00),
 }
 
 # Sentinel value returned when model is not in the pricing table.

--- a/sdk/python/tests/test_pricing.py
+++ b/sdk/python/tests/test_pricing.py
@@ -132,6 +132,18 @@ class TestComputeCost:
         cost = compute_cost("openai/gpt-4o-mini", input_tokens=1_000_000, output_tokens=0)
         assert abs(cost - 0.15) < 1e-9
 
+    def test_openai_codex_prefix_model_is_priced(self):
+        from agentweave.pricing import compute_cost
+        cost = compute_cost("openai-codex/gpt-5.4", input_tokens=1_000_000, output_tokens=0)
+        assert abs(cost - 2.50) < 1e-9
+
+    def test_openai_codex_aliases_match_expected_price(self):
+        from agentweave.pricing import compute_cost
+        base = compute_cost("gpt-5.3", input_tokens=1_000_000, output_tokens=1_000_000)
+        codex = compute_cost("gpt-5.3-codex", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert abs(base - 12.50) < 1e-9
+        assert abs(codex - base) < 1e-9
+
 
 class TestPricingEnvOverride:
     """Test AGENTWEAVE_PRICING_OVERRIDE env variable."""


### PR DESCRIPTION
## Summary
- extend OpenAI pricing table coverage for dogfood model IDs that were resolving to unknown cost
- add `gpt-5.3`, `gpt-5.3-codex`, and `gpt-5.4` aliases in `sdk/python/agentweave/pricing.py`
- add pricing tests for `openai-codex/gpt-5.4` and parity between `gpt-5.3` and `gpt-5.3-codex`

## Validation
- `pytest -q sdk/python/tests/test_pricing.py`

Closes #156