### PR TITLE
fix(#172): bridge pricing fallback + dashboard filter for agent_turn spans

### DIFF
--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -43,10 +43,17 @@ export function getStepForRange(range: TimeRange): number {
 export const TEMPO_SERVICE = 'agentweave-proxy'
 
 export function tempoSearchQuery(project?: string): string {
-  // select() fetches span attributes; used for both trace table and stat card aggregation
+  // select() fetches span attributes; used for both trace table and stat card aggregation.
+  //
+  // Activity filter matches both:
+  //   - `llm_call` spans from the Python proxy (direct Anthropic/OpenAI/Google paths)
+  //   - `agent_turn` spans from openclaw-agentweave-bridge (which carry prov.llm.*
+  //     after the bridge's model.usage handler writes them)
+  // Without the agent_turn branch, MiniMax and other bridge-routed calls never
+  // appear in the Total Cost / LLM Calls StatCards.
   const projectFilter = project ? ` && span.prov.project = "${project}"` : ''
   return (
-    `{ resource.service.name = "${TEMPO_SERVICE}" && span.prov.activity.type = "llm_call"${projectFilter} }` +
+    `{ resource.service.name = "${TEMPO_SERVICE}" && (span.prov.activity.type = "llm_call" || (span.prov.activity.type = "agent_turn" && span.prov.llm.model != "")) ${projectFilter} }` +
     ` | select(span.prov.llm.model, span.cost.usd, span.prov.llm.prompt_tokens,` +
     ` span.prov.llm.completion_tokens, span.cache.hit_rate, span.session.id, span.prov.agent.id, span.prov.project,` +
     ` span.prov.security.pii_detected, span.prov.security.pii_kinds)`

--- a/plugins/openclaw-agentweave-bridge/src/pricing.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/pricing.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { computeCost, resolveCost } from "./pricing.js"
+
+describe("computeCost", () => {
+  it("returns undefined for unknown models", () => {
+    expect(computeCost("never-heard-of-this-model", { inputTokens: 100, outputTokens: 50 })).toBeUndefined()
+  })
+
+  it("prices claude-sonnet-4-6 exactly ($3/M in, $15/M out)", () => {
+    const cost = computeCost("claude-sonnet-4-6", { inputTokens: 1_000_000, outputTokens: 0 })
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+
+  it("prices MiniMax-M2.7-highspeed per official rates", () => {
+    // $0.60/M in, $2.40/M out
+    const cost = computeCost("MiniMax-M2.7-highspeed", { inputTokens: 1_000_000, outputTokens: 1_000_000 })
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+
+  it("handles cache-aware pricing for MiniMax-M2.7 ($0.06/M cache_read)", () => {
+    const cost = computeCost("MiniMax-M2.7-highspeed", {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 1_000_000,
+    })
+    expect(cost).toBeCloseTo(0.06, 9)
+  })
+
+  it("M2.5 cache_read ($0.03/M) is half of M2.7 ($0.06/M)", () => {
+    const m25 = computeCost("MiniMax-M2.5-highspeed", {
+      inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 1_000_000,
+    })
+    const m27 = computeCost("MiniMax-M2.7-highspeed", {
+      inputTokens: 1_000_000, outputTokens: 0, cacheReadTokens: 1_000_000,
+    })
+    expect(m25).toBeCloseTo(0.03, 9)
+    expect(m27).toBeCloseTo(0.06, 9)
+  })
+
+  it("case-insensitive + provider-prefix-stripping", () => {
+    const a = computeCost("anthropic/claude-haiku-4-5", { inputTokens: 1_000_000, outputTokens: 0 })
+    const b = computeCost("Claude-Haiku-4-5", { inputTokens: 1_000_000, outputTokens: 0 })
+    expect(a).toBeCloseTo(0.80, 9)
+    expect(b).toBeCloseTo(0.80, 9)
+  })
+
+  it("partial-matches versioned models (claude-sonnet-4-6-20250101 → claude-sonnet-4-6)", () => {
+    const cost = computeCost("claude-sonnet-4-6-20250101", { inputTokens: 1_000_000, outputTokens: 0 })
+    expect(cost).toBeCloseTo(3.0, 9)
+  })
+})
+
+describe("resolveCost", () => {
+  it("passes through a positive upstream cost unchanged", () => {
+    const out = resolveCost(0.042, "MiniMax-M2.7-highspeed", { inputTokens: 100, outputTokens: 50 })
+    expect(out).toBe(0.042)
+  })
+
+  it("falls back to local table when upstream is 0", () => {
+    const out = resolveCost(0, "MiniMax-M2.7-highspeed", {
+      inputTokens: 1_000_000, outputTokens: 1_000_000,
+    })
+    expect(out).toBeCloseTo(3.0, 9)
+  })
+
+  it("falls back when upstream is negative (sentinel) or NaN", () => {
+    expect(resolveCost(-1, "claude-sonnet-4-6", { inputTokens: 1_000_000, outputTokens: 0 })).toBeCloseTo(3.0, 9)
+    expect(resolveCost(NaN, "claude-sonnet-4-6", { inputTokens: 1_000_000, outputTokens: 0 })).toBeCloseTo(3.0, 9)
+  })
+
+  it("returns 0 when upstream is 0 AND model is unknown (no worse than status quo)", () => {
+    const out = resolveCost(0, "exotic-model", { inputTokens: 1000, outputTokens: 500 })
+    expect(out).toBe(0)
+  })
+})

--- a/plugins/openclaw-agentweave-bridge/src/pricing.ts
+++ b/plugins/openclaw-agentweave-bridge/src/pricing.ts
@@ -1,0 +1,97 @@
+/**
+ * LLM pricing fallback for the openclaw-agentweave-bridge plugin.
+ *
+ * OpenClaw emits a `model.usage` event with `costUsd`; for models it doesn't
+ * know, `costUsd` is 0. This module fills that gap so spans written to Tempo
+ * carry a real `cost.usd` value.
+ *
+ * Entries MUST stay in sync with `sdk/python/agentweave/pricing.py`. Prices
+ * are USD per 1 million tokens.
+ */
+
+type PriceEntry =
+  | readonly [input: number, output: number]
+  | readonly [input: number, output: number, cacheRead: number, cacheWrite: number]
+
+const PRICING: Record<string, PriceEntry> = {
+  // ── Anthropic ──────────────────────────────────────────────────────────────
+  "claude-opus-4":              [15.00, 75.00, 1.50, 18.75],
+  "claude-opus-4-5":            [15.00, 75.00, 1.50, 18.75],
+  "claude-3-opus":              [15.00, 75.00, 1.50, 18.75],
+  "claude-sonnet-4-6":          [ 3.00, 15.00, 0.30,  3.75],
+  "claude-sonnet-4-5":          [ 3.00, 15.00, 0.30,  3.75],
+  "claude-3-5-sonnet":          [ 3.00, 15.00, 0.30,  3.75],
+  "claude-3-haiku":             [ 0.25,  1.25, 0.03,  0.30],
+  "claude-haiku-4-5":           [ 0.80,  4.00, 0.08,  1.00],
+  "claude-haiku-3-5":           [ 0.80,  4.00, 0.08,  1.00],
+  "claude-3-5-haiku":           [ 0.80,  4.00, 0.08,  1.00],
+  // ── OpenAI / Codex aliases ────────────────────────────────────────────────
+  "gpt-4o":                     [ 2.50, 10.00],
+  "gpt-4o-mini":                [ 0.15,  0.60],
+  "gpt-5.3":                    [ 2.50, 10.00],
+  "gpt-5.3-codex":              [ 2.50, 10.00],
+  "gpt-5.4":                    [ 2.50, 10.00],
+  // ── MiniMax (official pay-as-you-go, highspeed tier) ──────────────────────
+  "minimax-m2.7-highspeed":     [ 0.60,  2.40, 0.06, 0.375],
+  "minimax-m2.5-highspeed":     [ 0.60,  2.40, 0.03, 0.375],
+}
+
+function normalize(model: string): string {
+  const m = model.toLowerCase().trim()
+  return m.includes("/") ? m.slice(m.indexOf("/") + 1) : m
+}
+
+function findPricing(model: string): PriceEntry | undefined {
+  const n = normalize(model)
+  if (n in PRICING) return PRICING[n]
+  for (const [key, prices] of Object.entries(PRICING)) {
+    if (key.includes(n) || n.includes(key)) return prices
+  }
+  return undefined
+}
+
+export interface TokenUsage {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens?: number
+  cacheWriteTokens?: number
+}
+
+/**
+ * Compute USD cost from tokens. Returns `undefined` when the model is not in
+ * the table, so callers can distinguish "unknown" from "free".
+ */
+export function computeCost(model: string, u: TokenUsage): number | undefined {
+  const prices = findPricing(model)
+  if (!prices) return undefined
+
+  const [inputPrice, outputPrice] = prices
+  const cacheReadPrice = prices.length === 4 ? prices[2] : 0
+  const cacheWritePrice = prices.length === 4 ? prices[3] : 0
+
+  const cacheRead = u.cacheReadTokens ?? 0
+  const cacheWrite = u.cacheWriteTokens ?? 0
+  const uncachedInput = Math.max(0, u.inputTokens - cacheRead - cacheWrite)
+
+  return (
+    (uncachedInput * inputPrice) / 1_000_000 +
+    (u.outputTokens * outputPrice) / 1_000_000 +
+    (cacheRead * cacheReadPrice) / 1_000_000 +
+    (cacheWrite * cacheWritePrice) / 1_000_000
+  )
+}
+
+/**
+ * If `upstreamCost` looks unreliable (0, negative, or NaN), fall back to the
+ * local table. Callers who DO know the cost pass a positive value and get it
+ * back unchanged.
+ */
+export function resolveCost(
+  upstreamCost: number,
+  model: string,
+  usage: TokenUsage,
+): number {
+  if (Number.isFinite(upstreamCost) && upstreamCost > 0) return upstreamCost
+  const fallback = computeCost(model, usage)
+  return fallback ?? 0
+}

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -3,6 +3,7 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto"
 import { NodeSDK } from "@opentelemetry/sdk-node"
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { resolveCost } from "./pricing.js"
 
 interface ActiveTurn {
   span: Span
@@ -382,11 +383,20 @@ export function createAgentWeaveBridgeService() {
 
               const provider = e.provider ?? ""
               const model = e.model ?? ""
-              const costUsd = e.costUsd ?? 0
               const inputTokens = e.usage?.input ?? 0
               const outputTokens = e.usage?.output ?? 0
               const cacheReadTokens = e.usage?.cacheRead ?? 0
               const cacheWriteTokens = e.usage?.cacheWrite ?? 0
+
+              // OpenClaw may not know pricing for every model (e.g. MiniMax) and
+              // reports costUsd=0 in that case. Fall back to a local pricing
+              // table so the span carries a real cost rather than silently 0.
+              const costUsd = resolveCost(e.costUsd ?? 0, model, {
+                inputTokens,
+                outputTokens,
+                cacheReadTokens,
+                cacheWriteTokens,
+              })
 
               // Keep event emission for event-level timelines/debugging.
               turn.span.addEvent("model.usage", {


### PR DESCRIPTION
## Summary
- Adds a TS pricing table in `plugins/openclaw-agentweave-bridge/src/pricing.ts` mirroring `sdk/python/agentweave/pricing.py`, with a `resolveCost()` that falls back to the local table when OpenClaw returns `costUsd=0` (e.g. MiniMax).
- Widens `dashboard/src/lib/queries.ts::tempoSearchQuery` to include `agent_turn` spans that carry `prov.llm.model`, so bridge-routed calls show up in the LLM Calls and Total Cost StatCards.

Closes #172

## Test plan
- [x] `npm test` in the plugin → 19 passed (11 new pricing tests + 8 existing).
- [x] `tsc --noEmit` in dashboard → clean (pre-existing unrelated error in plugin `index.ts` confirmed on main, not introduced here).
- [x] Widened Tempo filter verified live against the NAS Tempo, matches both `llm_call` (claude-opus-4-7) and `agent_turn` (MiniMax) traces.
- [ ] After merge + bridge update + dashboard redeploy: confirm a new MiniMax span emits `cost.usd > 0` and the Total Cost card reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)