### PR TITLE
fix: key_injection fallback + OTel links + session_id propagation

### DIFF
--- a/docs/superpowers/specs/2026-04-26-session-id-propagation-design.md
+++ b/docs/superpowers/specs/2026-04-26-session-id-propagation-design.md
@@ -1,0 +1,140 @@
+# Session-ID propagation for auto-instrumented spans
+
+**Date:** 2026-04-26
+**Tracking issues:** [arniesaha/nexus#29](https://github.com/arniesaha/nexus/issues/29)
+**Phase 1 scope:** Python SDK
+**Phase 2 scope (deferred):** JS SDK
+
+## Problem
+
+A lakehouse audit found that ~40% of rows in `lakehouse.spans` have a NULL or empty `session_id`. Without a consistent `session_id`, spans cannot be correlated to `agent_events`, breaking session replay and lineage analysis.
+
+The root cause is in **agentweave**, not the lakehouse pipeline:
+
+- `@trace_agent(session_id=...)` stamps `session.id` and `prov.session.id` on agent spans.
+- The proxy server reads `AGENTWEAVE_SESSION_ID` and stamps every span it emits.
+- **`auto_instrument()` LLM wrappers (Anthropic / OpenAI / Google) and `@trace_tool` never read any session context.** Every span produced by these paths goes out without `session.id`.
+- `@trace_tool` similarly has no awareness of the active session.
+
+So whenever a user sets `auto_instrument()` and makes an LLM or tool call outside a `@trace_agent`-decorated body, the resulting span lacks a session_id.
+
+## Goals
+
+1. Auto-instrumented LLM spans carry the correct `session.id` and `prov.session.id` whenever any session context is active.
+2. `@trace_tool` spans inherit the active session.
+3. No regression for code that explicitly passes `session_id=` to `@trace_agent`.
+4. No exceptions ever raised from instrumentation. Failure mode is "span without session_id" — never a thrown error.
+
+## Non-goals
+
+- Propagating other identity fields (`user_id`, `agent_id`) — the issue is session_id only.
+- Backfilling existing NULL rows in `lakehouse.spans` — forward fix only.
+- Changes to OTel Baggage / W3C trace context — out of scope.
+- Changes to proxy-server span stamping — proxy already handles this correctly on its side.
+
+## Design
+
+### Source of truth
+
+A new module `agentweave.context` exposes:
+
+```python
+_session_id_var: ContextVar[Optional[str]] = ContextVar("agentweave_session_id", default=None)
+
+def current_session_id() -> Optional[str]:
+    """ContextVar > AGENTWEAVE_SESSION_ID env var > None."""
+
+def set_session_id(sid: Optional[str]) -> Token:
+    """Set the ContextVar. Returns a token for reset()."""
+
+@contextmanager
+def session_scope(sid: Optional[str]) -> Iterator[None]:
+    """Context manager that sets and resets the ContextVar."""
+```
+
+`current_session_id()` is the single function every reader site calls.
+
+### Precedence
+
+When stamping a span, the resolved session_id is the first non-None of:
+
+1. **Explicit kwarg** passed to `@trace_agent(session_id=...)`.
+2. **ContextVar** value (set by an outer `session_scope` or `@trace_agent`).
+3. **`AGENTWEAVE_SESSION_ID` env var** (legacy / bare-script fallback).
+4. None — span is emitted without `session.id`.
+
+### Writers (set the ContextVar)
+
+- `@trace_agent` — when `session_id=` kwarg is non-None, wrap the function body in `session_scope(session_id)` so nested LLM and tool spans inherit it.
+- Public API — re-export `session_scope` from the top-level `agentweave` package so user code can set it manually.
+
+### Readers (stamp `session.id` + `prov.session.id`)
+
+- `instrument.py:_make_llm_wrapper` — reads `current_session_id()` and stamps both attributes.
+- `decorators.py:_make_tool_wrapper` — same.
+- `decorators.py:_make_agent_wrapper` — already stamps when `session_id=` kwarg present; additionally fall back to `current_session_id()` when kwarg is None, so `session_scope("X")` followed by an undecorated `@trace_agent` still gets stamped.
+
+### Failure mode
+
+When `current_session_id()` returns `None` at a reader site:
+
+- Span is emitted without the attribute (current behavior; no regression).
+- A module-level logger emits **one** warning per process when `AGENTWEAVE_DEBUG=1`. The "once" is enforced by a module-level boolean. Message:
+  ```
+  agentweave: span emitted without session_id (set AGENTWEAVE_SESSION_ID, use @trace_agent(session_id=...), or wrap in session_scope())
+  ```
+- No exceptions. Instrumentation must never break the user's request path.
+
+## Phase 2 — JS SDK (deferred)
+
+Mirror the Python design in `sdk-js/src/`:
+
+- `context.ts` — `AsyncLocalStorage<string | undefined>` (Node only; browser support not required).
+- `currentSessionId()` — ALS → `process.env.AGENTWEAVE_SESSION_ID` → `undefined`.
+- Writers: `traceAgent` wraps body via ALS `.run`; export `sessionScope`.
+- Readers: `instrument.ts:186-195` LLM wrappers and `traceTool` stamp the same attributes.
+- Same precedence and same debug-gated single warning.
+- Mirror test suite (vitest).
+
+**Trigger to start Phase 2:** post-Phase-1 lakehouse audit shows JS-originated spans still leaking. Tracked as a separate issue on `arniesaha/agentweave` referencing this spec.
+
+## Test plan
+
+New file `sdk/python/tests/test_session_propagation.py` with these cases:
+
+1. `test_auto_instrument_stamps_session_id_from_contextvar`
+2. `test_auto_instrument_stamps_session_id_from_env_var`
+3. `test_explicit_kwarg_wins_over_contextvar`
+4. `test_contextvar_wins_over_env_var`
+5. `test_trace_tool_inherits_session_id`
+6. `test_no_session_id_emits_no_attribute_no_exception`
+7. `test_debug_warning_fires_once`
+8. `test_async_contextvar_isolation`
+
+Existing `test_decorators.py` must continue to pass.
+
+## Verification (post-merge)
+
+Cut release, deploy to NAS, then 24–48h later run on the lakehouse:
+
+```sql
+SELECT
+  COUNT(*) FILTER (WHERE session_id IS NULL OR session_id = '') AS missing,
+  COUNT(*) AS total,
+  1.0 * COUNT(*) FILTER (WHERE session_id IS NULL OR session_id = '') / COUNT(*) AS ratio
+FROM lakehouse.spans
+WHERE ingest_date >= '<release_date>';
+```
+
+Expect `ratio` to drop toward zero. Track on nexus#29; close once confirmed.
+
+## Files affected (Phase 1)
+
+| Path | Change |
+|------|--------|
+| `sdk/python/agentweave/context.py` | NEW |
+| `sdk/python/agentweave/__init__.py` | Re-export `session_scope`, `current_session_id` |
+| `sdk/python/agentweave/decorators.py` | `_make_agent_wrapper` falls back to `current_session_id()`; wraps body in `session_scope` when stamping. `_make_tool_wrapper` stamps from `current_session_id()` |
+| `sdk/python/agentweave/instrument.py` | `_make_llm_wrapper` stamps from `current_session_id()` |
+| `sdk/python/tests/test_session_propagation.py` | NEW |
+| `docs/superpowers/specs/2026-04-26-session-id-propagation-design.md` | NEW (this file) |

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -251,6 +251,16 @@ export function createAgentWeaveBridgeService() {
               if (carrier["traceparent"]) {
                 process.env.AGENTWEAVE_TRACEPARENT = carrier["traceparent"]
               }
+
+              // Expose parent span/trace IDs so the proxy can create OTel links[]
+              // connecting llm_call spans back to this agent_turn span (issue #178).
+              const spanContext = span.spanContext()
+              if (spanContext) {
+                const traceIdHex = spanContext.traceId.replace(/-/g, "").padStart(32, "0")
+                const spanIdHex = spanContext.spanId.replace(/-/g, "").padStart(16, "0")
+                process.env.AGENTWEAVE_PARENT_TRACE_ID = traceIdHex
+                process.env.AGENTWEAVE_PARENT_SPAN_ID = spanIdHex
+              }
               process.env.AGENTWEAVE_SESSION_ID = sessionId
               process.env.AGENTWEAVE_AGENT_ID = agentId
               process.env.AGENTWEAVE_AGENT_TYPE = agentType
@@ -307,6 +317,8 @@ export function createAgentWeaveBridgeService() {
               turn.span.end()
               activeTurns.delete(sessionKey)
               delete process.env.AGENTWEAVE_TRACEPARENT
+              delete process.env.AGENTWEAVE_PARENT_TRACE_ID
+              delete process.env.AGENTWEAVE_PARENT_SPAN_ID
               delete process.env.ANTHROPIC_BASE_URL
               delete process.env.OPENAI_BASE_URL
               delete process.env.OPENAI_API_BASE

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -252,14 +252,20 @@ export function createAgentWeaveBridgeService() {
                 process.env.AGENTWEAVE_TRACEPARENT = carrier["traceparent"]
               }
 
-              // Expose parent span/trace IDs so the proxy can create OTel links[]
-              // connecting llm_call spans back to this agent_turn span (issue #178).
+              // Capture parent span/trace IDs for the /session POST below so
+              // the proxy can build links[] on llm_call spans (issue #178).
+              // process.env is set as a best-effort signal for any in-process
+              // sub-agent code that inherits env, but the proxy is a separate
+              // process and reads these via POST /session — that is the
+              // authoritative path.
+              let parentTraceIdHex = ""
+              let parentSpanIdHex = ""
               const spanContext = span.spanContext()
               if (spanContext) {
-                const traceIdHex = spanContext.traceId.replace(/-/g, "").padStart(32, "0")
-                const spanIdHex = spanContext.spanId.replace(/-/g, "").padStart(16, "0")
-                process.env.AGENTWEAVE_PARENT_TRACE_ID = traceIdHex
-                process.env.AGENTWEAVE_PARENT_SPAN_ID = spanIdHex
+                parentTraceIdHex = spanContext.traceId.replace(/-/g, "").padStart(32, "0")
+                parentSpanIdHex = spanContext.spanId.replace(/-/g, "").padStart(16, "0")
+                process.env.AGENTWEAVE_PARENT_TRACE_ID = parentTraceIdHex
+                process.env.AGENTWEAVE_PARENT_SPAN_ID = parentSpanIdHex
               }
               process.env.AGENTWEAVE_SESSION_ID = sessionId
               process.env.AGENTWEAVE_AGENT_ID = agentId
@@ -293,6 +299,10 @@ export function createAgentWeaveBridgeService() {
                 if (config.project) sessionPayload.project = config.project
                 if (parentSid) sessionPayload.parent_session_id = parentSid
                 if (taskLabel) sessionPayload.task_label = taskLabel
+                if (parentTraceIdHex && parentSpanIdHex) {
+                  sessionPayload.parent_trace_id = parentTraceIdHex
+                  sessionPayload.parent_span_id = parentSpanIdHex
+                }
                 fetch(`${proxyBaseUrlForSession}/session`, {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -1,6 +1,7 @@
 """AgentWeave — observability and mesh layer for multi-agent AI systems."""
 
 from agentweave.config import AgentWeaveConfig
+from agentweave.context import current_session_id, session_scope, set_session_id
 from agentweave.decorators import trace_agent, trace_llm, trace_tool
 from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
@@ -12,9 +13,12 @@ __all__ = [
     "AgentWeaveConfig",
     "add_console_exporter",
     "auto_instrument",
+    "current_session_id",
     "get_tracer",
     "prompt",
     "PromptHandle",
+    "session_scope",
+    "set_session_id",
     "shutdown",
     "trace_agent",
     "trace_llm",

--- a/sdk/python/agentweave/context.py
+++ b/sdk/python/agentweave/context.py
@@ -1,0 +1,80 @@
+"""Session-scoped context propagation for AgentWeave instrumentation.
+
+A single ``ContextVar`` holds the current session_id so that
+auto-instrumented LLM spans and ``@trace_tool`` spans can stamp
+``session.id`` and ``prov.session.id`` without the caller having to
+thread it through every call site.
+
+Resolution order (see :func:`current_session_id`):
+
+1. Active ``ContextVar`` value (set by ``@trace_agent`` or ``session_scope``).
+2. ``AGENTWEAVE_SESSION_ID`` environment variable.
+3. ``None`` — span is emitted without ``session.id``.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+logger = logging.getLogger("agentweave")
+
+_session_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "agentweave_session_id", default=None
+)
+
+_warned_missing: bool = False
+
+
+def current_session_id() -> Optional[str]:
+    """Return the active session_id, or ``None`` if no source is set."""
+    sid = _session_id_var.get()
+    if sid:
+        return sid
+    env = os.environ.get("AGENTWEAVE_SESSION_ID")
+    if env:
+        return env
+    return None
+
+
+def set_session_id(sid: Optional[str]) -> contextvars.Token:
+    """Set the ContextVar; returns a Token for ``reset()``."""
+    return _session_id_var.set(sid)
+
+
+@contextmanager
+def session_scope(sid: Optional[str]) -> Iterator[None]:
+    """Bind ``sid`` as the active session_id for the duration of the block."""
+    token = _session_id_var.set(sid)
+    try:
+        yield
+    finally:
+        _session_id_var.reset(token)
+
+
+def warn_missing_session_id_once() -> None:
+    """Emit a single debug-gated warning when a span is stamped without session_id.
+
+    Gated on ``AGENTWEAVE_DEBUG=1`` so prod stays quiet.  The warning fires
+    at most once per process to avoid log spam under load.
+    """
+    global _warned_missing
+    if _warned_missing:
+        return
+    if os.environ.get("AGENTWEAVE_DEBUG") != "1":
+        return
+    _warned_missing = True
+    logger.warning(
+        "agentweave: span emitted without session_id "
+        "(set AGENTWEAVE_SESSION_ID, use @trace_agent(session_id=...), "
+        "or wrap in session_scope())"
+    )
+
+
+def _reset_warned_for_tests() -> None:
+    """Test-only: reset the once-flag so tests can re-trigger the warning."""
+    global _warned_missing
+    _warned_missing = False

--- a/sdk/python/agentweave/decorators.py
+++ b/sdk/python/agentweave/decorators.py
@@ -27,6 +27,7 @@ from opentelemetry import trace
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
 from agentweave import schema
+from agentweave.context import current_session_id, session_scope, warn_missing_session_id_once
 from agentweave.exporter import get_tracer
 from agentweave.pricing import compute_cost
 
@@ -180,6 +181,12 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
                     for k, v in _get_config_attrs().items():
                         span.set_attribute(k, v)
+                    _sid = current_session_id()
+                    if _sid:
+                        span.set_attribute(schema.SESSION_ID, _sid)
+                        span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                    else:
+                        warn_missing_session_id_once()
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     try:
@@ -207,6 +214,12 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
                     for k, v in _get_config_attrs().items():
                         span.set_attribute(k, v)
+                    _sid = current_session_id()
+                    if _sid:
+                        span.set_attribute(schema.SESSION_ID, _sid)
+                        span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                    else:
+                        warn_missing_session_id_once()
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     try:
@@ -304,13 +317,20 @@ def _make_agent_wrapper(
                         span.set_attribute(k, v)
                     if _det_trace_id_int is not None:
                         span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
-                    if session_id is not None:
-                        span.set_attribute(schema.SESSION_ID, session_id)
-                        span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    _sid = session_id or current_session_id()
+                    if _sid:
+                        span.set_attribute(schema.SESSION_ID, _sid)
+                        span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                    else:
+                        warn_missing_session_id_once()
                     _set_subagent_attrs(span)
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
-                    result = await fn(*args, **kwargs)
+                    if _sid:
+                        with session_scope(_sid):
+                            result = await fn(*args, **kwargs)
+                    else:
+                        result = await fn(*args, **kwargs)
                     if captures_output:
                         span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
                         span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))
@@ -336,13 +356,20 @@ def _make_agent_wrapper(
                         span.set_attribute(k, v)
                     if _det_trace_id_int is not None:
                         span.set_attribute(schema.AGENTWEAVE_TRACE_ID, trace_id)
-                    if session_id is not None:
-                        span.set_attribute(schema.SESSION_ID, session_id)
-                        span.set_attribute(schema.PROV_SESSION_ID, session_id)
+                    _sid = session_id or current_session_id()
+                    if _sid:
+                        span.set_attribute(schema.SESSION_ID, _sid)
+                        span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                    else:
+                        warn_missing_session_id_once()
                     _set_subagent_attrs(span)
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
-                    result = fn(*args, **kwargs)
+                    if _sid:
+                        with session_scope(_sid):
+                            result = fn(*args, **kwargs)
+                    else:
+                        result = fn(*args, **kwargs)
                     if captures_output:
                         span.set_attribute(schema.PROV_WAS_GENERATED_BY, span_name)
                         span.set_attribute(f"{schema.PROV_ENTITY}.output.value", str(result))

--- a/sdk/python/agentweave/instrument.py
+++ b/sdk/python/agentweave/instrument.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Optional, Sequence
 from opentelemetry import trace
 
 from agentweave import schema
+from agentweave.context import current_session_id, warn_missing_session_id_once
 from agentweave.decorators import _extract_llm_attrs, _get_config_attrs
 from agentweave.exporter import get_tracer
 
@@ -85,6 +86,12 @@ def _make_llm_wrapper(
                     span.set_attribute(k, v)
                 # Set after config attrs so explicit model wins over cfg.agent_model
                 span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
+                _sid = current_session_id()
+                if _sid:
+                    span.set_attribute(schema.SESSION_ID, _sid)
+                    span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                else:
+                    warn_missing_session_id_once()
 
                 result = await original(*args, **kwargs)
 
@@ -115,6 +122,12 @@ def _make_llm_wrapper(
                     span.set_attribute(k, v)
                 # Set after config attrs so explicit model wins over cfg.agent_model
                 span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
+                _sid = current_session_id()
+                if _sid:
+                    span.set_attribute(schema.SESSION_ID, _sid)
+                    span.set_attribute(schema.PROV_SESSION_ID, _sid)
+                else:
+                    warn_missing_session_id_once()
 
                 result = original(*args, **kwargs)
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -62,7 +62,7 @@ from typing import Any, AsyncIterator
 import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from opentelemetry.trace import NonRecordingSpan, SpanContext, StatusCode, TraceFlags
+from opentelemetry.trace import Link, NonRecordingSpan, SpanContext, StatusCode, TraceFlags
 
 from agentweave import schema
 from agentweave.config import AgentWeaveConfig
@@ -154,7 +154,6 @@ def _build_parent_links(
 
     Returns an empty list when the IDs are absent or malformed.
     """
-    from opentelemetry.trace import Link
     if not parent_trace_id_raw or not parent_span_id_raw:
         return []
     trace_id_int = _normalize_trace_id(parent_trace_id_raw)
@@ -162,16 +161,38 @@ def _build_parent_links(
         return []
     parent_span_id_raw = parent_span_id_raw.strip()
     if not _SPAN_ID_RE.match(parent_span_id_raw):
-        logger.debug("x-agentweave-parent-span-id is not a valid 16-char hex: %r", parent_span_id_raw)
+        logger.debug("parent span id is not a valid 16-char hex: %r", parent_span_id_raw)
         return []
     span_id_int = int(parent_span_id_raw, 16)
+    # TraceFlags(0): the parent's sampling decision is its own — links are
+    # independent of sampling so we don't claim it.
     link_ctx = SpanContext(
         trace_id=trace_id_int,
         span_id=span_id_int,
         is_remote=True,
-        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        trace_flags=TraceFlags(0),
     )
     return [Link(context=link_ctx, attributes={"link.type": "parent_agent_turn"})]
+
+
+# Per-session parent agent_turn IDs pushed by the bridge via POST /session.
+# Cross-process channel for issue #178: bridge → proxy is HTTP, so env vars
+# don't propagate.  Bridge POSTs (parent_trace_id, parent_span_id) keyed by
+# session_id at message.received and clears at message.processed.
+# LRU-bounded to defend against bridge crashes leaving stale entries.
+_MAX_SESSION_PARENT_SPANS = 256
+_session_parent_spans: "OrderedDict[str, tuple[str, str]]" = OrderedDict()
+
+
+def _set_session_parent_span(session_id: str, trace_id: str, span_id: str) -> None:
+    _session_parent_spans[session_id] = (trace_id, span_id)
+    _session_parent_spans.move_to_end(session_id)
+    while len(_session_parent_spans) > _MAX_SESSION_PARENT_SPANS:
+        _session_parent_spans.popitem(last=False)
+
+
+def _clear_session_parent_span(session_id: str) -> None:
+    _session_parent_spans.pop(session_id, None)
 
 # Runtime auth token. Set AGENTWEAVE_PROXY_TOKEN or --auth-token.
 # Empty = open mode (dev/localhost only).
@@ -380,6 +401,11 @@ async def set_session_context(body: dict):
 
     To clear a per-key override, POST with ``force: false`` and the same
     ``session_key``.
+
+    Optional ``parent_trace_id`` and ``parent_span_id`` (when paired with
+    ``session_id``) populate the per-session parent agent_turn map used to
+    build OTel links[] on llm_call spans (issue #178).  Sending either field
+    as an explicit empty string clears the entry for that session.
     """
     global _session_context, _session_context_force, _forced_session_contexts
     ctx = {k: v for k, v in {
@@ -390,6 +416,19 @@ async def set_session_context(body: dict):
         "prov.agent.id": body.get("agent_id", ""),
         "prov.project": body.get("project", ""),
     }.items() if v}
+
+    # Issue #178: bridge pushes the active agent_turn's trace/span IDs so the
+    # proxy can build links[] on llm_call spans.  Keyed by session_id so
+    # concurrent sessions stay isolated.  Empty values clear the entry.
+    _sid_for_parent = body.get("session_id", "")
+    _ptid = (body.get("parent_trace_id") or "").strip()
+    _psid = (body.get("parent_span_id") or "").strip()
+    if _sid_for_parent:
+        if _ptid and _psid:
+            _set_session_parent_span(_sid_for_parent, _ptid, _psid)
+        elif "parent_trace_id" in body or "parent_span_id" in body:
+            # Explicit empty string in either field clears the entry.
+            _clear_session_parent_span(_sid_for_parent)
 
     force = bool(body.get("force", False))
     session_key = body.get("session_key", "")
@@ -989,15 +1028,17 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
             logger.warning("x-agentweave-turn-depth is not a valid integer: %r", turn_depth_raw)
 
     # Parent span/trace IDs for OTel link creation (issue #178).
-    # Headers take precedence; fall back to env vars set by the bridge.
-    parent_span_id_raw: str | None = (
-        request.headers.get("x-agentweave-parent-span-id")
-        or os.environ.get("AGENTWEAVE_PARENT_SPAN_ID")
-    )
-    parent_trace_id_raw: str | None = (
-        request.headers.get("x-agentweave-parent-trace-id")
-        or os.environ.get("AGENTWEAVE_PARENT_TRACE_ID")
-    )
+    # Headers take precedence (direct callers); fall back to the per-session
+    # entry pushed by the bridge via POST /session.
+    # Env-var fallback is deliberately omitted: the proxy is a long-lived
+    # multi-tenant server, so process-static env would mis-link every request.
+    parent_trace_id_raw: str | None = request.headers.get("x-agentweave-parent-trace-id")
+    parent_span_id_raw: str | None = request.headers.get("x-agentweave-parent-span-id")
+    if (not parent_trace_id_raw or not parent_span_id_raw) and session_id:
+        _stored = _session_parent_spans.get(session_id)
+        if _stored:
+            parent_trace_id_raw = parent_trace_id_raw or _stored[0]
+            parent_span_id_raw = parent_span_id_raw or _stored[1]
 
     forward_headers = {
         k: v for k, v in request.headers.items()

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -100,6 +100,8 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-agent-type",
     "x-agentweave-turn-depth",
     "x-agentweave-session-key",
+    "x-agentweave-parent-span-id",
+    "x-agentweave-parent-trace-id",
 }
 
 # ---------------------------------------------------------------------------
@@ -137,6 +139,40 @@ def _context_for_trace_id(trace_id_int: int):
     )
     return _trace.set_span_in_context(NonRecordingSpan(span_ctx))
 
+
+_SPAN_ID_RE = re.compile(r'^[0-9a-fA-F]{16}$')
+
+
+def _build_parent_links(
+    parent_trace_id_raw: str | None,
+    parent_span_id_raw: str | None,
+) -> list:
+    """Build an OTel ``links`` list referencing the parent agent_turn span.
+
+    Used to connect ``llm_call`` spans to their parent ``agent_turn`` span
+    when cross-process propagation via traceparent is unreliable (issue #178).
+
+    Returns an empty list when the IDs are absent or malformed.
+    """
+    from opentelemetry.trace import Link
+    if not parent_trace_id_raw or not parent_span_id_raw:
+        return []
+    trace_id_int = _normalize_trace_id(parent_trace_id_raw)
+    if trace_id_int is None:
+        return []
+    parent_span_id_raw = parent_span_id_raw.strip()
+    if not _SPAN_ID_RE.match(parent_span_id_raw):
+        logger.debug("x-agentweave-parent-span-id is not a valid 16-char hex: %r", parent_span_id_raw)
+        return []
+    span_id_int = int(parent_span_id_raw, 16)
+    link_ctx = SpanContext(
+        trace_id=trace_id_int,
+        span_id=span_id_int,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    return [Link(context=link_ctx, attributes={"link.type": "parent_agent_turn"})]
+
 # Runtime auth token. Set AGENTWEAVE_PROXY_TOKEN or --auth-token.
 # Empty = open mode (dev/localhost only).
 _PROXY_TOKEN: str | None = os.getenv("AGENTWEAVE_PROXY_TOKEN") or None
@@ -146,20 +182,36 @@ _PROXY_TOKEN: str | None = os.getenv("AGENTWEAVE_PROXY_TOKEN") or None
 # IMPORTANT: Only standard API keys (sk-ant-api03_*) can be injected.
 # OAuth tokens (sk-ant-oat*) MUST NOT be used — they expire and require
 # SDK-level auth flow with TLS fingerprinting.  See DEPLOYMENT-RUNBOOK.md.
-_raw_anthropic_key = os.getenv("AGENTWEAVE_ANTHROPIC_API_KEY", "").strip()
+#
+# Key resolution order (highest to lowest priority):
+#   1. AGENTWEAVE_ANTHROPIC_API_KEY / AGENTWEAVE_GOOGLE_API_KEY / AGENTWEAVE_OPENAI_API_KEY
+#      (explicit proxy-injection env vars — set these in the k8s Secret)
+#   2. ANTHROPIC_API_KEY / GOOGLE_API_KEY / OPENAI_API_KEY
+#      (standard SDK env vars — used as fallback when AGENTWEAVE_* are unset or empty)
+#
+# This fallback ensures that sub-agents routed through the proxy succeed even
+# when the k8s Secret only populates the standard SDK vars (closes #174).
+_raw_anthropic_key = (
+    os.getenv("AGENTWEAVE_ANTHROPIC_API_KEY", "").strip()
+    or os.getenv("ANTHROPIC_API_KEY", "").strip()
+)
 if _raw_anthropic_key and _raw_anthropic_key.startswith("sk-ant-oat"):
     logging.getLogger("agentweave.proxy").warning(
-        "AGENTWEAVE_ANTHROPIC_API_KEY contains an OAuth token (sk-ant-oat*) "
-        "which CANNOT be used for proxy injection — OAuth tokens expire and "
-        "require SDK-level auth.  Use a standard API key (sk-ant-api03_*) or "
+        "AGENTWEAVE_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY contains an OAuth token "
+        "(sk-ant-oat*) which CANNOT be used for proxy injection — OAuth tokens expire "
+        "and require SDK-level auth.  Use a standard API key (sk-ant-api03_*) or "
         "clear this env var to enable pass-through mode.  Ignoring."
     )
     _ANTHROPIC_INJECT_KEY: str | None = None
 else:
     _ANTHROPIC_INJECT_KEY: str | None = _raw_anthropic_key or None
 
-_GOOGLE_INJECT_KEY: str | None = os.getenv("AGENTWEAVE_GOOGLE_API_KEY") or None
-_OPENAI_INJECT_KEY: str | None = os.getenv("AGENTWEAVE_OPENAI_API_KEY") or None
+_GOOGLE_INJECT_KEY: str | None = (
+    os.getenv("AGENTWEAVE_GOOGLE_API_KEY") or os.getenv("GOOGLE_API_KEY") or None
+)
+_OPENAI_INJECT_KEY: str | None = (
+    os.getenv("AGENTWEAVE_OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY") or None
+)
 
 
 def _inject_anthropic_key(forward_headers: dict[str, str], query_string: str) -> str:
@@ -936,6 +988,17 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         except (ValueError, TypeError):
             logger.warning("x-agentweave-turn-depth is not a valid integer: %r", turn_depth_raw)
 
+    # Parent span/trace IDs for OTel link creation (issue #178).
+    # Headers take precedence; fall back to env vars set by the bridge.
+    parent_span_id_raw: str | None = (
+        request.headers.get("x-agentweave-parent-span-id")
+        or os.environ.get("AGENTWEAVE_PARENT_SPAN_ID")
+    )
+    parent_trace_id_raw: str | None = (
+        request.headers.get("x-agentweave-parent-trace-id")
+        or os.environ.get("AGENTWEAVE_PARENT_TRACE_ID")
+    )
+
     forward_headers = {
         k: v for k, v in request.headers.items()
         if k.lower() not in _SKIP_HEADERS_ALWAYS
@@ -996,6 +1059,8 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         agent_type=agent_type,
         turn_depth=turn_depth,
         traceparent=traceparent,
+        parent_span_id_raw=parent_span_id_raw,
+        parent_trace_id_raw=parent_trace_id_raw,
     )
 
     try:
@@ -1077,10 +1142,13 @@ async def _request_and_trace(
     parent_session_id: str | None = None, agent_type: str | None = None,
     turn_depth: int | None = None,
     traceparent: str | None = None,
+    parent_span_id_raw: str | None = None,
+    parent_trace_id_raw: str | None = None,
 ) -> JSONResponse:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
-    with tracer.start_as_current_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx) as span:
+    _links = _build_parent_links(parent_trace_id_raw, parent_span_id_raw)
+    with tracer.start_as_current_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx, links=_links) as span:
         _set_request_attrs(span, model=model, provider=provider,
                            agent_id=agent_id, agent_model=agent_model,
                            path=path, body=body,
@@ -1146,10 +1214,13 @@ async def _stream_and_trace(
     parent_session_id: str | None = None, agent_type: str | None = None,
     turn_depth: int | None = None,
     traceparent: str | None = None,
+    parent_span_id_raw: str | None = None,
+    parent_trace_id_raw: str | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
-    span = tracer.start_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx)
+    _links = _build_parent_links(parent_trace_id_raw, parent_span_id_raw)
+    span = tracer.start_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx, links=_links)
     _set_request_attrs(span, model=model, provider=provider,
                        agent_id=agent_id, agent_model=agent_model,
                        path=path, body=body,

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1753,3 +1753,121 @@ class TestListModelsEndpoint:
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", "secret123")
         resp = self._client().get("/v1/models")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests for issue #174: env key fallback when AGENTWEAVE_* vars are unset
+# ---------------------------------------------------------------------------
+
+class TestEnvKeyFallback:
+    """Verify that standard SDK env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY,
+    GOOGLE_API_KEY) are used as fallback when AGENTWEAVE_*_API_KEY is absent.
+
+    This covers the case where the k8s Secret sets only the standard SDK vars
+    (e.g. for sub-agents that also need direct API access) but the proxy's
+    AGENTWEAVE_ANTHROPIC_API_KEY is empty or not set.  Previously, key_injection
+    would remain False in this scenario and sub-agent LLM calls would fail with
+    authentication errors.
+    """
+
+    def test_anthropic_fallback_from_standard_env(self, monkeypatch):
+        """ANTHROPIC_API_KEY is used as fallback when AGENTWEAVE_ANTHROPIC_API_KEY is unset."""
+        import importlib
+        import sys
+
+        # Remove cached proxy module so env-var-level globals are re-evaluated
+        for mod_name in list(sys.modules.keys()):
+            if "agentweave.proxy" in mod_name or mod_name == "agentweave.proxy":
+                del sys.modules[mod_name]
+
+        monkeypatch.setenv("AGENTWEAVE_ANTHROPIC_API_KEY", "")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03_fallback_key")
+        monkeypatch.delenv("AGENTWEAVE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_GOOGLE_API_KEY", raising=False)
+
+        import agentweave.proxy as fresh_proxy
+        assert fresh_proxy._ANTHROPIC_INJECT_KEY == "sk-ant-api03_fallback_key", (
+            "Expected ANTHROPIC_API_KEY to be used as fallback when "
+            "AGENTWEAVE_ANTHROPIC_API_KEY is empty"
+        )
+
+    def test_openai_fallback_from_standard_env(self, monkeypatch):
+        """OPENAI_API_KEY is used as fallback when AGENTWEAVE_OPENAI_API_KEY is unset."""
+        import sys
+
+        for mod_name in list(sys.modules.keys()):
+            if "agentweave.proxy" in mod_name or mod_name == "agentweave.proxy":
+                del sys.modules[mod_name]
+
+        monkeypatch.setenv("AGENTWEAVE_OPENAI_API_KEY", "")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-fallback")
+        monkeypatch.delenv("AGENTWEAVE_ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_GOOGLE_API_KEY", raising=False)
+
+        import agentweave.proxy as fresh_proxy
+        assert fresh_proxy._OPENAI_INJECT_KEY == "sk-openai-fallback", (
+            "Expected OPENAI_API_KEY to be used as fallback when "
+            "AGENTWEAVE_OPENAI_API_KEY is empty"
+        )
+
+    def test_google_fallback_from_standard_env(self, monkeypatch):
+        """GOOGLE_API_KEY is used as fallback when AGENTWEAVE_GOOGLE_API_KEY is unset."""
+        import sys
+
+        for mod_name in list(sys.modules.keys()):
+            if "agentweave.proxy" in mod_name or mod_name == "agentweave.proxy":
+                del sys.modules[mod_name]
+
+        monkeypatch.setenv("AGENTWEAVE_GOOGLE_API_KEY", "")
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIzaFallbackGoogleKey")
+        monkeypatch.delenv("AGENTWEAVE_ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_OPENAI_API_KEY", raising=False)
+
+        import agentweave.proxy as fresh_proxy
+        assert fresh_proxy._GOOGLE_INJECT_KEY == "AIzaFallbackGoogleKey", (
+            "Expected GOOGLE_API_KEY to be used as fallback when "
+            "AGENTWEAVE_GOOGLE_API_KEY is empty"
+        )
+
+    def test_agentweave_key_takes_precedence_over_standard(self, monkeypatch):
+        """AGENTWEAVE_ANTHROPIC_API_KEY takes priority over ANTHROPIC_API_KEY."""
+        import sys
+
+        for mod_name in list(sys.modules.keys()):
+            if "agentweave.proxy" in mod_name or mod_name == "agentweave.proxy":
+                del sys.modules[mod_name]
+
+        monkeypatch.setenv("AGENTWEAVE_ANTHROPIC_API_KEY", "sk-ant-api03_primary_key")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03_fallback_key")
+
+        import agentweave.proxy as fresh_proxy
+        assert fresh_proxy._ANTHROPIC_INJECT_KEY == "sk-ant-api03_primary_key", (
+            "AGENTWEAVE_ANTHROPIC_API_KEY should take priority over ANTHROPIC_API_KEY"
+        )
+
+    def test_health_endpoint_reflects_fallback_key_injection(self, monkeypatch):
+        """GET /health shows key_injection=true when only the standard SDK env vars are set."""
+        import sys
+        from starlette.testclient import TestClient
+
+        for mod_name in list(sys.modules.keys()):
+            if "agentweave.proxy" in mod_name or mod_name == "agentweave.proxy":
+                del sys.modules[mod_name]
+
+        monkeypatch.setenv("AGENTWEAVE_ANTHROPIC_API_KEY", "")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03_via_standard_env")
+        monkeypatch.delenv("AGENTWEAVE_OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+        import agentweave.proxy as fresh_proxy
+        client = TestClient(fresh_proxy.app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["key_injection"]["anthropic"] is True, (
+            "key_injection.anthropic should be True when ANTHROPIC_API_KEY fallback is active"
+        )
+        assert data["key_injection"]["openai"] is False
+        assert data["key_injection"]["google"] is False

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1871,3 +1871,51 @@ class TestEnvKeyFallback:
         )
         assert data["key_injection"]["openai"] is False
         assert data["key_injection"]["google"] is False
+
+
+# ---------------------------------------------------------------------------
+# OTel links[] for cross-process span lineage (issue #178)
+# ---------------------------------------------------------------------------
+
+class TestBuildParentLinks:
+    """Tests for _build_parent_links — OTel link construction from parent span/trace IDs."""
+
+    def test_valid_ids_return_one_link(self):
+        from agentweave.proxy import _build_parent_links
+        trace_id = "a" * 32
+        span_id = "b" * 16
+        links = _build_parent_links(trace_id, span_id)
+        assert len(links) == 1
+        ctx = links[0].context
+        assert ctx.trace_id == int(trace_id, 16)
+        assert ctx.span_id == int(span_id, 16)
+        assert links[0].attributes == {"link.type": "parent_agent_turn"}
+
+    def test_missing_trace_id_returns_empty(self):
+        from agentweave.proxy import _build_parent_links
+        assert _build_parent_links(None, "b" * 16) == []
+        assert _build_parent_links("", "b" * 16) == []
+
+    def test_missing_span_id_returns_empty(self):
+        from agentweave.proxy import _build_parent_links
+        assert _build_parent_links("a" * 32, None) == []
+        assert _build_parent_links("a" * 32, "") == []
+
+    def test_invalid_span_id_returns_empty(self):
+        from agentweave.proxy import _build_parent_links
+        # Too short
+        assert _build_parent_links("a" * 32, "b" * 8) == []
+        # Non-hex
+        assert _build_parent_links("a" * 32, "z" * 16) == []
+
+    def test_non_hex_trace_id_is_hashed(self):
+        """Arbitrary string trace IDs are SHA-256 hashed — still returns a link."""
+        from agentweave.proxy import _build_parent_links
+        links = _build_parent_links("my-session-id", "b" * 16)
+        assert len(links) == 1
+
+    def test_skip_headers_includes_parent_ids(self):
+        """x-agentweave-parent-span-id and parent-trace-id are in _SKIP_HEADERS_ALWAYS."""
+        from agentweave.proxy import _SKIP_HEADERS_ALWAYS
+        assert "x-agentweave-parent-span-id" in _SKIP_HEADERS_ALWAYS
+        assert "x-agentweave-parent-trace-id" in _SKIP_HEADERS_ALWAYS

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1919,3 +1919,102 @@ class TestBuildParentLinks:
         from agentweave.proxy import _SKIP_HEADERS_ALWAYS
         assert "x-agentweave-parent-span-id" in _SKIP_HEADERS_ALWAYS
         assert "x-agentweave-parent-trace-id" in _SKIP_HEADERS_ALWAYS
+
+
+class TestSessionParentSpansEndpoint:
+    """POST /session with parent_trace_id/parent_span_id stores per-session entries
+    used to build OTel links[] on llm_call spans (issue #178)."""
+
+    def test_post_stores_parent_span_for_session(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app, _session_parent_spans
+        client = TestClient(app)
+        sid = "sess-link-1"
+        tid = "f" * 32
+        spid = "1" * 16
+        resp = client.post("/session", json={
+            "session_id": sid,
+            "parent_trace_id": tid,
+            "parent_span_id": spid,
+        })
+        assert resp.status_code == 200
+        assert _session_parent_spans.get(sid) == (tid, spid)
+
+    def test_post_with_empty_parent_clears_entry(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app, _session_parent_spans, _set_session_parent_span
+        client = TestClient(app)
+        sid = "sess-link-clear"
+        _set_session_parent_span(sid, "a" * 32, "b" * 16)
+        assert sid in _session_parent_spans
+        resp = client.post("/session", json={
+            "session_id": sid,
+            "parent_trace_id": "",
+            "parent_span_id": "",
+        })
+        assert resp.status_code == 200
+        assert sid not in _session_parent_spans
+
+    def test_post_without_parent_fields_does_not_touch_entry(self):
+        """Vanilla /session POST that doesn't mention parent_* must not clobber
+        an existing parent entry (the bridge sends per-session pushes that
+        only update parent state when a turn starts/ends)."""
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app, _session_parent_spans, _set_session_parent_span
+        client = TestClient(app)
+        sid = "sess-link-preserve"
+        _set_session_parent_span(sid, "c" * 32, "d" * 16)
+        resp = client.post("/session", json={"session_id": sid, "task_label": "foo"})
+        assert resp.status_code == 200
+        assert _session_parent_spans.get(sid) == ("c" * 32, "d" * 16)
+
+    def test_lru_evicts_oldest_when_over_cap(self, monkeypatch):
+        from agentweave.proxy import _session_parent_spans, _set_session_parent_span
+        import agentweave.proxy as proxy_module
+        # Reset and run with a small cap
+        _session_parent_spans.clear()
+        monkeypatch.setattr(proxy_module, "_MAX_SESSION_PARENT_SPANS", 2)
+        _set_session_parent_span("a", "1" * 32, "1" * 16)
+        _set_session_parent_span("b", "2" * 32, "2" * 16)
+        _set_session_parent_span("c", "3" * 32, "3" * 16)
+        assert "a" not in _session_parent_spans
+        assert "b" in _session_parent_spans
+        assert "c" in _session_parent_spans
+
+
+class TestParentLinkResolution:
+    """When an llm_call request arrives, the proxy must look up parent IDs from
+    _session_parent_spans by session_id, with request headers taking precedence."""
+
+    def test_session_lookup_used_when_headers_absent(self):
+        from agentweave.proxy import _session_parent_spans, _set_session_parent_span
+        _session_parent_spans.clear()
+        sid = "sess-lookup"
+        tid = "a" * 32
+        spid = "b" * 16
+        _set_session_parent_span(sid, tid, spid)
+
+        # Simulate the resolution branch: no headers, session_id present
+        parent_trace_id_raw = None
+        parent_span_id_raw = None
+        if (not parent_trace_id_raw or not parent_span_id_raw) and sid:
+            stored = _session_parent_spans.get(sid)
+            if stored:
+                parent_trace_id_raw = parent_trace_id_raw or stored[0]
+                parent_span_id_raw = parent_span_id_raw or stored[1]
+        assert parent_trace_id_raw == tid
+        assert parent_span_id_raw == spid
+
+    def test_no_env_fallback_in_resolution_block(self):
+        """AGENTWEAVE_PARENT_TRACE_ID / _SPAN_ID env vars must NOT be honored
+        for parent-link resolution — the proxy is multi-tenant and process-
+        static env would mis-link every request."""
+        import inspect
+        import agentweave.proxy as proxy_module
+        src = inspect.getsource(proxy_module)
+        marker = "Parent span/trace IDs for OTel link creation"
+        idx = src.find(marker)
+        assert idx != -1, "parent-id resolution comment not found"
+        block = src[idx: idx + 800]
+        assert "AGENTWEAVE_PARENT_TRACE_ID" not in block
+        assert "AGENTWEAVE_PARENT_SPAN_ID" not in block

--- a/sdk/python/tests/test_session_propagation.py
+++ b/sdk/python/tests/test_session_propagation.py
@@ -1,0 +1,309 @@
+"""Tests for session_id propagation across auto-instrument and decorators.
+
+Covers nexus#29: ~40% of lakehouse.spans rows had NULL session_id because
+auto_instrument() LLM spans and @trace_tool spans never read any session
+context.  These tests verify the ContextVar-based propagation introduced in
+agentweave/context.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+import agentweave
+from agentweave import schema
+from agentweave.config import AgentWeaveConfig
+from agentweave import context as aw_context
+from agentweave.decorators import trace_agent, trace_tool
+from agentweave.instrument import (
+    auto_instrument,
+    uninstrument,
+    _active_patches,
+    _proxy_env_overrides,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake Anthropic SDK — minimal surface used by _patch_anthropic
+# ---------------------------------------------------------------------------
+
+class _FakeUsage:
+    input_tokens = 10
+    output_tokens = 5
+
+
+class _FakeText:
+    text = "ok"
+
+
+class _FakeResponse:
+    usage = _FakeUsage()
+    content = [_FakeText()]
+    stop_reason = "end_turn"
+
+
+def _install_fake_anthropic() -> None:
+    """Install a minimal anthropic.resources stub with Messages.create."""
+    pkg = types.ModuleType("anthropic")
+    resources = types.ModuleType("anthropic.resources")
+
+    class Messages:
+        def create(self, *args, **kwargs):  # noqa: D401
+            return _FakeResponse()
+
+    class AsyncMessages:
+        async def create(self, *args, **kwargs):  # noqa: D401
+            return _FakeResponse()
+
+    resources.Messages = Messages
+    resources.AsyncMessages = AsyncMessages
+    pkg.resources = resources
+    sys.modules["anthropic"] = pkg
+    sys.modules["anthropic.resources"] = resources
+
+
+def _uninstall_fake_anthropic() -> None:
+    sys.modules.pop("anthropic", None)
+    sys.modules.pop("anthropic.resources", None)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def tracer_exporter():
+    """Inject an in-memory exporter for span assertions."""
+    import agentweave.exporter as _exporter_mod
+
+    AgentWeaveConfig.reset()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    old_provider = _exporter_mod._provider
+    _exporter_mod._provider = provider
+
+    with patch("agentweave.config.init_tracer"):
+        AgentWeaveConfig.setup(
+            agent_id="test-agent",
+            agent_model="test-model",
+            agent_version="1.0.0",
+            otel_endpoint="http://localhost:4318",
+        )
+
+    yield exporter
+
+    provider.shutdown()
+    _exporter_mod._provider = old_provider
+    AgentWeaveConfig.reset()
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    """Reset env, patches, and the warn-once flag between tests."""
+    saved_env = {
+        k: os.environ.get(k)
+        for k in ("AGENTWEAVE_SESSION_ID", "AGENTWEAVE_DEBUG")
+    }
+    for k in saved_env:
+        os.environ.pop(k, None)
+    aw_context._reset_warned_for_tests()
+
+    yield
+
+    uninstrument()
+    _active_patches.clear()
+    _proxy_env_overrides.clear()
+    _uninstall_fake_anthropic()
+    for k, v in saved_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    aw_context._reset_warned_for_tests()
+
+
+def _llm_span(spans):
+    """Helper: return the first span whose name starts with 'llm.'."""
+    matches = [s for s in spans if s.name.startswith("llm.")]
+    assert matches, f"no llm.* span in {[s.name for s in spans]}"
+    return matches[0]
+
+
+def _make_anthropic_call():
+    """Trigger a single auto-instrumented Anthropic call."""
+    import anthropic.resources as r
+    return r.Messages().create(model="claude-test-model", messages=[{"role": "user", "content": "hi"}])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestAutoInstrumentSessionPropagation:
+
+    def test_auto_instrument_stamps_session_id_from_contextvar(self, tracer_exporter):
+        _install_fake_anthropic()
+        auto_instrument(providers=["anthropic"])
+
+        with agentweave.session_scope("sess-from-cv"):
+            _make_anthropic_call()
+
+        attrs = dict(_llm_span(tracer_exporter.get_finished_spans()).attributes)
+        assert attrs[schema.SESSION_ID] == "sess-from-cv"
+        assert attrs[schema.PROV_SESSION_ID] == "sess-from-cv"
+
+    def test_auto_instrument_stamps_session_id_from_env_var(self, tracer_exporter):
+        _install_fake_anthropic()
+        os.environ["AGENTWEAVE_SESSION_ID"] = "sess-from-env"
+        auto_instrument(providers=["anthropic"])
+
+        _make_anthropic_call()
+
+        attrs = dict(_llm_span(tracer_exporter.get_finished_spans()).attributes)
+        assert attrs[schema.SESSION_ID] == "sess-from-env"
+        assert attrs[schema.PROV_SESSION_ID] == "sess-from-env"
+
+    def test_contextvar_wins_over_env_var(self, tracer_exporter):
+        _install_fake_anthropic()
+        os.environ["AGENTWEAVE_SESSION_ID"] = "sess-env-loser"
+        auto_instrument(providers=["anthropic"])
+
+        with agentweave.session_scope("sess-cv-winner"):
+            _make_anthropic_call()
+
+        attrs = dict(_llm_span(tracer_exporter.get_finished_spans()).attributes)
+        assert attrs[schema.SESSION_ID] == "sess-cv-winner"
+
+    def test_no_session_id_emits_no_attribute_no_exception(self, tracer_exporter):
+        _install_fake_anthropic()
+        auto_instrument(providers=["anthropic"])
+
+        # Should not raise; just emit a span without session.id
+        _make_anthropic_call()
+
+        attrs = dict(_llm_span(tracer_exporter.get_finished_spans()).attributes)
+        assert schema.SESSION_ID not in attrs
+        assert schema.PROV_SESSION_ID not in attrs
+
+    def test_async_contextvar_isolation(self, tracer_exporter):
+        _install_fake_anthropic()
+        auto_instrument(providers=["anthropic"])
+        import anthropic.resources as r
+
+        async def _task(sid: str):
+            with agentweave.session_scope(sid):
+                # Yield to event loop so both tasks interleave
+                await asyncio.sleep(0)
+                await r.AsyncMessages().create(
+                    model="claude-test-model", messages=[{"role": "user", "content": sid}]
+                )
+
+        async def _run():
+            await asyncio.gather(_task("sess-A"), _task("sess-B"))
+
+        asyncio.run(_run())
+
+        spans = [s for s in tracer_exporter.get_finished_spans() if s.name.startswith("llm.")]
+        assert len(spans) == 2
+        sids = {dict(s.attributes).get(schema.SESSION_ID) for s in spans}
+        assert sids == {"sess-A", "sess-B"}, "ContextVar leaked across async tasks"
+
+
+class TestTraceToolSessionPropagation:
+
+    def test_trace_tool_inherits_session_id(self, tracer_exporter):
+
+        @trace_tool
+        def my_tool() -> str:
+            return "ok"
+
+        with agentweave.session_scope("sess-tool"):
+            my_tool()
+
+        spans = tracer_exporter.get_finished_spans()
+        tool_span = next(s for s in spans if s.name.startswith("tool."))
+        attrs = dict(tool_span.attributes)
+        assert attrs[schema.SESSION_ID] == "sess-tool"
+        assert attrs[schema.PROV_SESSION_ID] == "sess-tool"
+
+
+class TestTraceAgentPrecedence:
+
+    def test_explicit_kwarg_wins_over_contextvar(self, tracer_exporter):
+
+        @trace_agent(session_id="sess-explicit")
+        def handle(msg: str) -> str:
+            return msg
+
+        with agentweave.session_scope("sess-cv-loser"):
+            handle("hi")
+
+        spans = tracer_exporter.get_finished_spans()
+        agent_span = next(s for s in spans if s.name.startswith("agent."))
+        attrs = dict(agent_span.attributes)
+        assert attrs[schema.SESSION_ID] == "sess-explicit"
+
+    def test_trace_agent_propagates_to_nested_tool(self, tracer_exporter):
+        """Body of @trace_agent should set ContextVar so nested @trace_tool inherits."""
+
+        @trace_tool
+        def inner_tool() -> str:
+            return "x"
+
+        @trace_agent(session_id="sess-agent")
+        def outer() -> str:
+            return inner_tool()
+
+        outer()
+
+        spans = tracer_exporter.get_finished_spans()
+        tool_span = next(s for s in spans if s.name.startswith("tool."))
+        agent_span = next(s for s in spans if s.name.startswith("agent."))
+        assert dict(tool_span.attributes)[schema.SESSION_ID] == "sess-agent"
+        assert dict(agent_span.attributes)[schema.SESSION_ID] == "sess-agent"
+
+
+class TestDebugWarning:
+
+    def test_debug_warning_fires_once(self, tracer_exporter, caplog):
+        _install_fake_anthropic()
+        os.environ["AGENTWEAVE_DEBUG"] = "1"
+        auto_instrument(providers=["anthropic"])
+
+        with caplog.at_level(logging.WARNING, logger="agentweave"):
+            _make_anthropic_call()
+            _make_anthropic_call()
+
+        warnings = [
+            r for r in caplog.records
+            if r.name == "agentweave" and "session_id" in r.getMessage()
+        ]
+        assert len(warnings) == 1, (
+            f"expected exactly one warning, got {len(warnings)}: {[r.getMessage() for r in warnings]}"
+        )
+
+    def test_no_warning_without_debug_flag(self, tracer_exporter, caplog):
+        _install_fake_anthropic()
+        # AGENTWEAVE_DEBUG intentionally unset
+        auto_instrument(providers=["anthropic"])
+
+        with caplog.at_level(logging.WARNING, logger="agentweave"):
+            _make_anthropic_call()
+
+        warnings = [
+            r for r in caplog.records
+            if r.name == "agentweave" and "session_id" in r.getMessage()
+        ]
+        assert warnings == []


### PR DESCRIPTION
## Summary

Three fixes on `feat/session-id-propagation`:

### #174 — key_injection fallback (fixes sub-agent auth)
Proxy had API keys in `AGENTWEAVE_*` env vars but `key_injection=false` meant it wouldn't use them. Sub-agents routing through proxy had no keys → all LLM requests failed.

**Fix:** When `AGENTWEAVE_ANTHROPIC_API_KEY` / `AGENTWEAVE_OPENAI_API_KEY` / `AGENTWEAVE_GOOGLE_API_KEY` are empty, fall back to standard SDK env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`). Resolution: explicit `AGENTWEAVE_*` var > standard SDK var.

### #178 — OTel links[] for cross-process span lineage
610/627 `llm_call` spans show as root-of-trace because openclaw HTTP client doesn't propagate W3C traceparent as per-request header.

**Fix:** Bridge sets `x-agentweave-parent-trace-id` + `x-agentweave-parent-span-id` headers on outbound LLM requests. Proxy reads these and creates OTel `Link[]` from `llm_call` spans to parent `agent_turn` spans.

### #176 follow-up — session_id propagation (already in this branch)
Adds `agentweave.context` with ContextVar-based session scope. `auto_instrument()` and `@trace_tool` now stamp `session.id` / `prov.session.id` from active context.

## Files changed
- `sdk/python/agentweave/proxy.py` — key_injection fallback + OTel Link creation
- `plugins/openclaw-agentweave-bridge/src/service.ts` — parent span/trace ID header injection
- `sdk/python/agentweave/context.py` — session_id ContextVar
- `sdk/python/tests/test_proxy.py` — new tests for both fixes