### PR TITLE
fix(bridge): inject OPENAI_BASE_URL for openai-codex subagent proxy routing (closes #150)

### DIFF
--- a/plugins/openclaw-agentweave-bridge/openclaw.plugin.json
+++ b/plugins/openclaw-agentweave-bridge/openclaw.plugin.json
@@ -26,7 +26,7 @@
       },
       "proxyUrl": {
         "type": "string",
-        "description": "AgentWeave proxy URL injected as ANTHROPIC_BASE_URL for sub-agents. Falls back to AGENTWEAVE_PROXY_URL env var"
+        "description": "AgentWeave proxy URL injected as ANTHROPIC_BASE_URL, OPENAI_BASE_URL, and OPENAI_API_BASE for sub-agents (with trailing /v1 stripped). Falls back to AGENTWEAVE_PROXY_URL env var"
       }
     }
   }

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -75,6 +75,12 @@ const activeTurns = new Map<string, ActiveTurn>()
 let sdk: NodeSDK | null = null
 let unsubscribe: (() => void) | null = null
 
+
+function normalizeProxyBaseUrl(url?: string): string | undefined {
+  if (!url) return undefined
+  return url.replace(/\/v1\/?$/, "")
+}
+
 function initSdk(config: BridgeConfig): void {
   if (sdk) return
   const exporter = new OTLPTraceExporter({ url: `${config.otlpEndpoint.replace(/\/$/, "")}/v1/traces` })
@@ -245,8 +251,11 @@ export function createAgentWeaveBridgeService() {
               process.env.AGENTWEAVE_SESSION_ID = sessionId
               process.env.AGENTWEAVE_AGENT_ID = agentId
               process.env.AGENTWEAVE_AGENT_TYPE = agentType
-              if (config.proxyUrl) {
-                process.env.ANTHROPIC_BASE_URL = config.proxyUrl
+              const proxyBaseUrl = normalizeProxyBaseUrl(config.proxyUrl)
+              if (proxyBaseUrl) {
+                process.env.ANTHROPIC_BASE_URL = proxyBaseUrl
+                process.env.OPENAI_BASE_URL = proxyBaseUrl
+                process.env.OPENAI_API_BASE = proxyBaseUrl
               }
 
               activeTurns.set(sessionKey, { span, ctx: spanCtx })
@@ -269,6 +278,8 @@ export function createAgentWeaveBridgeService() {
               activeTurns.delete(sessionKey)
               delete process.env.AGENTWEAVE_TRACEPARENT
               delete process.env.ANTHROPIC_BASE_URL
+              delete process.env.OPENAI_BASE_URL
+              delete process.env.OPENAI_API_BASE
               delete process.env.AGENTWEAVE_AGENT_ID
               delete process.env.AGENTWEAVE_AGENT_TYPE
               delete process.env.AGENTWEAVE_PARENT_SESSION_ID
@@ -308,7 +319,7 @@ export function createAgentWeaveBridgeService() {
                   activeTurns.set(sessionKey, { span, ctx: spanCtx })
 
                   // Force the proxy to attribute LLM calls to this sub-agent session
-                  const proxyUrl = config.proxyUrl?.replace(/\/v1\/?$/, "") || "http://192.168.1.70:30400"
+                  const proxyUrl = normalizeProxyBaseUrl(config.proxyUrl) || "http://192.168.1.70:30400"
                   const mainSessionId = mainKey ? (activeTurns.get(mainKey)?.span as any)?._attributes?.["session.id"] || "nix-main" : "nix-main"
                   fetch(`${proxyUrl}/session`, {
                     method: "POST",
@@ -336,7 +347,7 @@ export function createAgentWeaveBridgeService() {
                   activeTurns.delete(sessionKey)
 
                   // Restore proxy to main session (clear force)
-                  const proxyUrl = config.proxyUrl?.replace(/\/v1\/?$/, "") || "http://192.168.1.70:30400"
+                  const proxyUrl = normalizeProxyBaseUrl(config.proxyUrl) || "http://192.168.1.70:30400"
                   fetch(`${proxyUrl}/session`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -414,6 +425,9 @@ export function createAgentWeaveBridgeService() {
         activeTurns.delete(key)
       }
       delete process.env.AGENTWEAVE_TRACEPARENT
+      delete process.env.ANTHROPIC_BASE_URL
+      delete process.env.OPENAI_BASE_URL
+      delete process.env.OPENAI_API_BASE
       if (sdk) { await sdk.shutdown(); sdk = null }
     },
   }


### PR DESCRIPTION
## Summary
- inject OpenAI/Codex proxy env vars for subagent turns in the bridge plugin
- set OPENAI_BASE_URL and OPENAI_API_BASE alongside existing ANTHROPIC_BASE_URL
- normalize configured proxy URL by stripping trailing /v1 before injecting envs and before proxy session calls
- clear OpenAI env vars when turns end / plugin stops to avoid leakage

## Scope
- Fixes Bug 1 from #150 only (Codex/OpenAI subagent calls bypassing proxy)
- Does not address Bug 2 phantom span behavior