### PR TITLE
fix: reroute /v1/responses with ChatGPT-mode JWT to chatgpt.com codex backend

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -319,6 +319,44 @@ def _detect_provider(path: str) -> str:
     return "anthropic"
 
 
+# Paths that have a ChatGPT-backend equivalent under /codex/<suffix>.
+# OpenAI rejects ChatGPT-mode JWTs at api.openai.com — those tokens only work
+# against chatgpt.com/backend-api/codex/*. When a caller hits the OpenAI
+# Responses API (typically the OpenClaw openai-codex provider, which always
+# emits POST /v1/responses regardless of upstream), detect the JWT-shaped
+# bearer and reroute it to the ChatGPT backend.
+_OPENAI_TO_CODEX_PATH = {"v1/responses": "codex/responses"}
+
+
+def _is_chatgpt_mode_bearer(auth_header: str) -> bool:
+    """True when the Authorization header carries a ChatGPT-mode JWT.
+
+    ChatGPT-mode access tokens are RS256 JWTs (start with ``eyJ`` after
+    base64-decoding the header) and are not interchangeable with ``sk-*``
+    OpenAI API keys.  ``sk-ant-*`` (Anthropic) is also explicitly excluded.
+    """
+    if not auth_header:
+        return False
+    token = auth_header[7:] if auth_header.startswith("Bearer ") else auth_header
+    return token.startswith("eyJ") and not token.startswith("sk-")
+
+
+def _maybe_reroute_openai_to_codex(provider: str, path: str, auth_header: str) -> tuple[str, str]:
+    """Reroute OpenAI Responses-API traffic to the ChatGPT codex backend when
+    the caller is using a ChatGPT-mode JWT instead of an ``sk-*`` API key.
+
+    Returns the (provider, path) pair to use for upstream dispatch.
+    """
+    if provider != "openai":
+        return provider, path
+    rewritten = _OPENAI_TO_CODEX_PATH.get(path)
+    if rewritten is None:
+        return provider, path
+    if not _is_chatgpt_mode_bearer(auth_header):
+        return provider, path
+    return "codex", rewritten
+
+
 def _upstream_url(provider: str, path: str, query_string: str) -> str:
     if provider == "google":
         base = _GOOGLE_BASE
@@ -914,6 +952,11 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
             pass
 
     provider = _detect_provider(path)
+    # ChatGPT-mode tokens (Bearer eyJ…) reach api.openai.com only to be rejected.
+    # Reroute Responses-API calls carrying such tokens to chatgpt.com/backend-api/codex.
+    provider, path = _maybe_reroute_openai_to_codex(
+        provider, path, request.headers.get("authorization", "")
+    )
     model = _extract_model(provider, path, body)
     is_stream = _is_streaming(provider, path, body)
     query_string = request.url.query

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -15,6 +15,8 @@ import agentweave.proxy as proxy_module
 from agentweave.proxy import (
     _check_auth,
     _detect_provider,
+    _is_chatgpt_mode_bearer,
+    _maybe_reroute_openai_to_codex,
     _extract_anthropic_cache_tokens,
     _inject_anthropic_key,
     _openai_response_text,
@@ -75,6 +77,69 @@ class TestDetectProvider:
 
     def test_anthropic_fallback(self):
         assert _detect_provider("v1/unknown/path") == "anthropic"
+
+
+class TestChatGPTModeBearerDetection:
+    """ChatGPT-mode JWTs (eyJ…) versus OpenAI sk-* keys versus empty/anthropic."""
+
+    def test_chatgpt_jwt_with_bearer_prefix(self):
+        assert _is_chatgpt_mode_bearer("Bearer eyJhbGciOiJSUzI1NiIs.payload.sig") is True
+
+    def test_chatgpt_jwt_without_prefix(self):
+        assert _is_chatgpt_mode_bearer("eyJhbGciOiJSUzI1NiIs.payload.sig") is True
+
+    def test_openai_sk_key_is_not_chatgpt(self):
+        assert _is_chatgpt_mode_bearer("Bearer sk-proj-abc123") is False
+
+    def test_anthropic_sk_ant_is_not_chatgpt(self):
+        assert _is_chatgpt_mode_bearer("Bearer sk-ant-oat01-abc") is False
+
+    def test_empty_header(self):
+        assert _is_chatgpt_mode_bearer("") is False
+
+
+class TestMaybeRerouteOpenAIToCodex:
+    """Reroute /v1/responses to /codex/responses when caller uses ChatGPT JWT."""
+
+    def test_v1_responses_with_chatgpt_jwt_reroutes(self):
+        provider, path = _maybe_reroute_openai_to_codex(
+            "openai", "v1/responses", "Bearer eyJhbGciOi.payload.sig"
+        )
+        assert provider == "codex"
+        assert path == "codex/responses"
+
+    def test_v1_responses_with_sk_key_passes_through(self):
+        provider, path = _maybe_reroute_openai_to_codex(
+            "openai", "v1/responses", "Bearer sk-proj-abc"
+        )
+        assert provider == "openai"
+        assert path == "v1/responses"
+
+    def test_v1_responses_with_no_auth_passes_through(self):
+        provider, path = _maybe_reroute_openai_to_codex("openai", "v1/responses", "")
+        assert provider == "openai"
+        assert path == "v1/responses"
+
+    def test_chat_completions_is_unaffected(self):
+        provider, path = _maybe_reroute_openai_to_codex(
+            "openai", "v1/chat/completions", "Bearer eyJhbGciOi.payload.sig"
+        )
+        assert provider == "openai"
+        assert path == "v1/chat/completions"
+
+    def test_anthropic_provider_unaffected(self):
+        provider, path = _maybe_reroute_openai_to_codex(
+            "anthropic", "v1/messages", "Bearer eyJhbGciOi.payload.sig"
+        )
+        assert provider == "anthropic"
+        assert path == "v1/messages"
+
+    def test_codex_provider_unaffected(self):
+        provider, path = _maybe_reroute_openai_to_codex(
+            "codex", "codex/responses", "Bearer eyJhbGciOi.payload.sig"
+        )
+        assert provider == "codex"
+        assert path == "codex/responses"
 
 
 class _FakeSpan:


### PR DESCRIPTION
## Summary

- OpenClaw's `openai-codex` provider always emits `POST /v1/responses` regardless of the configured upstream base URL. When the bearer token is a ChatGPT-mode JWT (`eyJ...`) rather than an `sk-*` API key, `api.openai.com` rejects the call — those tokens only work against `chatgpt.com/backend-api/codex/*`.
- This change detects JWT-shaped bearer tokens hitting `/v1/responses` in the proxy and reroutes them to `codex/responses` (which already dispatches to the ChatGPT backend). `sk-*` API keys and the `chat/completions` surface are unchanged.
- All other providers (`anthropic`, `codex`, etc.) pass through untouched.

## Why

OpenClaw users running ChatGPT subscription auth through the agentweave proxy currently get auth-rejected at OpenAI. Without this reroute, the only workaround is to hand-edit the openclaw provider catalog to point at `codex/responses`, which fights the plugin's normalization.

## Implementation

- `_is_chatgpt_mode_bearer(auth_header)` — true iff token starts with `eyJ` and not `sk-` (Anthropic `sk-ant-*` keys are explicitly excluded by the `sk-` check).
- `_maybe_reroute_openai_to_codex(provider, path, auth_header)` — narrow rewrite for `provider == "openai" && path == "v1/responses" && JWT bearer`. Returns `(provider, path)`; no-op for everything else.
- Wired into the request handler immediately after `_detect_provider`, so `_extract_model`, streaming detection, and upstream URL building all see the rewritten provider/path.

## Test plan

- [x] Added `TestChatGPTModeBearerDetection` (5 cases): JWT with/without `Bearer ` prefix, `sk-*` keys, `sk-ant-*`, empty header.
- [x] Added `TestMaybeRerouteOpenAIToCodex` (6 cases): reroute happy path, sk-key passthrough, no-auth passthrough, `chat/completions` unaffected, `anthropic` unaffected, `codex` provider unaffected.
- [x] Existing 162-test suite still passes.
- [x] End-to-end verification against a live OpenClaw codex session is pending — see openclaw-side silent-skip investigation (codex provider currently never emits `/v1/responses` traffic to exercise this path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)