### PR TITLE
fix(#189): explicit headers beat legacy global force; bridge subagent POSTs use session_key

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -11,6 +11,7 @@
 - Reads `AGENTWEAVE_AGENT_TYPE` from env — auto-tags spans with `prov.agent.type`
 - Session context via `POST /session` or env vars: `AGENTWEAVE_SESSION_ID`, `AGENTWEAVE_PARENT_SESSION_ID`, `AGENTWEAVE_TASK_LABEL`, `AGENTWEAVE_AGENT_TYPE`
 - Prefer per-session-key isolation for concurrent agents: include `session_key` in `POST /session` and send `x-agentweave-session-key` + optional `x-agentweave-task-label` on each proxied LLM request
+- Attribution precedence: explicit per-request headers beat legacy global forced context (issue #189). For delegated Claude Code launches, use `scripts/claude-delegate.sh`. See `docs/attribution-runbook.md`.
 - Sub-agent attribution: `prov.parent.session.id`, `prov.agent.type`, `prov.task.label`
 - traceparent passthrough: reads incoming `traceparent` header, sets `prov.trace.parent` on span, forwards downstream
 - Benchmarks: ~6ms p50 overhead on LLM calls (<2%)

--- a/docs/attribution-runbook.md
+++ b/docs/attribution-runbook.md
@@ -1,0 +1,76 @@
+# Attribution Runbook
+
+How AgentWeave assigns `prov.agent.id`, `prov.session.id`, etc. to every LLM
+span, and how to diagnose missing/wrong attribution.
+
+## Resolution order (`sdk/python/agentweave/proxy.py:_resolve_attrs`)
+
+For each attribute (`agent_id`, `session_id`, `task_label`,
+`parent_session_id`, `agent_type`, `project`), the proxy resolves in this
+order — first non-empty value wins:
+
+1. **Per-key forced context** — if the request carries
+   `X-AgentWeave-Session-Key: <k>` and `<k>` is in
+   `_forced_session_contexts`, the stored value wins. This is the
+   bridge-driven subagent path: caller opts in by sending the matching key.
+2. **Subagent env vars** — if `AGENTWEAVE_AGENT_TYPE=subagent` is set in
+   the proxy process env, `AGENTWEAVE_<ATTR>` is used.
+3. **Explicit request header** — `X-AgentWeave-Agent-Id`,
+   `X-AgentWeave-Session-Id`, `X-AgentWeave-Task-Label`,
+   `X-AgentWeave-Parent-Session-Id`, `X-AgentWeave-Agent-Type`,
+   `X-AgentWeave-Project`.
+4. **Legacy global forced context** — if `_session_context_force` is set
+   globally (legacy callers that POST `/session` without `session_key`),
+   the stored value is used as a low-priority fallback. This intentionally
+   ranks BELOW explicit headers so unrelated callers are not hijacked
+   (issue #189).
+5. **Proxy process env** — `AGENTWEAVE_<ATTR>` without subagent mode.
+6. **Static config** — `agentweave.yaml`.
+7. **Sentinel** — `"unattributed"` for `agent_id`; `None` for the rest.
+
+## `unattributed` vs `unknown` on the dashboard
+
+| Bucket | Meaning | What to look at |
+|---|---|---|
+| `unattributed` | Proxy explicitly stamped this — the resolution chain reached step 7 because nothing was supplied. | Caller is not sending attribution. Either set `AGENTWEAVE_AGENT_ID` env or use `scripts/claude-delegate.sh`. |
+| `unknown` | Dashboard / Prometheus side — the label was dropped or the metric was emitted before `prov.agent.id` existed on the span. | spanmetrics processor config, Prometheus relabel rules, or a span that bypassed the proxy entirely. Pull the trace from Tempo to confirm. |
+
+## Finding offending traces
+
+```bash
+# Traces with no prov.agent.id at all (last 1h)
+curl -s 'http://192.168.1.70:30418/api/search' \
+  --get \
+  --data-urlencode 'q={resource.service.name="agentweave-proxy" && !prov.agent.id}' \
+  --data-urlencode 'limit=20' | jq '.traces[]|{traceID,rootServiceName,startTimeUnixNano}'
+
+# Traces stamped as `unattributed`
+curl -s 'http://192.168.1.70:30418/api/search' \
+  --get \
+  --data-urlencode 'q={prov.agent.id="unattributed"}' \
+  --data-urlencode 'limit=20' | jq '.traces[]|.traceID'
+```
+
+If `prov.agent.id="unattributed"` appears for a known caller, the caller
+is not sending attribution at all. If `unknown` appears on the dashboard
+but Tempo shows `prov.agent.id` on the span, the gap is in
+spanmetrics/Prometheus — check the collector pipeline.
+
+## Delegated Claude Code launches
+
+For any work delegated to Claude Code (Nix → Claude Code, manual sub-tasks,
+dryruns), use `scripts/claude-delegate.sh` rather than handcrafted
+`ANTHROPIC_CUSTOM_HEADERS`. Static global settings in
+`~/.claude/settings.json` are fine for interactive use but are too coarse
+for delegated work — every delegated session would collapse into the same
+`claude-code-main`.
+
+```bash
+scripts/claude-delegate.sh \
+  --agent-id   claude-code-nas-subagent \
+  --session-id "claude-code-mux-67-$(date +%Y%m%d-%H%M%S)" \
+  --parent     nix-main \
+  --project    mux \
+  --task       "mux issue 67 openclaw routing" \
+  -- --dangerously-skip-permissions --model claude-sonnet-4-6 --print "<task>"
+```

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -353,10 +353,15 @@ export function createAgentWeaveBridgeService() {
                   // Force the proxy to attribute LLM calls to this sub-agent session
                   const proxyUrl = normalizeProxyBaseUrl(config.proxyUrl) || "http://192.168.1.70:30400"
                   const mainSessionId = mainKey ? (activeTurns.get(mainKey)?.span as any)?._attributes?.["session.id"] || "nix-main" : "nix-main"
+                  // Issue #189: include session_key so the proxy stores this
+                  // forced context per-key in _forced_session_contexts, instead
+                  // of toggling the legacy global _session_context_force flag
+                  // (which would hijack attribution for unrelated callers).
                   fetch(`${proxyUrl}/session`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
+                      session_key: sessionKey,
                       session_id: sessionId,
                       parent_session_id: mainSessionId,
                       agent_id: subagentId,
@@ -378,12 +383,17 @@ export function createAgentWeaveBridgeService() {
                   turn.span.end()
                   activeTurns.delete(sessionKey)
 
-                  // Restore proxy to main session (clear force)
+                  // Restore proxy to main session — clear the per-key forced
+                  // context for this sessionKey (issue #189). force:false +
+                  // matching session_key removes the entry from
+                  // _forced_session_contexts without touching the legacy
+                  // global flag.
                   const proxyUrl = normalizeProxyBaseUrl(config.proxyUrl) || "http://192.168.1.70:30400"
                   fetch(`${proxyUrl}/session`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
+                      session_key: sessionKey,
                       session_id: "nix-main",
                       agent_type: "main",
                       force: false,

--- a/plugins/openclaw-agentweave-bridge/test/stubs/openclaw-plugin-sdk-diagnostic-runtime.ts
+++ b/plugins/openclaw-agentweave-bridge/test/stubs/openclaw-plugin-sdk-diagnostic-runtime.ts
@@ -1,0 +1,32 @@
+// Test-only stub for the host-provided `openclaw/plugin-sdk/diagnostic-runtime`
+// module. At runtime in OpenClaw, the host injects the real module; under
+// vitest there is nothing to inject, so this stub is aliased in via
+// vitest.config.ts.
+//
+// The test harness in service.test.ts fires events by walking
+// `globalThis.__openclawDiagnosticEventsState.listeners` — the same global
+// singleton the plugin used to write to directly before the plugin-sdk
+// hand-off. We register listeners into that same state so existing tests
+// keep working.
+
+interface DiagnosticEventsState {
+  listeners: Set<(evt: unknown) => void>
+}
+
+function getState(): DiagnosticEventsState {
+  const g = globalThis as Record<string, unknown>
+  let state = g.__openclawDiagnosticEventsState as DiagnosticEventsState | undefined
+  if (!state) {
+    state = { listeners: new Set() }
+    g.__openclawDiagnosticEventsState = state
+  }
+  return state
+}
+
+export function onDiagnosticEvent(listener: (evt: unknown) => void): () => void {
+  const state = getState()
+  state.listeners.add(listener)
+  return () => {
+    state.listeners.delete(listener)
+  }
+}

--- a/plugins/openclaw-agentweave-bridge/vitest.config.ts
+++ b/plugins/openclaw-agentweave-bridge/vitest.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from "vitest/config"
+import path from "node:path"
 
+// The plugin imports `openclaw/plugin-sdk/diagnostic-runtime` at runtime from
+// the host OpenClaw process, which is not present in the plugin's local
+// node_modules. Alias it to a no-op stub so vitest can load service.ts.
 export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "openclaw/plugin-sdk/diagnostic-runtime": path.resolve(
+        __dirname,
+        "test/stubs/openclaw-plugin-sdk-diagnostic-runtime.ts",
+      ),
+    },
   },
 })

--- a/scripts/claude-delegate.sh
+++ b/scripts/claude-delegate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Wrapper that launches Claude Code through AgentWeave with consistent,
+# explicit per-session attribution headers. Use this for any DELEGATED
+# Claude Code work (Nix → Claude Code, manual sub-tasks, dryruns) so model
+# calls are correctly tagged in AgentWeave instead of inheriting the global
+# settings.json defaults.
+#
+# Usage:
+#   scripts/claude-delegate.sh \
+#     --agent-id   claude-code-nas-subagent \
+#     --session-id "claude-code-mux-67-$(date +%Y%m%d-%H%M%S)" \
+#     --parent     nix-main \
+#     --project    mux \
+#     --task       "mux issue 67 openclaw routing" \
+#     -- --dangerously-skip-permissions --model claude-sonnet-4-6 --print "<task>"
+#
+# Defaults that can be overridden via env:
+#   AGENTWEAVE_PROXY_URL  (default: http://192.168.1.70:30400)
+#   CLAUDE_BIN            (default: claude)
+#
+# Anything after `--` is forwarded to claude as-is.
+
+set -euo pipefail
+
+PROXY_URL="${AGENTWEAVE_PROXY_URL:-http://192.168.1.70:30400}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+
+agent_id=""
+session_id=""
+parent=""
+project=""
+task_label=""
+
+usage() {
+  sed -n '2,22p' "$0" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent-id)   agent_id="$2";   shift 2 ;;
+    --session-id) session_id="$2"; shift 2 ;;
+    --parent)     parent="$2";     shift 2 ;;
+    --project)    project="$2";    shift 2 ;;
+    --task)       task_label="$2"; shift 2 ;;
+    --proxy-url)  PROXY_URL="$2";  shift 2 ;;
+    -h|--help)    usage ;;
+    --)           shift; break ;;
+    *)            echo "claude-delegate: unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$agent_id" || -z "$session_id" ]]; then
+  echo "claude-delegate: --agent-id and --session-id are required" >&2
+  usage
+fi
+
+# Build the multiline ANTHROPIC_CUSTOM_HEADERS block. claude reads this and
+# emits each line as an HTTP header on every Anthropic API request — that
+# is the only knob the Claude Code CLI exposes for per-process attribution.
+headers="X-AgentWeave-Agent-Id: ${agent_id}
+X-AgentWeave-Session-Id: ${session_id}"
+[[ -n "$parent"     ]] && headers+=$'\n'"X-AgentWeave-Parent-Session-Id: ${parent}"
+[[ -n "$project"    ]] && headers+=$'\n'"X-AgentWeave-Project: ${project}"
+[[ -n "$task_label" ]] && headers+=$'\n'"X-AgentWeave-Task-Label: ${task_label}"
+
+ANTHROPIC_BASE_URL="$PROXY_URL" \
+ANTHROPIC_CUSTOM_HEADERS="$headers" \
+  exec "$CLAUDE_BIN" "$@"

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -992,15 +992,25 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         else None
     )
     _is_subagent_env = os.getenv("AGENTWEAVE_AGENT_TYPE", "").lower() == "subagent"
-    # _force is True when either a per-key override or the legacy global flag is active.
-    _force = bool(_forced_ctx is not None) or _session_context_force
+    # Issue #189: split per-key force from legacy global force.
+    # _force_per_key: request carries a session_key matching a stored forced
+    #   context — caller explicitly opted in, so this wins over per-request
+    #   headers (preserves bridge-driven subagent attribution).
+    # _force_legacy: legacy global _session_context_force flag is set, but the
+    #   request did NOT match a per-key context. Treat as a low-priority
+    #   FALLBACK only: explicit per-request headers must win, otherwise
+    #   unrelated callers get hijacked by whichever subagent the bridge
+    #   most recently forced (the original #189 symptom).
+    _force_per_key = _forced_ctx is not None
+    _force_legacy = _session_context_force and not _force_per_key
     # _active_ctx is the context dict to read forced attributes from.
-    _active_ctx: dict[str, str] = _forced_ctx if _forced_ctx is not None else _session_context
+    _active_ctx: dict[str, str] = _forced_ctx if _force_per_key else _session_context
 
     agent_id = (
-        (_active_ctx.get("prov.agent.id") if _force else None)
+        (_active_ctx.get("prov.agent.id") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_AGENT_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-id")
+        or (_active_ctx.get("prov.agent.id") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_AGENT_ID")
         or _config_value("agent_id")
         or "unattributed"
@@ -1012,17 +1022,25 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     )
 
     session_id = (
-        (_active_ctx.get("prov.session.id") if _force else None)
+        (_active_ctx.get("prov.session.id") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-session-id")
+        or (_active_ctx.get("prov.session.id") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_SESSION_ID")
     )
     # Only use explicitly set project — do NOT infer from agent_id prefix.
     # Use AGENTWEAVE_PROJECT env var or X-AgentWeave-Project header.
-    project = request.headers.get("x-agentweave-project") or os.getenv("AGENTWEAVE_PROJECT") or None
+    project = (
+        request.headers.get("x-agentweave-project")
+        or (_active_ctx.get("prov.project") if _force_per_key else None)
+        or os.getenv("AGENTWEAVE_PROJECT")
+        or (_active_ctx.get("prov.project") if _force_legacy else None)
+        or None
+    )
     task_label: str | None = (
-        (_active_ctx.get("prov.task.label") if _force else None)
+        (_active_ctx.get("prov.task.label") if _force_per_key else None)
         or request.headers.get("x-agentweave-task-label")
+        or (_active_ctx.get("prov.task.label") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_TASK_LABEL")
         or None
     )
@@ -1057,16 +1075,18 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
 
     # Sub-agent attribution headers (issue #15)
     parent_session_id: str | None = (
-        (_active_ctx.get("prov.parent.session.id") if _force else None)
+        (_active_ctx.get("prov.parent.session.id") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_PARENT_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-parent-session-id")
+        or (_active_ctx.get("prov.parent.session.id") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_PARENT_SESSION_ID")
         or None
     )
     agent_type: str | None = (
-        (_active_ctx.get("prov.agent.type") if _force else None)
+        (_active_ctx.get("prov.agent.type") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_AGENT_TYPE") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-type")
+        or (_active_ctx.get("prov.agent.type") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_AGENT_TYPE")
         or None
     )
@@ -1153,6 +1173,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         traceparent=traceparent,
         parent_span_id_raw=parent_span_id_raw,
         parent_trace_id_raw=parent_trace_id_raw,
+        task_label=task_label,
     )
 
     try:

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1281,6 +1281,154 @@ class TestForcedSessionContextRace:
         """x-agentweave-task-label must not be forwarded upstream."""
         assert "x-agentweave-task-label" in _SKIP_HEADERS_ALWAYS
 
+    def test_legacy_global_force_does_not_override_explicit_header(self, monkeypatch):
+        """Issue #189: when ONLY the legacy global force flag is set (no per-key
+        match) and the request carries an explicit X-AgentWeave-Agent-Id, the
+        explicit header MUST win — otherwise unrelated callers (e.g. a Claude
+        Code Mac dryrun) get hijacked into whatever subagent the bridge most
+        recently forced (e.g. nix-v1).
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        from agentweave.config import AgentWeaveConfig
+
+        # Legacy global force is on, with a global ctx pinning agent_id=nix-v1
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
+        monkeypatch.setattr(proxy_module, "_session_context", {
+            "prov.session.id": "claude-code-main",
+            "prov.agent.id": "nix-v1",
+            "prov.task.label": "subagent agent",
+            "prov.project": "claude-code",
+            "prov.parent.session.id": "nix-main",
+            "prov.agent.type": "subagent",
+        })
+        monkeypatch.setattr(proxy_module, "_session_context_force", True)
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+
+        captured: list[dict] = []
+        original_set_request_attrs = proxy_module._set_request_attrs
+
+        def _capturing(span, **kwargs):
+            captured.append({
+                "session_id": kwargs.get("session_id"),
+                "agent_id": kwargs.get("agent_id"),
+                "task_label": kwargs.get("task_label"),
+                "project": kwargs.get("project"),
+                "parent_session_id": kwargs.get("parent_session_id"),
+                "agent_type": kwargs.get("agent_type"),
+            })
+            return original_set_request_attrs(span, **kwargs)
+
+        fake_data = {
+            "id": "msg3", "type": "message", "role": "assistant", "content": [],
+            "model": "claude-3-haiku-20240307", "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        fake_resp = MagicMock(spec=httpx.Response)
+        fake_resp.status_code = 200
+        fake_resp.headers = {}
+        fake_resp.json.return_value = fake_data
+
+        client_instance = AsyncMock()
+        client_instance.request = AsyncMock(return_value=fake_resp)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client_instance)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm), \
+             patch.object(proxy_module, "_set_request_attrs", side_effect=_capturing):
+            client = TestClient(app)
+            # Mac dryrun: explicit headers, NO session_key
+            client.post(
+                "/v1/messages",
+                json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
+                      "messages": [{"role": "user", "content": "hi"}]},
+                headers={
+                    "x-api-key": "sk-ant-test",
+                    "x-agentweave-agent-id": "claude-code-mac-subagent",
+                    "x-agentweave-session-id": "claude-code-nexus-dryrun-20260510",
+                    "x-agentweave-task-label": "nexus dryrun",
+                    "x-agentweave-project": "nexus",
+                    "x-agentweave-parent-session-id": "nix-main",
+                    "x-agentweave-agent-type": "subagent",
+                },
+            )
+
+        assert len(captured) >= 1
+        c = captured[0]
+        assert c["agent_id"] == "claude-code-mac-subagent", (
+            f"Explicit header must beat legacy global force, got: {c['agent_id']!r}"
+        )
+        assert c["session_id"] == "claude-code-nexus-dryrun-20260510"
+        assert c["task_label"] == "nexus dryrun"
+        assert c["project"] == "nexus"
+        assert c["parent_session_id"] == "nix-main"
+        assert c["agent_type"] == "subagent"
+
+    def test_legacy_global_force_fills_attrs_when_header_missing(self, monkeypatch):
+        """Issue #189: legacy global force still acts as a fallback for
+        attributes the request does NOT supply — preserves backward compat
+        for the few legacy callers that have not migrated to session_key.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+        import httpx
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+        from agentweave.config import AgentWeaveConfig
+
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
+        monkeypatch.setattr(proxy_module, "_session_context", {
+            "prov.session.id": "legacy-fallback-sess",
+            "prov.agent.id": "legacy-fallback-agent",
+        })
+        monkeypatch.setattr(proxy_module, "_session_context_force", True)
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+
+        captured: list[dict] = []
+        original_set_request_attrs = proxy_module._set_request_attrs
+
+        def _capturing(span, **kwargs):
+            captured.append({
+                "session_id": kwargs.get("session_id"),
+                "agent_id": kwargs.get("agent_id"),
+            })
+            return original_set_request_attrs(span, **kwargs)
+
+        fake_data = {
+            "id": "msg4", "type": "message", "role": "assistant", "content": [],
+            "model": "claude-3-haiku-20240307", "stop_reason": "end_turn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        fake_resp = MagicMock(spec=httpx.Response)
+        fake_resp.status_code = 200
+        fake_resp.headers = {}
+        fake_resp.json.return_value = fake_data
+
+        client_instance = AsyncMock()
+        client_instance.request = AsyncMock(return_value=fake_resp)
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client_instance)
+        cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm), \
+             patch.object(proxy_module, "_set_request_attrs", side_effect=_capturing):
+            client = TestClient(app)
+            # No attribution headers — fallback chain should fill from legacy ctx
+            client.post(
+                "/v1/messages",
+                json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
+                      "messages": [{"role": "user", "content": "hi"}]},
+                headers={"x-api-key": "sk-ant-test"},
+            )
+
+        assert len(captured) >= 1
+        assert captured[0]["agent_id"] == "legacy-fallback-agent"
+        assert captured[0]["session_id"] == "legacy-fallback-sess"
+
     def test_legacy_force_without_key_still_works(self, monkeypatch):
         """Backward compat: POST /session with force:true and no session_key sets global flag."""
         from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary

Closes #189. Three intertwined fixes restore correct attribution for delegated Claude Code sessions and any non-Nix caller running through the proxy:

- **Proxy precedence** (`sdk/python/agentweave/proxy.py`): split `_force` into `_force_per_key` (authoritative — caller opted in via matching `x-agentweave-session-key`) and `_force_legacy` (fallback only). Explicit per-request headers now win over the legacy global `_session_context_force` flag — so a bridge subagent turn no longer hijacks attribution for unrelated callers (the original #189 symptom: Mac dryrun stamped as `nix-v1`).
- **Bridge subagent POSTs** (`plugins/openclaw-agentweave-bridge/src/service.ts`): the two subagent-lifecycle `/session` POSTs at start/end were still on the legacy global path. Both now include `session_key: sessionKey`, so forced context lands in `_forced_session_contexts` per-key and the global flag stays off.
- **`task_label` threading**: PR #185 added the parameter to `_request_and_trace` / `_stream_and_trace` / `_set_request_attrs` but the kwargs dict that calls them never forwarded it — `task_label` was always `None` in the live flow. Fixed.

## Tooling and docs

- `scripts/claude-delegate.sh` — wrapper that builds `ANTHROPIC_CUSTOM_HEADERS` from named args (`--agent-id`, `--session-id`, `--parent`, `--project`, `--task`). Use for any delegated Claude Code launch instead of handcrafted multiline env strings.
- `docs/attribution-runbook.md` — documents the resolution order, the `unattributed` vs `unknown` distinction, and Tempo queries for finding traces missing `prov.agent.id`.
- `docs/STATUS.md` — short pointer.

## Tests

- New regression `test_legacy_global_force_does_not_override_explicit_header` reproduces the #189 symptom and asserts the explicit header wins.
- Compat test `test_legacy_global_force_fills_attrs_when_header_missing` asserts the legacy global is still used as fallback when no header is sent.
- Full suite: 455 passed; 2 pre-existing `test_prompts.py` network failures unrelated to this change (confirmed by `git stash` baseline).

## Scope notes

- **Follow-up issue tracked separately** for eventually deprecating the legacy `_session_context_force` global path entirely (risky — depends on all callers being migrated; will file after this merges).
- Bridge changes activate only after OpenClaw reloads the plugin from its installed path — proxy deploy alone covers the precedence + `task_label` fixes; bridge restart is needed to fix the lingering global-force-on-subagent-start issue at the source.

## Test plan

- [x] `pytest sdk/python/tests/` — green
- [x] Targeted: `TestForcedSessionContextRace` (10/10)
- [x] Wrapper script: `printenv` verified `ANTHROPIC_BASE_URL` + multiline `ANTHROPIC_CUSTOM_HEADERS`
- [ ] Post-merge: deploy proxy, dryrun a delegated Claude Code call with `claude-delegate.sh`, confirm Tempo shows the explicit `prov.agent.id`/`prov.session.id` rather than `nix-v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)