### PR TITLE
Fix mobile usability of dashboard time range selector

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
-import { Activity, DollarSign, Zap, RefreshCw, GitBranch, BarChart2, X, PlayCircle } from 'lucide-react'
+import { Activity, DollarSign, Zap, RefreshCw, GitBranch, BarChart2, X, PlayCircle, Route } from 'lucide-react'
 import { Header } from './components/Header'
 import { StatCard } from './components/StatCard'
 import { TimeSeriesChart } from './components/TimeSeriesChart'
@@ -11,35 +11,37 @@ import { AgentHealthBadges } from './components/AgentHealthBadges'
 import { SessionExplorer } from './components/SessionExplorer'
 import { PromptVersionFilter, filterByPromptVersion, filterTempoSpansByPromptVersion } from './components/PromptVersionFilter'
 import { SessionReplay } from './components/SessionReplay'
+import { MuxRouting } from './components/MuxRouting'
 import {
   TimeRange,
   tempoSearchQuery,
-  tempoCostTimeSeriesQuery,
   tempoAgentAttributionQuery,
   tempoSubagentSearchQuery,
+  tempoMuxRoutingQuery,
+  transformMuxRoutingTraces,
   promLLMCallsRateQuery,
   promCallsByModelQuery,
   promP95LatencyByModelQuery,
   promCallsByAgentQuery,
-  transformTempoTraces,
-  transformTempoCostSeries,
-  extractTotalTempoCost,
-  transformAgentAttributionTraces,
-  transformSubagentTraces,
+  buildCostTotal,
   buildCostTimeSeries,
   buildCostByAgent,
+  transformTempoTraces,
+  transformAgentAttributionTraces,
+  transformSubagentTraces,
   extractProjects,
   computeAgentHealthScores,
 } from './lib/queries'
-import { useTempoSearch, useTempoSearchCount, useTempoMetrics, useSessionGraph } from './hooks/useTempo'
+import { useTempoSearch, useSessionGraph } from './hooks/useTempo'
 import { usePromQueryRange, usePromQueryInstant } from './hooks/usePrometheus'
 
-type ActiveTab = 'overview' | 'sessions' | 'replay'
+type ActiveTab = 'overview' | 'sessions' | 'replay' | 'routing'
 
 const REFRESH_INTERVAL_MS = 60_000 // 60s
 
 const TAB_CONFIG: { key: ActiveTab; label: string; icon: React.ElementType }[] = [
   { key: 'overview', label: 'Overview', icon: BarChart2 },
+  { key: 'routing', label: 'Routing', icon: Route },
   { key: 'sessions', label: 'Sessions', icon: GitBranch },
   { key: 'replay', label: 'Replay', icon: PlayCircle },
 ]
@@ -49,7 +51,7 @@ export default function App() {
   const [refreshKey, setRefreshKey] = useState(0)
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
   const rawTab = new URLSearchParams(window.location.search).get('tab')
-  const initialTab: ActiveTab = (rawTab === 'sessions' || rawTab === 'replay' ? rawTab : 'overview')
+  const initialTab: ActiveTab = (rawTab === 'sessions' || rawTab === 'replay' || rawTab === 'routing' ? rawTab : 'overview')
   const [activeTab, setActiveTab] = useState<ActiveTab>(initialTab)
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
   const [selectedProject, setSelectedProject] = useState<string | null>(null)
@@ -93,8 +95,9 @@ export default function App() {
     : traceRows
 
   // ─── Stat Card Data ────────────────────────────────────────────────────
-  const { count: llmCallCount, loading: llmCallLoading, error: llmCallError } =
-    useTempoSearchCount(tempoSearchQuery(selectedProject ?? undefined), timeRange, refreshKey)
+  const llmCallCount = tracesLoading ? null : traceRows.length
+  const llmCallLoading = tracesLoading
+  const llmCallError = tracesError
 
   const tracesWithCache = traceRows.filter((t) => t.cacheHitRate > 0)
   const cacheValue = tracesLoading
@@ -113,17 +116,8 @@ export default function App() {
   const { series: callsSeries, loading: callsSeriesLoading, error: callsSeriesError } =
     usePromQueryRange(promLLMCallsRateQuery(), timeRange, refreshKey, 'prov_llm_model')
 
-  const { result: costMetricResult, loading: costMetricLoading, error: costMetricError } =
-    useTempoMetrics(tempoCostTimeSeriesQuery(selectedProject ?? undefined), timeRange, refreshKey)
-
-  const costValue = extractTotalTempoCost(costMetricResult)
-  const costMetricSeries = transformTempoCostSeries(costMetricResult)
-  const costChartSeries = costMetricSeries.length > 0
-    ? costMetricSeries
-    : buildCostTimeSeries(traceRows, timeRange)
-  const costChartSubtitle = costMetricSeries.length > 0
-    ? 'Cost per time bucket (all spans)'
-    : 'Cost per time bucket (loaded traces)'
+  const costValue = useMemo(() => buildCostTotal(traceRows), [traceRows])
+  const costChartSeries = useMemo(() => buildCostTimeSeries(traceRows, timeRange), [traceRows, timeRange])
 
   // ─── Bar Chart Data ───────────────────────────────────────────────────
   const { bars: callsByModel, loading: callsByModelLoading, error: callsByModelError } =
@@ -149,7 +143,7 @@ export default function App() {
   const { bars: callsByAgent, loading: callsByAgentLoading, error: callsByAgentError } =
     usePromQueryInstant(promCallsByAgentQuery(timeRange), timeRange, refreshKey, 'prov_agent_id')
 
-  const costByAgent = buildCostByAgent(traceRows)
+  const costByAgent = useMemo(() => buildCostByAgent(traceRows), [traceRows])
 
   const agentHealthScores = useMemo(
     () => computeAgentHealthScores(traceRows),
@@ -164,6 +158,11 @@ export default function App() {
   const { traces: rawSubagent, loading: subagentLoading, error: subagentError } =
     useTempoSearch(tempoSubagentSearchQuery(), timeRange, refreshKey)
   const subagentRows = transformSubagentTraces(rawSubagent)
+
+  // ─── Mux Routing data ────────────────────────────────────────────────
+  const { traces: rawRoutingTraces, loading: routingLoading, error: routingError } =
+    useTempoSearch(tempoMuxRoutingQuery(), timeRange, refreshKey)
+  const routingRows = useMemo(() => transformMuxRoutingTraces(rawRoutingTraces), [rawRoutingTraces])
 
   // ─── Session graph data ──────────────────────────────────────────────
   const { nodes: sessionNodes, edges: sessionEdges, rawTraces: sessionRawTraces, loading: sessionLoading, error: sessionError } =
@@ -210,6 +209,15 @@ export default function App() {
       </div>
 
       <main className="max-w-screen-2xl mx-auto px-4 sm:px-6 py-6 space-y-5">
+        {/* Mux Routing tab */}
+        {activeTab === 'routing' && (
+          <MuxRouting
+            rows={routingRows}
+            loading={routingLoading}
+            error={routingError}
+          />
+        )}
+
         {/* Session Explorer tab */}
         {activeTab === 'sessions' && (
           <div className="space-y-4 animate-fade-in">
@@ -256,9 +264,9 @@ export default function App() {
             iconColor="text-signal-lime"
             iconBg="bg-signal-lime/8"
             label="Total Cost"
-            value={costValue !== null ? `$${costValue.toFixed(4)}` : null}
-            loading={costMetricLoading}
-            error={costMetricError}
+            value={!tracesLoading ? `$${costValue.toFixed(4)}` : null}
+            loading={tracesLoading}
+            error={tracesError}
           />
           <StatCard
             icon={Zap}
@@ -293,10 +301,10 @@ export default function App() {
           />
           <TimeSeriesChart
             title="Cost over Time"
-            subtitle={costChartSubtitle}
+            subtitle="Cost per time bucket"
             series={costChartSeries}
-            loading={costMetricLoading && tracesLoading}
-            error={costChartSeries.length === 0 ? (costMetricError ?? tracesError) : null}
+            loading={tracesLoading}
+            error={tracesError}
             type="area"
             valueFormatter={(v) => `$${v.toFixed(4)}`}
           />
@@ -339,7 +347,7 @@ export default function App() {
             subtitle="Estimated total cost per agent"
             data={costByAgent}
             loading={tracesLoading}
-            error={null}
+            error={tracesError}
             valueFormatter={(v) => `$${v.toFixed(4)}`}
           />
         </div>

--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -21,6 +21,9 @@ const TIME_RANGES: { value: TimeRange; label: string }[] = [
   { value: '6h', label: '6h' },
   { value: '24h', label: '24h' },
   { value: '7d', label: '7d' },
+  { value: '30d', label: '30d' },
+  { value: '60d', label: '60d' },
+  { value: '90d', label: '90d' },
 ]
 
 export function Header({ timeRange, onTimeRangeChange, onRefresh, lastUpdated, tempoError, projects, selectedProject, onProjectChange }: HeaderProps) {
@@ -50,9 +53,9 @@ export function Header({ timeRange, onTimeRangeChange, onRefresh, lastUpdated, t
           </div>
 
           {/* Right controls */}
-          <div className="flex items-center gap-3 overflow-x-auto">
+          <div className="flex items-center justify-end gap-2 sm:gap-3 flex-wrap">
             {lastUpdated && (
-              <span className="text-ink-faint text-xs hidden sm:flex items-center gap-1.5">
+              <span className="text-ink-faint text-xs hidden lg:flex items-center gap-1.5">
                 <span className="w-1 h-1 rounded-full bg-signal-lime animate-pulse-subtle" />
                 {formatDistanceToNow(lastUpdated, { addSuffix: true })}
               </span>
@@ -60,11 +63,11 @@ export function Header({ timeRange, onTimeRangeChange, onRefresh, lastUpdated, t
 
             {/* Project filter */}
             {projects && projects.length > 0 && (
-              <div className="relative">
+              <div className="relative flex-shrink-0">
                 <select
                   value={selectedProject ?? ''}
                   onChange={(e) => onProjectChange(e.target.value || null)}
-                  className="pl-2.5 pr-7 py-1.5 text-xs bg-surface border border-edge rounded-lg text-ink-muted hover:border-edge-hover focus:border-accent/40 focus:outline-none transition-colors appearance-none cursor-pointer"
+                  className="min-w-[120px] pl-2.5 pr-7 py-1.5 text-xs bg-surface border border-edge rounded-lg text-ink-muted hover:border-edge-hover focus:border-accent/40 focus:outline-none transition-colors appearance-none cursor-pointer"
                 >
                   <option value="">All projects</option>
                   {projects.map((p) => (
@@ -75,8 +78,23 @@ export function Header({ timeRange, onTimeRangeChange, onRefresh, lastUpdated, t
               </div>
             )}
 
-            {/* Time range selector */}
-            <div className="flex items-center bg-surface border border-edge rounded-lg overflow-hidden">
+            {/* Time range selector (mobile) */}
+            <div className="relative md:hidden flex-shrink-0">
+              <select
+                value={timeRange}
+                onChange={(e) => onTimeRangeChange(e.target.value as TimeRange)}
+                className="min-w-[84px] pl-2.5 pr-7 py-1.5 text-xs bg-surface border border-edge rounded-lg text-ink-muted hover:border-edge-hover focus:border-accent/40 focus:outline-none transition-colors appearance-none cursor-pointer"
+                aria-label="Select time range"
+              >
+                {TIME_RANGES.map((r) => (
+                  <option key={r.value} value={r.value}>{r.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-ink-faint pointer-events-none" />
+            </div>
+
+            {/* Time range selector (desktop/tablet) */}
+            <div className="hidden md:flex items-center bg-surface border border-edge rounded-lg overflow-hidden flex-shrink-0">
               {TIME_RANGES.map((r) => (
                 <button
                   key={r.value}

--- a/dashboard/src/components/MuxRouting.tsx
+++ b/dashboard/src/components/MuxRouting.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useMemo, useEffect } from 'react'
+import { format } from 'date-fns'
+import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
+import { MuxRoutingRow, buildRoutingReasonBreakdown, buildModelRedirectBreakdown } from '../lib/queries'
+import { BarChartPanel } from './BarChart'
+
+interface MuxRoutingProps {
+  rows: MuxRoutingRow[]
+  loading: boolean
+  error?: string | null
+}
+
+type SortKey = 'time' | 'latencyMs' | 'tokensIn'
+type SortDir = 'asc' | 'desc'
+
+function SkeletonRow() {
+  return (
+    <tr className="border-b border-edge">
+      {Array.from({ length: 7 }).map((_, i) => (
+        <td key={i} className="px-3 py-3">
+          <div className="skeleton h-4 rounded w-full" />
+        </td>
+      ))}
+    </tr>
+  )
+}
+
+export function MuxRouting({ rows, loading, error }: MuxRoutingProps) {
+  const PAGE_SIZE = 25
+  const [sortKey, setSortKey] = useState<SortKey>('time')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [page, setPage] = useState(0)
+
+  useEffect(() => { setPage(0) }, [rows, sortKey, sortDir])
+
+  const sorted = useMemo(() => {
+    return [...rows].sort((a, b) => {
+      const av = a[sortKey]
+      const bv = b[sortKey]
+      const cmp = av < bv ? -1 : av > bv ? 1 : 0
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  }, [rows, sortKey, sortDir])
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE))
+  const pageRows = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  const redirectCount = rows.filter(r => r.redirected).length
+  const redirectPct = rows.length > 0 ? ((redirectCount / rows.length) * 100).toFixed(1) : '0'
+
+  const reasonBars = useMemo(() => buildRoutingReasonBreakdown(rows), [rows])
+  const redirectBars = useMemo(() => buildModelRedirectBreakdown(rows), [rows])
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('desc')
+    }
+  }
+
+  function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+    if (!active) return <span className="text-ink-faint ml-1">&#8597;</span>
+    return <span className="text-accent ml-1">{dir === 'asc' ? '\u2191' : '\u2193'}</span>
+  }
+
+  return (
+    <div className="space-y-5 animate-fade-in">
+      {/* Stat summary */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="bg-surface border border-edge rounded-xl p-4">
+          <div className="text-xs text-ink-faint mb-1">Total Routed</div>
+          <div className="text-2xl font-semibold text-ink mono">{loading ? '...' : rows.length}</div>
+        </div>
+        <div className="bg-surface border border-edge rounded-xl p-4">
+          <div className="text-xs text-ink-faint mb-1">Redirected</div>
+          <div className="text-2xl font-semibold mono">
+            <span className={redirectCount > 0 ? 'text-signal-amber' : 'text-ink'}>{loading ? '...' : redirectCount}</span>
+            {!loading && rows.length > 0 && (
+              <span className="text-sm text-ink-faint ml-2">({redirectPct}%)</span>
+            )}
+          </div>
+        </div>
+        <div className="bg-surface border border-edge rounded-xl p-4">
+          <div className="text-xs text-ink-faint mb-1">Kept Original</div>
+          <div className="text-2xl font-semibold text-signal-lime mono">
+            {loading ? '...' : rows.length - redirectCount}
+          </div>
+        </div>
+        <div className="bg-surface border border-edge rounded-xl p-4">
+          <div className="text-xs text-ink-faint mb-1">Unique Reasons</div>
+          <div className="text-2xl font-semibold text-accent mono">
+            {loading ? '...' : reasonBars.length}
+          </div>
+        </div>
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <BarChartPanel
+          title="Routing Reasons"
+          subtitle="How often each routing rule fired"
+          data={reasonBars}
+          loading={loading}
+          error={error ?? null}
+          valueFormatter={v => v.toFixed(0)}
+        />
+        <BarChartPanel
+          title="Model Redirects"
+          subtitle="Requested model vs resolved model"
+          data={redirectBars}
+          loading={loading}
+          error={error ?? null}
+          valueFormatter={v => v.toFixed(0)}
+        />
+      </div>
+
+      {/* Routing decisions table */}
+      <div className="bg-surface border border-edge rounded-xl overflow-hidden">
+        <div className="px-4 py-3 border-b border-edge">
+          <h3 className="text-sm font-medium text-ink">Routing Decisions</h3>
+          <p className="text-xs text-ink-faint mt-0.5">Each row is a request routed through Mux</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-edge bg-void/50">
+                <th
+                  className="text-left px-3 py-2.5 text-ink-faint font-medium cursor-pointer select-none whitespace-nowrap"
+                  onClick={() => handleSort('time')}
+                >
+                  Time <SortIcon active={sortKey === 'time'} dir={sortDir} />
+                </th>
+                <th className="text-left px-3 py-2.5 text-ink-faint font-medium whitespace-nowrap">Prompt</th>
+                <th className="text-left px-3 py-2.5 text-ink-faint font-medium whitespace-nowrap">Routing</th>
+                <th className="text-left px-3 py-2.5 text-ink-faint font-medium whitespace-nowrap">Reason</th>
+                <th className="text-left px-3 py-2.5 text-ink-faint font-medium whitespace-nowrap">Runtime</th>
+                <th
+                  className="text-right px-3 py-2.5 text-ink-faint font-medium cursor-pointer select-none whitespace-nowrap"
+                  onClick={() => handleSort('tokensIn')}
+                >
+                  Tokens <SortIcon active={sortKey === 'tokensIn'} dir={sortDir} />
+                </th>
+                <th
+                  className="text-right px-3 py-2.5 text-ink-faint font-medium cursor-pointer select-none whitespace-nowrap"
+                  onClick={() => handleSort('latencyMs')}
+                >
+                  Latency <SortIcon active={sortKey === 'latencyMs'} dir={sortDir} />
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading && Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)}
+              {!loading && error && (
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-signal-coral text-xs">{error}</td></tr>
+              )}
+              {!loading && !error && pageRows.length === 0 && (
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-ink-faint text-xs">No routing traces found in this time range</td></tr>
+              )}
+              {!loading && !error && pageRows.map((row) => (
+                <tr key={`${row.traceId}-${row.time}`} className="border-b border-edge hover:bg-accent/3 transition-colors">
+                  <td className="px-3 py-2.5 text-ink-muted mono whitespace-nowrap">
+                    {format(new Date(row.time), 'HH:mm:ss')}
+                  </td>
+                  <td className="px-3 py-2.5 text-ink max-w-[300px] truncate" title={row.promptPreview}>
+                    {row.promptPreview || <span className="text-ink-faint italic">no preview</span>}
+                  </td>
+                  <td className="px-3 py-2.5 whitespace-nowrap">
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className={`mono text-xs ${row.redirected ? 'text-ink-muted line-through' : 'text-ink'}`}>
+                        {row.requestedModel}
+                      </span>
+                      {row.redirected && (
+                        <>
+                          <ArrowRight className="w-3 h-3 text-signal-amber" />
+                          <span className="mono text-xs text-signal-amber font-medium">
+                            {row.resolvedModel}
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5">
+                    <span className="inline-block bg-accent/8 text-accent text-[10px] font-medium px-2 py-0.5 rounded-full">
+                      {row.reason.replace('heuristic:', '')}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2.5 text-ink-muted mono">{row.runtime}</td>
+                  <td className="px-3 py-2.5 text-right text-ink-muted mono whitespace-nowrap">
+                    {row.tokensIn > 0 ? `${row.tokensIn.toLocaleString()} / ${row.tokensOut.toLocaleString()}` : '—'}
+                  </td>
+                  <td className="px-3 py-2.5 text-right text-ink-muted mono">
+                    {(row.latencyMs / 1000).toFixed(1)}s
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-2.5 border-t border-edge bg-void/30">
+            <span className="text-xs text-ink-faint mono">
+              {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, sorted.length)} of {sorted.length}
+            </span>
+            <div className="flex gap-1">
+              <button
+                onClick={() => setPage(p => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="p-1 rounded text-ink-faint hover:text-ink disabled:opacity-30 transition-colors"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+                className="p-1 rounded text-ink-faint hover:text-ink disabled:opacity-30 transition-colors"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -1,6 +1,6 @@
 // All query strings and transformers for AgentWeave Dashboard
 
-export type TimeRange = '15m' | '1h' | '3h' | '6h' | '24h' | '7d'
+export type TimeRange = '15m' | '1h' | '3h' | '6h' | '24h' | '7d' | '30d' | '60d' | '90d'
 
 export function getTimeRangeSeconds(range: TimeRange): number {
   const map: Record<TimeRange, number> = {
@@ -10,6 +10,9 @@ export function getTimeRangeSeconds(range: TimeRange): number {
     '6h': 21600,
     '24h': 86400,
     '7d': 604800,
+    '30d': 2592000,
+    '60d': 5184000,
+    '90d': 7776000,
   }
   return map[range]
 }
@@ -28,6 +31,9 @@ export function getStepForRange(range: TimeRange): number {
     '6h': 300,
     '24h': 600,
     '7d': 3600,
+    '30d': 7200,
+    '60d': 14400,
+    '90d': 21600,
   }
   return map[range]
 }
@@ -67,11 +73,42 @@ export function promCallsByAgentQuery(range: TimeRange): string {
   return `sum by (prov_agent_id) (increase(traces_spanmetrics_calls_total{service="${TEMPO_SERVICE}"}[${seconds}s]))`
 }
 
-export function promCostByAgentQuery(range: TimeRange): string {
-  // Uses Prometheus spanmetrics for call counts as a proxy; actual cost bucketed from traces
-  // This gives relative call volume per agent — use alongside cost stat for context
-  const seconds = getTimeRangeSeconds(range)
-  return `sum by (prov_agent_id) (increase(traces_spanmetrics_calls_total{service="${TEMPO_SERVICE}"}[${seconds}s]))`
+// ─── Client-side cost aggregation (from Tempo trace data) ────────────────────
+
+export function buildCostTotal(traces: TraceRow[]): number {
+  return traces.reduce((sum, t) => sum + t.costUsd, 0)
+}
+
+export function buildCostTimeSeries(
+  traces: TraceRow[],
+  timeRange: TimeRange,
+): Array<{ label: string; points: TimeSeriesPoint[] }> {
+  const stepMs = getStepForRange(timeRange) * 1000
+  const buckets = new Map<number, number>()
+  for (const t of traces) {
+    if (t.costUsd <= 0) continue
+    const bucket = Math.floor(t.time / stepMs) * stepMs
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + t.costUsd)
+  }
+  if (!buckets.size) return []
+  const points = Array.from(buckets.entries())
+    .sort((a, b) => a[0] - b[0])
+    .map(([time, value]) => ({ time, value }))
+  return [{ label: 'Cost', points }]
+}
+
+export function buildCostByAgent(
+  traces: TraceRow[],
+): Array<{ label: string; value: number }> {
+  const byAgent = new Map<string, number>()
+  for (const t of traces) {
+    if (t.costUsd <= 0) continue
+    const agent = t.agentId || 'unknown'
+    byAgent.set(agent, (byAgent.get(agent) ?? 0) + t.costUsd)
+  }
+  return Array.from(byAgent.entries())
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value)
 }
 
 // ─── Response transformers ─────────────────────────────────────────────────
@@ -220,30 +257,7 @@ export function transformTempoTraces(traces: TempoSpan[]): TraceRow[] {
   })
 }
 
-export interface TempoMetricResult {
-  series: Array<{
-    labels?: Record<string, string> | Array<{ key: string; value: { stringValue?: string } }>
-    samples: Array<{
-      timestamp_ms?: number
-      timestampMs?: number | string
-      value: string | number
-    }>
-  }>
-}
-
-export function extractLastTempoMetricValue(result: TempoMetricResult | null): number | null {
-  if (!result?.series?.length) return null
-  // sum the last value of each series
-  let total = 0
-  for (const s of result.series) {
-    if (s.samples.length > 0) {
-      total += metricSampleValue(s.samples[s.samples.length - 1]) || 0
-    }
-  }
-  return total
-}
-
-// ─── Tempo Metrics queries ────────────────────────────────────────────────────
+// ─── Tempo Queries ───────────────────────────────────────────────────────────
 
 /** TraceQL search query returning all spans for a specific session. */
 export function tempoSessionQuery(sessionId: string): string {
@@ -350,79 +364,13 @@ export function buildReplayTurns(traces: TempoSpan[], searchedSessionId?: string
     .map((row, i) => ({ ...row, turnNumber: row.turnNumber || i + 1 }))
 }
 
-/** TraceQL metrics query that returns cost.usd summed per time bucket. */
-export function tempoCostTimeSeriesQuery(project?: string): string {
-  const projectFilter = project ? ` && span.prov.project = "${project}"` : ''
-  return (
-    `{ resource.service.name = "${TEMPO_SERVICE}" && name != "llm.unknown"${projectFilter} }` +
-    ` | sum_over_time(span.cost.usd)`
-  )
-}
-
-/**
- * Transform a TempoMetricResult into the series format expected by TimeSeriesChart.
- * Aggregates all series into a single "Cost USD" series (sum across labels).
- */
-function metricSampleTimeMs(sample: { timestamp_ms?: number; timestampMs?: number | string }): number | null {
-  const ts = sample.timestamp_ms ?? (typeof sample.timestampMs === 'string' ? parseInt(sample.timestampMs, 10) : sample.timestampMs)
-  return Number.isFinite(ts) ? (ts as number) : null
-}
-
-function metricSampleValue(sample: { value: string | number }): number {
-  if (typeof sample.value === 'number') return sample.value
-  return parseFloat(sample.value) || 0
-}
-
-export function transformTempoCostSeries(
-  result: TempoMetricResult | null,
-): Array<{ label: string; points: Array<{ time: number; value: number }> }> {
-  if (!result?.series?.length) return []
-
-  // Merge all series into a single time-bucketed map (sum across any label dimensions)
-  const buckets = new Map<number, number>()
-  for (const s of result.series) {
-    for (const sample of s.samples) {
-      const ts = metricSampleTimeMs(sample)
-      const v = metricSampleValue(sample)
-      if (ts === null || v <= 0) continue
-      buckets.set(ts, (buckets.get(ts) ?? 0) + v)
-    }
-  }
-
-  if (!buckets.size) return []
-
-  const points = Array.from(buckets.entries())
-    .sort((a, b) => a[0] - b[0])
-    .map(([time, value]) => ({ time, value }))
-
-  return [{ label: 'Cost USD', points }]
-}
-
-/**
- * Compute total cost across the selected time range from Tempo metrics buckets.
- * Returns null when metrics are unavailable.
- */
-export function extractTotalTempoCost(result: TempoMetricResult | null): number | null {
-  if (!result?.series) return null
-
-  let total = 0
-  for (const s of result.series) {
-    for (const sample of s.samples ?? []) {
-      const v = metricSampleValue(sample)
-      if (v <= 0) continue
-      total += v
-    }
-  }
-
-  return total
-}
 
 // ─── Agent Attribution queries ────────────────────────────────────────────────
 
 /** TraceQL search selecting sub-agent attribution attributes. */
 export function tempoAgentAttributionQuery(): string {
   return (
-    `{ resource.service.name = "${TEMPO_SERVICE}" && name != "llm.unknown" }` +
+    `{ resource.service.name = "${TEMPO_SERVICE}" && span.prov.activity.type = "llm_call" }` +
     ` | select(span.prov.agent.type, span.prov.parent.session.id, span.prov.session.turn,` +
     ` span.session.id, span.cost.usd, span.prov.agent.id)`
   )
@@ -431,7 +379,7 @@ export function tempoAgentAttributionQuery(): string {
 /** TraceQL search for session graph: fetches all spans with session identity attributes. */
 export function tempoSessionGraphQuery(): string {
   return (
-    `{ resource.service.name = "${TEMPO_SERVICE}" && name != "llm.unknown" }` +
+    `{ resource.service.name = "${TEMPO_SERVICE}" && span.prov.activity.type = "llm_call" }` +
     ` | select(span.prov.session.id, span.session.id, span.prov.parent.session.id, span.prov.task.label,` +
     ` span.prov.agent.id, span.prov.agent.type, span.cost.usd, span.prov.llm.model,` +
     ` span.prov.llm.prompt_tokens, span.prov.llm.completion_tokens, span.prov.project)`
@@ -441,7 +389,7 @@ export function tempoSessionGraphQuery(): string {
 /** TraceQL search for sub-agent spans only. */
 export function tempoSubagentSearchQuery(): string {
   return (
-    `{ resource.service.name = "${TEMPO_SERVICE}" && span.prov.agent.type = "subagent" }` +
+    `{ resource.service.name = "${TEMPO_SERVICE}" && span.prov.agent.type = "subagent" && span.prov.activity.type = "llm_call" }` +
     ` | select(span.prov.llm.model, span.cost.usd, span.prov.llm.prompt_tokens,` +
     ` span.prov.llm.completion_tokens, span.prov.parent.session.id, span.session.id,` +
     ` span.prov.agent.id, span.prov.agent.type)`
@@ -570,41 +518,89 @@ export function transformSubagentTraces(traces: TempoSpan[]): SubagentTraceRow[]
   })
 }
 
-// ─── Trace-derived aggregations ──────────────────────────────────────────────
+// ─── Mux Routing queries & types ─────────────────────────────────────────────
 
-/** Aggregate total cost per agent from trace rows. */
-export function buildCostByAgent(
-  traces: TraceRow[]
+export const MUX_SERVICE = 'mux-router'
+
+export function tempoMuxRoutingQuery(): string {
+  return (
+    `{ resource.service.name = "${MUX_SERVICE}" && name = "agent.mux" }` +
+    ` | select(span.prov.llm.prompt_preview, span.prov.route.requested_model,` +
+    ` span.prov.route.resolved_model, span.prov.route.reason,` +
+    ` span.prov.route.runtime, span.prov.route.message_count,` +
+    ` span.prov.llm.prompt_tokens, span.prov.llm.completion_tokens)`
+  )
+}
+
+export interface MuxRoutingRow {
+  traceId: string
+  time: number
+  latencyMs: number
+  promptPreview: string
+  requestedModel: string
+  resolvedModel: string
+  reason: string
+  runtime: string
+  messageCount: number
+  tokensIn: number
+  tokensOut: number
+  redirected: boolean
+}
+
+export function transformMuxRoutingTraces(traces: TempoSpan[]): MuxRoutingRow[] {
+  return traces.map((t) => {
+    const spans = t.spanSets?.[0]?.spans ?? t.spanSet?.spans ?? []
+    const span = spans[0]
+    const attrs = span?.attributes ?? []
+    const requested = getSpanAttr(attrs, 'prov.route.requested_model') || 'unknown'
+    const resolved = getSpanAttr(attrs, 'prov.route.resolved_model') || 'unknown'
+    return {
+      traceId: t.traceID,
+      time: parseInt(t.startTimeUnixNano) / 1e6,
+      latencyMs: span ? span.durationNanos / 1e6 : t.durationMs,
+      promptPreview: getSpanAttr(attrs, 'prov.llm.prompt_preview'),
+      requestedModel: requested,
+      resolvedModel: resolved,
+      reason: getSpanAttr(attrs, 'prov.route.reason'),
+      runtime: getSpanAttr(attrs, 'prov.route.runtime') || 'unknown',
+      messageCount: parseInt(getSpanAttr(attrs, 'prov.route.message_count') || '0') || 0,
+      tokensIn: parseInt(getSpanAttr(attrs, 'prov.llm.prompt_tokens') || '0') || 0,
+      tokensOut: parseInt(getSpanAttr(attrs, 'prov.llm.completion_tokens') || '0') || 0,
+      redirected: requested !== resolved,
+    }
+  }).sort((a, b) => b.time - a.time)
+}
+
+export function buildRoutingReasonBreakdown(
+  rows: MuxRoutingRow[]
 ): Array<{ label: string; value: number }> {
   const map = new Map<string, number>()
-  for (const t of traces) {
-    if (t.costUsd <= 0) continue
-    const key = t.agentId || 'unknown'
-    map.set(key, (map.get(key) ?? 0) + t.costUsd)
+  for (const r of rows) {
+    if (!r.reason) continue
+    map.set(r.reason, (map.get(r.reason) ?? 0) + 1)
   }
   return Array.from(map.entries())
     .map(([label, value]) => ({ label, value }))
     .sort((a, b) => b.value - a.value)
 }
 
-/** Bucket trace costs into a time series for the cost-over-time chart. */
-export function buildCostTimeSeries(
-  traces: TraceRow[],
-  timeRange: TimeRange
-): Array<{ label: string; points: Array<{ time: number; value: number }> }> {
-  if (!traces.length) return []
-  const stepMs = getStepForRange(timeRange) * 1000
-  const buckets = new Map<number, number>()
-  for (const t of traces) {
-    if (t.costUsd <= 0) continue
-    const bucket = Math.floor(t.time / stepMs) * stepMs
-    buckets.set(bucket, (buckets.get(bucket) ?? 0) + t.costUsd)
+export function buildModelRedirectBreakdown(
+  rows: MuxRoutingRow[]
+): Array<{ label: string; value: number }> {
+  const map = new Map<string, number>()
+  for (const r of rows) {
+    const label = r.redirected
+      ? `${r.requestedModel} → ${r.resolvedModel}`
+      : `${r.requestedModel} (kept)`
+    map.set(label, (map.get(label) ?? 0) + 1)
   }
-  const points = Array.from(buckets.entries())
-    .sort((a, b) => a[0] - b[0])
-    .map(([time, value]) => ({ time, value }))
-  return points.length ? [{ label: 'Cost USD', points }] : []
+  return Array.from(map.entries())
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => b.value - a.value)
 }
+
+// ─── Trace-derived aggregations ──────────────────────────────────────────────
+
 
 // ─── Session Graph types & transformers ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- replace the mobile time range segmented buttons with a compact dropdown/select
- keep existing segmented time range selector for md+ breakpoints
- preserve all existing time range options and behavior
- tighten header control wrapping so project filter + time control + refresh remain usable on narrow screens

## Testing
- cd dashboard && npm run build

Fixes #165