### PR TITLE
feat(proxy): emit prov.cwd and prov.repository on spans

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -52,6 +52,7 @@ import asyncio
 import hashlib
 from collections import OrderedDict
 import json
+import pathlib
 import logging
 import os
 import re
@@ -1726,6 +1727,20 @@ def _maybe_set_response_preview(span: Any, text: str) -> None:
 # Request attributes
 # ---------------------------------------------------------------------------
 
+def _detect_repository_name(cwd: str | None) -> str | None:
+    """Return nearest enclosing git repository name for cwd, if any."""
+    if not cwd:
+        return None
+    try:
+        p = pathlib.Path(cwd).resolve()
+        for candidate in (p, *p.parents):
+            if (candidate / ".git").exists():
+                return candidate.name or None
+    except Exception:
+        return None
+    return None
+
+
 def _set_request_attrs(
     span: Any, model: str, provider: str, agent_id: str, agent_model: str,
     path: str, body: dict,
@@ -1752,6 +1767,14 @@ def _set_request_attrs(
         span.set_attribute(schema.PROV_SESSION_TURN, turn)
     if det_trace_id_raw is not None:
         span.set_attribute(schema.AGENTWEAVE_TRACE_ID, det_trace_id_raw)
+
+    # Invocation environment context (issue #181)
+    cwd = os.getenv("PWD") or os.getcwd()
+    if cwd:
+        span.set_attribute(schema.PROV_CWD, cwd)
+        repository = _detect_repository_name(cwd)
+        if repository:
+            span.set_attribute(schema.PROV_REPOSITORY, repository)
 
     # Sub-agent attribution (issue #15)
     if parent_session_id is not None:

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -50,6 +50,8 @@ PROV_SESSION_TURN = "prov.session.turn"
 PROV_PARENT_SESSION_ID = "prov.parent.session.id"  # ID of parent session that spawned this sub-agent
 PROV_AGENT_TYPE = "prov.agent.type"                 # "main" | "subagent" | "delegated"
 PROV_TASK_LABEL = "prov.task.label"                 # human-readable task label for session
+PROV_CWD = "prov.cwd"                               # caller working directory
+PROV_REPOSITORY = "prov.repository"                 # enclosing git repository name
 
 # Agent type constants
 AGENT_TYPE_MAIN = "main"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -27,6 +27,7 @@ from agentweave.proxy import (
     _set_google_response_attrs,
     _set_openai_response_attrs,
     _set_request_attrs,
+    _detect_repository_name,
     _anthropic_response_text,
     _google_response_text,
     _SKIP_HEADERS_ALWAYS,
@@ -2083,3 +2084,61 @@ class TestParentLinkResolution:
         block = src[idx: idx + 800]
         assert "AGENTWEAVE_PARENT_TRACE_ID" not in block
         assert "AGENTWEAVE_PARENT_SPAN_ID" not in block
+
+class TestRepositoryDetection:
+    def test_detect_repository_name_finds_nearest_git_root(self, tmp_path):
+        repo = tmp_path / "repo-a"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        nested = repo / "sub" / "deep"
+        nested.mkdir(parents=True)
+
+        assert _detect_repository_name(str(nested)) == "repo-a"
+
+    def test_detect_repository_name_returns_none_when_not_in_repo(self, tmp_path):
+        d = tmp_path / "no-repo"
+        d.mkdir()
+        assert _detect_repository_name(str(d)) is None
+
+
+class TestSetRequestAttrsCwdRepository:
+    def test_sets_prov_cwd_and_optional_repository(self, monkeypatch, tmp_path):
+        repo = tmp_path / "myproj"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        monkeypatch.setenv("PWD", str(repo))
+
+        span = _FakeSpan()
+        _set_request_attrs(
+            span,
+            model="gpt-4o",
+            provider="openai",
+            agent_id="nix-v1",
+            agent_model="gpt-4o",
+            path="v1/responses",
+            body={},
+        )
+
+        assert span.attrs["prov.cwd"] == str(repo)
+        assert span.attrs["prov.repository"] == "myproj"
+
+    def test_sets_only_prov_cwd_when_no_repo(self, monkeypatch, tmp_path):
+        d = tmp_path / "scratch"
+        d.mkdir()
+
+        monkeypatch.setenv("PWD", str(d))
+
+        span = _FakeSpan()
+        _set_request_attrs(
+            span,
+            model="gpt-4o",
+            provider="openai",
+            agent_id="nix-v1",
+            agent_model="gpt-4o",
+            path="v1/responses",
+            body={},
+        )
+
+        assert span.attrs["prov.cwd"] == str(d)
+        assert "prov.repository" not in span.attrs

--- a/sdk/python/tests/test_schema.py
+++ b/sdk/python/tests/test_schema.py
@@ -48,6 +48,8 @@ class TestProvAttributes:
         assert schema.PROV_SESSION_ID == "prov.session.id"
         assert schema.PROV_PROJECT == "prov.project"
         assert schema.PROV_SESSION_TURN == "prov.session.turn"
+        assert schema.PROV_CWD == "prov.cwd"
+        assert schema.PROV_REPOSITORY == "prov.repository"
 
     def test_all_prov_attributes_start_with_prov(self):
         """All PROV_ constants should have values starting with 'prov.'."""


### PR DESCRIPTION
Closes #181

## What changed
- Added two new span attributes in the Python schema:
  - `prov.cwd`
  - `prov.repository`
- Proxy now sets `prov.cwd` on every LLM span from the proxy process invocation directory.
- Proxy now attempts to derive `prov.repository` by walking up from `cwd` to the nearest `.git` directory and emitting the repo directory name when found.

## Tests
- Updated schema constant coverage.
- Added proxy tests for:
  - repository detection helper
  - `prov.cwd` emission
  - conditional `prov.repository` emission

## Verification
```bash
pytest -q sdk/python/tests/test_schema.py sdk/python/tests/test_proxy.py -k 'cwd or repository'
```

Result:
- `4 passed, 171 deselected in 0.24s`

## Notes
- `prov.repository` is optional by design and omitted when no enclosing git repo is found.
