### PR TITLE
fix(proxy): replace global _session_context_force with per-key forced context map (issue #149)

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+from collections import OrderedDict
 import json
 import logging
 import os
@@ -299,7 +300,17 @@ _session_context_force: bool = False
 # each sub-agent window stores its override under a unique key so concurrent
 # requests from other channels (e.g. Telegram) are not misattributed.
 # Key: session_key string, Value: dict of forced session context attrs
-_forced_session_contexts: dict[str, dict[str, str]] = {}
+# LRU-bounded: orphaned entries (e.g. from bridge plugin crashes mid sub-agent)
+# are evicted when the map exceeds _MAX_FORCED_CONTEXTS, preventing slow leak.
+_MAX_FORCED_CONTEXTS = 256
+_forced_session_contexts: OrderedDict[str, dict[str, str]] = OrderedDict()
+
+
+def _set_forced_context(session_key: str, ctx: dict[str, str]) -> None:
+    _forced_session_contexts[session_key] = ctx
+    _forced_session_contexts.move_to_end(session_key)
+    while len(_forced_session_contexts) > _MAX_FORCED_CONTEXTS:
+        _forced_session_contexts.popitem(last=False)
 
 @app.post("/session", include_in_schema=True)
 async def set_session_context(body: dict):
@@ -334,7 +345,7 @@ async def set_session_context(body: dict):
     if session_key:
         if force:
             # Store per-key forced context — isolates concurrent request streams
-            _forced_session_contexts[session_key] = ctx
+            _set_forced_context(session_key, ctx)
         else:
             # Clear the per-key forced context when force is disabled
             _forced_session_contexts.pop(session_key, None)

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -98,6 +98,7 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-parent-session-id",
     "x-agentweave-agent-type",
     "x-agentweave-turn-depth",
+    "x-agentweave-session-key",
 }
 
 # ---------------------------------------------------------------------------
@@ -289,8 +290,16 @@ async def health() -> dict:
     return resp
 
 
-# When True, _session_context overrides request headers (used during sub-agent windows)
+# When True, _session_context overrides request headers (used during sub-agent windows).
+# Kept for backward compatibility with callers that don't supply a session_key.
 _session_context_force: bool = False
+
+# Per-session-key forced context map (issue #149).
+# Replaces the single global _session_context_force for concurrent-safe attribution:
+# each sub-agent window stores its override under a unique key so concurrent
+# requests from other channels (e.g. Telegram) are not misattributed.
+# Key: session_key string, Value: dict of forced session context attrs
+_forced_session_contexts: dict[str, dict[str, str]] = {}
 
 @app.post("/session", include_in_schema=True)
 async def set_session_context(body: dict):
@@ -299,9 +308,18 @@ async def set_session_context(body: dict):
     When ``force: true`` is included, the session context takes precedence
     over per-request headers.  This allows the bridge plugin to temporarily
     switch attribution during a sub-agent window.
+
+    When ``session_key`` is also provided, the override is stored per-key in
+    ``_forced_session_contexts`` so concurrent requests on different channels
+    are not misattributed (issue #149).  Requests that carry the matching
+    ``X-AgentWeave-Session-Key`` header will use this override; all other
+    requests continue to see the global ``_session_context``.
+
+    To clear a per-key override, POST with ``force: false`` and the same
+    ``session_key``.
     """
-    global _session_context, _session_context_force
-    _session_context = {k: v for k, v in {
+    global _session_context, _session_context_force, _forced_session_contexts
+    ctx = {k: v for k, v in {
         "prov.session.id": body.get("session_id", ""),
         "prov.parent.session.id": body.get("parent_session_id", ""),
         "prov.task.label": body.get("task_label", ""),
@@ -309,8 +327,28 @@ async def set_session_context(body: dict):
         "prov.agent.id": body.get("agent_id", ""),
         "prov.project": body.get("project", ""),
     }.items() if v}
-    _session_context_force = bool(body.get("force", False))
-    return {"ok": True, "context": _session_context, "force": _session_context_force}
+
+    force = bool(body.get("force", False))
+    session_key = body.get("session_key", "")
+
+    if session_key:
+        if force:
+            # Store per-key forced context — isolates concurrent request streams
+            _forced_session_contexts[session_key] = ctx
+        else:
+            # Clear the per-key forced context when force is disabled
+            _forced_session_contexts.pop(session_key, None)
+        # Update global context so GET /session reflects the latest state;
+        # but do NOT set the global force flag — that would affect all requests.
+        _session_context = ctx
+        _session_context_force = False
+    else:
+        # Legacy path (no session_key): update global context and force flag.
+        # Not concurrent-safe — callers should migrate to session_key.
+        _session_context = ctx
+        _session_context_force = force
+
+    return {"ok": True, "context": ctx, "force": force, "session_key": session_key}
 
 
 @app.get("/session", include_in_schema=True)
@@ -795,14 +833,25 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
             stream_opts["include_usage"] = True
             body_bytes = json.dumps(body).encode("utf-8")
 
-    # When _session_context_force is True (set by POST /session with force:true),
-    # the session context overrides request headers. This is used by the bridge
-    # plugin to temporarily switch attribution during sub-agent windows.
+    # Resolve the active forced session context for this request (issue #149).
+    # Per-key lookup (concurrent-safe): if the request carries X-AgentWeave-Session-Key
+    # and a matching entry exists in _forced_session_contexts, use that entry.
+    # Fall back to the legacy global _session_context_force flag for callers
+    # that haven't migrated to session_key yet.
+    _incoming_session_key = request.headers.get("x-agentweave-session-key", "")
+    _forced_ctx: dict[str, str] | None = (
+        _forced_session_contexts.get(_incoming_session_key)
+        if _incoming_session_key
+        else None
+    )
     _is_subagent_env = os.getenv("AGENTWEAVE_AGENT_TYPE", "").lower() == "subagent"
-    _force = _session_context_force
+    # _force is True when either a per-key override or the legacy global flag is active.
+    _force = bool(_forced_ctx is not None) or _session_context_force
+    # _active_ctx is the context dict to read forced attributes from.
+    _active_ctx: dict[str, str] = _forced_ctx if _forced_ctx is not None else _session_context
 
     agent_id = (
-        (_session_context.get("prov.agent.id") if _force else None)
+        (_active_ctx.get("prov.agent.id") if _force else None)
         or (os.getenv("AGENTWEAVE_AGENT_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-id")
         or os.getenv("AGENTWEAVE_AGENT_ID")
@@ -816,7 +865,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     )
 
     session_id = (
-        (_session_context.get("prov.session.id") if _force else None)
+        (_active_ctx.get("prov.session.id") if _force else None)
         or (os.getenv("AGENTWEAVE_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-session-id")
         or os.getenv("AGENTWEAVE_SESSION_ID")
@@ -855,14 +904,14 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
 
     # Sub-agent attribution headers (issue #15)
     parent_session_id: str | None = (
-        (_session_context.get("prov.parent.session.id") if _force else None)
+        (_active_ctx.get("prov.parent.session.id") if _force else None)
         or (os.getenv("AGENTWEAVE_PARENT_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-parent-session-id")
         or os.getenv("AGENTWEAVE_PARENT_SESSION_ID")
         or None
     )
     agent_type: str | None = (
-        (_session_context.get("prov.agent.type") if _force else None)
+        (_active_ctx.get("prov.agent.type") if _force else None)
         or (os.getenv("AGENTWEAVE_AGENT_TYPE") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-type")
         or os.getenv("AGENTWEAVE_AGENT_TYPE")

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+from collections import OrderedDict
 
 import pytest
 
@@ -1046,7 +1047,7 @@ class TestForcedSessionContextRace:
         """POST /session with force+session_key stores in _forced_session_contexts, not global flag."""
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
-        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {})
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
         monkeypatch.setattr(proxy_module, "_session_context_force", False)
 
         client = TestClient(app)
@@ -1073,7 +1074,7 @@ class TestForcedSessionContextRace:
         """POST /session with force:false + session_key removes the key from the map."""
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
-        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {"key-abc": {"prov.session.id": "s"}})
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict({"key-abc": {"prov.session.id": "s"}}))
 
         client = TestClient(app)
         resp = client.post("/session", json={
@@ -1093,9 +1094,9 @@ class TestForcedSessionContextRace:
         from agentweave.config import AgentWeaveConfig
 
         # Seed a forced context for key "key-subagent"
-        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict({
             "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
-        })
+        }))
         monkeypatch.setattr(proxy_module, "_session_context_force", False)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
@@ -1151,9 +1152,9 @@ class TestForcedSessionContextRace:
         from agentweave.proxy import app
         from agentweave.config import AgentWeaveConfig
 
-        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict({
             "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
-        })
+        }))
         monkeypatch.setattr(proxy_module, "_session_context_force", False)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
@@ -1214,7 +1215,7 @@ class TestForcedSessionContextRace:
         """Backward compat: POST /session with force:true and no session_key sets global flag."""
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
-        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {})
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
         monkeypatch.setattr(proxy_module, "_session_context_force", False)
 
         client = TestClient(app)
@@ -1226,7 +1227,29 @@ class TestForcedSessionContextRace:
         assert resp.status_code == 200
         # Legacy path: global flag should be set
         assert proxy_module._session_context_force is True
-        assert proxy_module._forced_session_contexts == {}
+        assert len(proxy_module._forced_session_contexts) == 0
+
+    def test_forced_contexts_map_is_lru_bounded(self, monkeypatch):
+        """Orphaned entries (bridge plugin crashes mid sub-agent) must not leak.
+
+        _set_forced_context evicts the oldest entry once the map exceeds
+        _MAX_FORCED_CONTEXTS, so an unbounded stream of unique session_keys
+        cannot grow the map past the cap.
+        """
+        cap = proxy_module._MAX_FORCED_CONTEXTS
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
+
+        # Insert cap+50 distinct keys
+        for i in range(cap + 50):
+            proxy_module._set_forced_context(f"key-{i}", {"prov.session.id": f"s-{i}"})
+
+        assert len(proxy_module._forced_session_contexts) == cap
+        # Earliest 50 evicted
+        assert "key-0" not in proxy_module._forced_session_contexts
+        assert "key-49" not in proxy_module._forced_session_contexts
+        # Most-recent cap entries remain
+        assert f"key-{cap + 49}" in proxy_module._forced_session_contexts
+        assert f"key-50" in proxy_module._forced_session_contexts
 
 
 class TestProjectTracking:

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1039,6 +1039,196 @@ class TestSessionEndpoint:
         assert "prov.task.label" not in span.attrs
 
 
+class TestForcedSessionContextRace:
+    """Per-key forced session context must not bleed across concurrent channels (issue #149)."""
+
+    def test_session_key_stores_in_forced_map(self, monkeypatch):
+        """POST /session with force+session_key stores in _forced_session_contexts, not global flag."""
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {})
+        monkeypatch.setattr(proxy_module, "_session_context_force", False)
+
+        client = TestClient(app)
+        resp = client.post("/session", json={
+            "session_id": "subagent-sess-001",
+            "parent_session_id": "parent-001",
+            "force": True,
+            "session_key": "key-abc",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["force"] is True
+        assert data["session_key"] == "key-abc"
+        # Per-key map must be populated
+        assert proxy_module._forced_session_contexts.get("key-abc") == {
+            "prov.session.id": "subagent-sess-001",
+            "prov.parent.session.id": "parent-001",
+        }
+        # Global force flag must NOT be set — that's the whole fix
+        assert proxy_module._session_context_force is False
+
+    def test_session_key_clear_removes_from_map(self, monkeypatch):
+        """POST /session with force:false + session_key removes the key from the map."""
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {"key-abc": {"prov.session.id": "s"}})
+
+        client = TestClient(app)
+        resp = client.post("/session", json={
+            "session_id": "s",
+            "force": False,
+            "session_key": "key-abc",
+        })
+        assert resp.status_code == 200
+        assert "key-abc" not in proxy_module._forced_session_contexts
+
+    def test_unkeyed_request_not_affected_by_forced_key(self, monkeypatch):
+        """A request without X-AgentWeave-Session-Key must NOT use the forced context."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        from agentweave.config import AgentWeaveConfig
+
+        # Seed a forced context for key "key-subagent"
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {
+            "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
+        })
+        monkeypatch.setattr(proxy_module, "_session_context_force", False)
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+
+        captured: list[dict] = []
+        original_set_request_attrs = proxy_module._set_request_attrs
+
+        def _capturing(span, **kwargs):
+            captured.append({
+                "session_id": kwargs.get("session_id"),
+                "agent_id": kwargs.get("agent_id"),
+            })
+            return original_set_request_attrs(span, **kwargs)
+
+        fake_data = {
+            "id": "msg1", "type": "message", "role": "assistant", "content": [],
+            "model": "claude-3-haiku-20240307", "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        fake_resp = MagicMock(spec=httpx.Response)
+        fake_resp.status_code = 200
+        fake_resp.headers = {}
+        fake_resp.json.return_value = fake_data
+
+        client_instance = AsyncMock()
+        client_instance.request = AsyncMock(return_value=fake_resp)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client_instance)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm), \
+             patch.object(proxy_module, "_set_request_attrs", side_effect=_capturing):
+            client = TestClient(app)
+            # No X-AgentWeave-Session-Key header → must NOT use forced context
+            client.post(
+                "/v1/messages",
+                json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
+                      "messages": [{"role": "user", "content": "hi"}]},
+                headers={"x-api-key": "sk-ant-test", "x-agentweave-agent-id": "telegram-agent"},
+            )
+
+        assert len(captured) >= 1
+        # Must use the per-request header, NOT the forced-agent from the forced context
+        assert captured[0]["agent_id"] == "telegram-agent", (
+            f"Unkeyed request picked up forced agent_id: {captured[0]['agent_id']!r}"
+        )
+
+    def test_keyed_request_uses_forced_context(self, monkeypatch):
+        """A request WITH X-AgentWeave-Session-Key uses the matching forced context."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        from agentweave.config import AgentWeaveConfig
+
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {
+            "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
+        })
+        monkeypatch.setattr(proxy_module, "_session_context_force", False)
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+
+        captured: list[dict] = []
+        original_set_request_attrs = proxy_module._set_request_attrs
+
+        def _capturing(span, **kwargs):
+            captured.append({
+                "session_id": kwargs.get("session_id"),
+                "agent_id": kwargs.get("agent_id"),
+            })
+            return original_set_request_attrs(span, **kwargs)
+
+        fake_data = {
+            "id": "msg2", "type": "message", "role": "assistant", "content": [],
+            "model": "claude-3-haiku-20240307", "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        fake_resp = MagicMock(spec=httpx.Response)
+        fake_resp.status_code = 200
+        fake_resp.headers = {}
+        fake_resp.json.return_value = fake_data
+
+        client_instance = AsyncMock()
+        client_instance.request = AsyncMock(return_value=fake_resp)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client_instance)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm), \
+             patch.object(proxy_module, "_set_request_attrs", side_effect=_capturing):
+            client = TestClient(app)
+            # Matching X-AgentWeave-Session-Key → must use the forced context
+            client.post(
+                "/v1/messages",
+                json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
+                      "messages": [{"role": "user", "content": "hi"}]},
+                headers={
+                    "x-api-key": "sk-ant-test",
+                    "x-agentweave-session-key": "key-subagent",
+                },
+            )
+
+        assert len(captured) >= 1
+        assert captured[0]["agent_id"] == "forced-agent", (
+            f"Keyed request should use forced agent_id, got: {captured[0]['agent_id']!r}"
+        )
+        assert captured[0]["session_id"] == "forced-sess", (
+            f"Keyed request should use forced session_id, got: {captured[0]['session_id']!r}"
+        )
+
+    def test_session_key_header_stripped_from_forwarding(self):
+        """x-agentweave-session-key must not be forwarded upstream."""
+        assert "x-agentweave-session-key" in _SKIP_HEADERS_ALWAYS
+
+    def test_legacy_force_without_key_still_works(self, monkeypatch):
+        """Backward compat: POST /session with force:true and no session_key sets global flag."""
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", {})
+        monkeypatch.setattr(proxy_module, "_session_context_force", False)
+
+        client = TestClient(app)
+        resp = client.post("/session", json={
+            "session_id": "legacy-sess",
+            "force": True,
+            # no session_key
+        })
+        assert resp.status_code == 200
+        # Legacy path: global flag should be set
+        assert proxy_module._session_context_force is True
+        assert proxy_module._forced_session_contexts == {}
+
+
 class TestProjectTracking:
     """Verify prov.project is propagated via env var, POST /session, and header (issue #101)."""
 


### PR DESCRIPTION
## Summary

- Replaces the single global `_session_context_force: bool` with `_forced_session_contexts: dict[str, dict[str, str]]` keyed by `session_key`
- `POST /session` with `force: true` + `session_key` stores the override in the per-key map; the global force flag is **not** set, so concurrent requests from other channels are unaffected
- The proxy request handler reads `X-AgentWeave-Session-Key` from incoming requests and looks up the matching forced context; unkeyed requests see neither the forced context nor its session/agent attribution
- `X-AgentWeave-Session-Key` is added to `_SKIP_HEADERS_ALWAYS` so it is never forwarded upstream
- Legacy path (no `session_key`) preserved for backward compatibility — global `_session_context_force` still works as before

## Test plan

- [ ] `test_session_key_stores_in_forced_map` — POST with force+key stores in map, does NOT set global flag
- [ ] `test_session_key_clear_removes_from_map` — POST with force:false+key removes the entry
- [ ] `test_unkeyed_request_not_affected_by_forced_key` — request without session-key header ignores the forced context, uses its own request headers
- [ ] `test_keyed_request_uses_forced_context` — request with matching session-key header picks up the forced agent_id/session_id
- [ ] `test_session_key_header_stripped_from_forwarding` — header is in `_SKIP_HEADERS_ALWAYS`
- [ ] `test_legacy_force_without_key_still_works` — no session_key → global flag set as before

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)