### PR TITLE
fix(#170): MiniMax-M2.7/M2.5-highspeed pricing for nix-v1 cost tracking

### DIFF
--- a/sdk/python/agentweave/pricing.py
+++ b/sdk/python/agentweave/pricing.py
@@ -70,6 +70,13 @@ _DEFAULT_PRICING: dict[str, _PriceEntry] = {
     "gpt-5.3":                    (2.50, 10.00),
     "gpt-5.3-codex":              (2.50, 10.00),
     "gpt-5.4":                    (2.50, 10.00),
+
+    # ── MiniMax (input, output, cache_read, cache_write) ─────────────────────
+    # Official pay-as-you-go prices: https://platform.minimax.io/docs/guides/pricing-paygo
+    # Model names match the `prov.llm.model` attribute emitted by the
+    # OpenClaw/nix-v1 bridge, which uses MiniMax's OpenAI-compatible endpoint.
+    "minimax-m2.7-highspeed":     (0.60, 2.40, 0.06, 0.375),
+    "minimax-m2.5-highspeed":     (0.60, 2.40, 0.03, 0.375),
 }
 
 # Sentinel value returned when model is not in the pricing table.

--- a/sdk/python/tests/test_pricing.py
+++ b/sdk/python/tests/test_pricing.py
@@ -144,6 +144,55 @@ class TestComputeCost:
         assert abs(base - 12.50) < 1e-9
         assert abs(codex - base) < 1e-9
 
+    def test_minimax_m27_highspeed_pricing(self):
+        """MiniMax-M2.7-highspeed: $0.60 input / $2.40 output per 1M tokens."""
+        from agentweave.pricing import compute_cost
+        # Model name as emitted by the nix-v1 bridge — partial-match path.
+        cost = compute_cost("MiniMax-M2.7-highspeed", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert abs(cost - 3.00) < 1e-9
+
+    def test_minimax_m25_highspeed_pricing(self):
+        """MiniMax-M2.5-highspeed: $0.60 input / $2.40 output per 1M tokens."""
+        from agentweave.pricing import compute_cost
+        cost = compute_cost("MiniMax-M2.5-highspeed", input_tokens=1_000_000, output_tokens=1_000_000)
+        assert abs(cost - 3.00) < 1e-9
+
+    def test_minimax_m27_cache_pricing(self):
+        """Cache read ($0.06/M) and cache write ($0.375/M) for M2.7-highspeed."""
+        from agentweave.pricing import compute_cost
+        # 1M cache_read only
+        cost_read = compute_cost(
+            "MiniMax-M2.7-highspeed",
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cache_read_tokens=1_000_000,
+        )
+        assert abs(cost_read - 0.06) < 1e-9
+        # 1M cache_write only
+        cost_write = compute_cost(
+            "MiniMax-M2.7-highspeed",
+            input_tokens=1_000_000,
+            output_tokens=0,
+            cache_write_tokens=1_000_000,
+        )
+        assert abs(cost_write - 0.375) < 1e-9
+
+    def test_minimax_m25_vs_m27_cache_read_differs(self):
+        """M2.7 cache read ($0.06/M) is 2x M2.5 ($0.03/M) per official docs."""
+        from agentweave.pricing import compute_cost
+        c_m25 = compute_cost(
+            "MiniMax-M2.5-highspeed",
+            input_tokens=1_000_000, output_tokens=0,
+            cache_read_tokens=1_000_000,
+        )
+        c_m27 = compute_cost(
+            "MiniMax-M2.7-highspeed",
+            input_tokens=1_000_000, output_tokens=0,
+            cache_read_tokens=1_000_000,
+        )
+        assert abs(c_m25 - 0.03) < 1e-9
+        assert abs(c_m27 - 0.06) < 1e-9
+
 
 class TestPricingEnvOverride:
     """Test AGENTWEAVE_PRICING_OVERRIDE env variable."""


### PR DESCRIPTION
## Summary
- Adds `minimax-m2.7-highspeed` and `minimax-m2.5-highspeed` to `_DEFAULT_PRICING` so MiniMax calls from the nix-v1 OpenClaw agent produce a real `cost.usd` instead of `-1.0`.
- Rates pulled from MiniMax's official pay-as-you-go page; M2.7 and M2.5 differ only in cache-read ($0.06/M vs $0.03/M).
- Tests cover base pricing, cache-aware path, and the cache-read differential.

Closes #170

## Test plan
- [x] `pytest sdk/python/tests/test_pricing.py` — 38 passed locally (4 new tests).
- [ ] After merge + proxy redeploy, query Tempo for recent `MiniMax-*-highspeed` spans and confirm `cost.usd > 0`.
- [ ] Dashboard Total Cost card picks up MiniMax contributions over a multi-day window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)