### PR TITLE
fix(#189): claude-delegate.sh uses private HOME so attribution actually applies

### DIFF
--- a/scripts/claude-delegate.sh
+++ b/scripts/claude-delegate.sh
@@ -5,6 +5,14 @@
 # calls are correctly tagged in AgentWeave instead of inheriting the global
 # settings.json defaults.
 #
+# Why this exists at all: Claude Code's settings.json `env` block is
+# applied AFTER process-env on startup, so an interactive
+# `ANTHROPIC_CUSTOM_HEADERS=... claude ...` invocation silently loses to
+# whatever is in `~/.claude/settings.json`. This wrapper sidesteps that by
+# running Claude with a private HOME directory that contains a minimal
+# settings.json (just our env block + skipAutoPermissionPrompt) and
+# symlinks to the real auth/skills/plugins/agents so Claude still works.
+#
 # Usage:
 #   scripts/claude-delegate.sh \
 #     --agent-id   claude-code-nas-subagent \
@@ -14,9 +22,10 @@
 #     --task       "mux issue 67 openclaw routing" \
 #     -- --dangerously-skip-permissions --model claude-sonnet-4-6 --print "<task>"
 #
-# Defaults that can be overridden via env:
+# Defaults overridable via env:
 #   AGENTWEAVE_PROXY_URL  (default: http://192.168.1.70:30400)
-#   CLAUDE_BIN            (default: claude)
+#   CLAUDE_BIN            (default: claude on PATH)
+#   CLAUDE_REAL_HOME      (default: $HOME — source of credentials/skills)
 #
 # Anything after `--` is forwarded to claude as-is.
 
@@ -24,29 +33,32 @@ set -euo pipefail
 
 PROXY_URL="${AGENTWEAVE_PROXY_URL:-http://192.168.1.70:30400}"
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+REAL_HOME="${CLAUDE_REAL_HOME:-$HOME}"
 
 agent_id=""
 session_id=""
 parent=""
 project=""
 task_label=""
+keep_temp_home=0
 
 usage() {
-  sed -n '2,22p' "$0" >&2
+  sed -n '2,30p' "$0" >&2
   exit 2
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --agent-id)   agent_id="$2";   shift 2 ;;
-    --session-id) session_id="$2"; shift 2 ;;
-    --parent)     parent="$2";     shift 2 ;;
-    --project)    project="$2";    shift 2 ;;
-    --task)       task_label="$2"; shift 2 ;;
-    --proxy-url)  PROXY_URL="$2";  shift 2 ;;
-    -h|--help)    usage ;;
-    --)           shift; break ;;
-    *)            echo "claude-delegate: unknown arg: $1" >&2; usage ;;
+    --agent-id)        agent_id="$2";   shift 2 ;;
+    --session-id)      session_id="$2"; shift 2 ;;
+    --parent)          parent="$2";     shift 2 ;;
+    --project)         project="$2";    shift 2 ;;
+    --task)            task_label="$2"; shift 2 ;;
+    --proxy-url)       PROXY_URL="$2";  shift 2 ;;
+    --keep-temp-home)  keep_temp_home=1; shift ;;
+    -h|--help)         usage ;;
+    --)                shift; break ;;
+    *)                 echo "claude-delegate: unknown arg: $1" >&2; usage ;;
   esac
 done
 
@@ -55,15 +67,48 @@ if [[ -z "$agent_id" || -z "$session_id" ]]; then
   usage
 fi
 
-# Build the multiline ANTHROPIC_CUSTOM_HEADERS block. claude reads this and
-# emits each line as an HTTP header on every Anthropic API request — that
-# is the only knob the Claude Code CLI exposes for per-process attribution.
+# Build the multiline ANTHROPIC_CUSTOM_HEADERS block.
 headers="X-AgentWeave-Agent-Id: ${agent_id}
 X-AgentWeave-Session-Id: ${session_id}"
 [[ -n "$parent"     ]] && headers+=$'\n'"X-AgentWeave-Parent-Session-Id: ${parent}"
 [[ -n "$project"    ]] && headers+=$'\n'"X-AgentWeave-Project: ${project}"
 [[ -n "$task_label" ]] && headers+=$'\n'"X-AgentWeave-Task-Label: ${task_label}"
 
+# Private HOME: contains only what Claude needs (auth + skills + plugins
+# + agents + commands + the cache for OAuth refresh tokens) plus a fresh
+# settings.json that sets our env block. This prevents the real
+# ~/.claude/settings.json from clobbering the headers via its own env block.
+TEMP_HOME="$(mktemp -d -t claude-delegate.XXXXXXXX)"
+mkdir -p "$TEMP_HOME/.claude"
+
+if [[ "$keep_temp_home" -ne 1 ]]; then
+  trap 'rm -rf "$TEMP_HOME"' EXIT
+fi
+
+# Symlink everything needed for Claude to authenticate + behave normally.
+# Whitelist rather than blanket-symlink so the real settings.json doesn't
+# leak in through any indirect path.
+for entry in .credentials.json .claude.json agents skills plugins commands mcp-needs-auth-cache.json statusline-command.sh hooks projects todos shell-snapshots; do
+  src="$REAL_HOME/.claude/$entry"
+  if [[ -e "$src" || -L "$src" ]]; then
+    ln -s "$src" "$TEMP_HOME/.claude/$entry"
+  fi
+done
+
+# Minimal settings.json with our env block.
+cat > "$TEMP_HOME/.claude/settings.json" <<JSON
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "${PROXY_URL}",
+    "ANTHROPIC_CUSTOM_HEADERS": $(printf '%s' "$headers" | jq -Rs .),
+    "AGENTWEAVE_PROXY_URL": "${PROXY_URL}"
+  },
+  "skipAutoPermissionPrompt": true
+}
+JSON
+
 ANTHROPIC_BASE_URL="$PROXY_URL" \
 ANTHROPIC_CUSTOM_HEADERS="$headers" \
+AGENTWEAVE_PROXY_URL="$PROXY_URL" \
+HOME="$TEMP_HOME" \
   exec "$CLAUDE_BIN" "$@"

--- a/scripts/validate-claude-delegate.sh
+++ b/scripts/validate-claude-delegate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# End-to-end validation for scripts/claude-delegate.sh.
+#
+# Runs a short Claude Code dry-call through the wrapper with a unique
+# session id, then queries Tempo for a span carrying that exact
+# prov.session.id. Fails the script if Tempo never sees the requested
+# session id within the timeout, or if the most recent matching span
+# instead shows the legacy nix-v1 / claude-code-nas-main attribution.
+#
+# Usage:
+#   scripts/validate-claude-delegate.sh [--prompt "..."] [--model claude-sonnet-4-6]
+#
+# Env:
+#   AGENTWEAVE_PROXY_URL  default: http://192.168.1.70:30400
+#   TEMPO_API_URL         default: http://192.168.1.70:31989
+#   CLAUDE_BIN            default: claude
+#   VALIDATE_TIMEOUT      default: 60 (seconds to wait for Tempo to index)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROXY_URL="${AGENTWEAVE_PROXY_URL:-http://192.168.1.70:30400}"
+TEMPO_URL="${TEMPO_API_URL:-http://192.168.1.70:31989}"
+CLAUDE_BIN_VAL="${CLAUDE_BIN:-claude}"
+TIMEOUT="${VALIDATE_TIMEOUT:-60}"
+
+PROMPT="say only the word OK"
+MODEL="claude-sonnet-4-6"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --model)  MODEL="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0" >&2; exit 2 ;;
+    *) echo "validate-claude-delegate: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+ts() { printf "[%s] %s\n" "$(date '+%H:%M:%S')" "$*"; }
+fail() { ts "FAIL: $*" >&2; exit 1; }
+
+SESSION_ID="claude-code-validate-$(date +%Y%m%d-%H%M%S)-$$"
+AGENT_ID="claude-code-nas-subagent"
+PROJECT="agentweave"
+PARENT="nix-validate"
+TASK="validate-claude-delegate dry run"
+
+ts "session_id=${SESSION_ID}"
+ts "running claude via wrapper"
+
+CLAUDE_BIN="$CLAUDE_BIN_VAL" "$REPO_ROOT/scripts/claude-delegate.sh" \
+  --agent-id "$AGENT_ID" \
+  --session-id "$SESSION_ID" \
+  --parent "$PARENT" \
+  --project "$PROJECT" \
+  --task "$TASK" \
+  --proxy-url "$PROXY_URL" \
+  -- --print --model "$MODEL" "$PROMPT" \
+  > /tmp/validate-claude-delegate.out 2>&1 \
+  || fail "claude exited non-zero: $(head -c 500 /tmp/validate-claude-delegate.out)"
+
+ts "claude returned: $(head -c 200 /tmp/validate-claude-delegate.out | tr -d '\n')"
+
+# Tempo indexes traces with a few-second delay. Poll until we see the
+# requested session id or hit the timeout.
+ts "polling Tempo for prov.session.id=${SESSION_ID}"
+deadline=$(( $(date +%s) + TIMEOUT ))
+trace_json=""
+while [[ $(date +%s) -lt $deadline ]]; do
+  trace_json=$(curl -s "${TEMPO_URL}/api/search" --get \
+    --data-urlencode "q={resource.service.name=\"agentweave-proxy\" && .prov.session.id=\"${SESSION_ID}\"}" \
+    --data-urlencode "limit=5" 2>/dev/null || true)
+  match_count=$(printf '%s' "$trace_json" | jq -r '.traces | length // 0' 2>/dev/null || echo 0)
+  if [[ "$match_count" -gt 0 ]]; then
+    break
+  fi
+  sleep 3
+done
+
+match_count=$(printf '%s' "$trace_json" | jq -r '.traces | length // 0' 2>/dev/null || echo 0)
+if [[ "$match_count" -eq 0 ]]; then
+  fail "Tempo never indexed a span with prov.session.id=${SESSION_ID} within ${TIMEOUT}s — wrapper attribution did NOT reach the proxy"
+fi
+
+# Pull the first matching span's full attribute set to confirm attribution.
+trace_id=$(printf '%s' "$trace_json" | jq -r '.traces[0].traceID')
+ts "found trace ${trace_id}; fetching span attrs"
+span_json=$(curl -s "${TEMPO_URL}/api/traces/${trace_id}" 2>/dev/null || true)
+attrs=$(printf '%s' "$span_json" | jq -r '
+  [ .batches[]?.scopeSpans[]?.spans[]?
+      | select(.attributes? != null)
+      | (.attributes[] | {key,value:(.value.stringValue // .value.intValue // .value.boolValue // null)})
+  ] | from_entries
+' 2>/dev/null || echo '{}')
+
+want() {
+  local key="$1" want="$2"
+  local got
+  got=$(printf '%s' "$attrs" | jq -r --arg k "$key" '.[$k] // empty')
+  if [[ "$got" != "$want" ]]; then
+    fail "$key expected=${want} got=${got:-<missing>}"
+  fi
+  ts "  OK ${key}=${got}"
+}
+
+want "prov.agent.id"          "$AGENT_ID"
+want "prov.session.id"        "$SESSION_ID"
+want "prov.parent.session.id" "$PARENT"
+want "prov.project"           "$PROJECT"
+want "prov.task.label"        "$TASK"
+
+ts "PASS — delegated attribution propagated end-to-end"


### PR DESCRIPTION
Re-opens / completes #189 after Nix's 14:21 PT re-check showed delegated Claude Code calls still landing as `prov.agent.id=nix-v1`.

## What was actually broken

Claude Code applies the \`env\` block from \`~/.claude/settings.json\` **after** process-env on startup, so any \`ANTHROPIC_CUSTOM_HEADERS\` set by the parent shell are silently clobbered by whatever the user's settings.json has. Today that's:

\`\`\`json
"env": {
  "ANTHROPIC_BASE_URL": "http://192.168.1.70:30400",
  "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-nas\\nX-AgentWeave-Session-Id: claude-code-nas-main\\n..."
}
\`\`\`

…which pins every delegated call back to \`claude-code-nas\` / \`claude-code-nas-main\`. The \`claude --settings <json>\` route Nix also tried exhibits the same merge ordering.

## Fix

\`scripts/claude-delegate.sh\` now creates a private HOME under \`/tmp\`, symlinks the credentials + skills/plugins/agents/hooks/projects/etc. the user expects, and writes a minimal \`.claude/settings.json\` with only the attribution env block. Process env is also set as belt-and-braces, but the temp-HOME is what guarantees correctness — \`~/.claude/settings.json\` is never read.

\`scripts/validate-claude-delegate.sh\` (new) runs a tiny dry Claude call through the wrapper with a unique session id, polls Tempo for a span carrying that \`prov.session.id\`, and asserts all five attribution attrs match.

## Validation

\`\`\`
[14:45:59] claude returned: OK
[14:46:17] found trace a0a59332ed6864962fd5a5e981fc243c
  OK prov.agent.id=claude-code-nas-subagent
  OK prov.session.id=claude-code-validate-20260510-144554-862638
  OK prov.parent.session.id=nix-validate
  OK prov.project=agentweave
  OK prov.task.label=validate-claude-delegate dry run
[14:46:18] PASS — delegated attribution propagated end-to-end
\`\`\`

## Residual finding

Before the validation passed, an even-deeper symptom surfaced: \`_session_context_force=true\` was still active in the proxy from a stale legacy POST during the 12:17→12:25 window when the proxy already had the #190 fix but openclaw hadn't yet reloaded the new bridge build. The keyed-path code does clear the flag, but bridge subagent turns send \`force:true\` keyed, so they don't go through the clear branch for the *legacy* flag. \`POST /session {"force":false}\` from outside cleared it. This is exactly what #191 is meant to eliminate by deprecating the legacy path entirely.

## Not in this PR (follow-up)

Native ACP Claude spawn (\`sessions_spawn{runtime:"acp", agentId:"claude"}\`) still fails before producing a usable transcript. Per Nix, it needs:
- \`HOME=/home/Arnab\` (openclaw's codex layer flips \`HOME\` into \`codex-home\`)
- \`PATH\` including \`/home/Arnab/.local/bin\`
- Pinned \`acpx 0.6.1\` (\`node_modules/.bin/acpx\`), not the stale \`.pnpm\` wrapper resolving to \`0.3.0\`

That's openclaw-source territory, separate from agentweave; I'll file it as a follow-up issue in the openclaw fork.

## Test plan

- [x] \`scripts/validate-claude-delegate.sh\` passes end-to-end
- [x] Wrapper produces correct temp HOME structure (verified via \`CLAUDE_BIN=cat\` dry-run)
- [x] Existing CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)