### PR TITLE
fix: harden Claude delegate attribution

### DIFF
--- a/scripts/claude-delegate.sh
+++ b/scripts/claude-delegate.sh
@@ -24,16 +24,36 @@
 #
 # Defaults overridable via env:
 #   AGENTWEAVE_PROXY_URL  (default: http://192.168.1.70:30400)
-#   CLAUDE_BIN            (default: claude on PATH)
-#   CLAUDE_REAL_HOME      (default: $HOME — source of credentials/skills)
+#   CLAUDE_BIN            (default: claude on PATH, then native install)
+#   CLAUDE_REAL_HOME      (default: $HOME, then /home/Arnab if needed)
 #
 # Anything after `--` is forwarded to claude as-is.
 
 set -euo pipefail
 
 PROXY_URL="${AGENTWEAVE_PROXY_URL:-http://192.168.1.70:30400}"
-CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 REAL_HOME="${CLAUDE_REAL_HOME:-$HOME}"
+
+if [[ -z "${CLAUDE_REAL_HOME:-}" && -e /home/Arnab/.claude.json && -e /home/Arnab/.claude/.credentials.json ]]; then
+  REAL_HOME="/home/Arnab"
+fi
+
+if [[ -n "${CLAUDE_BIN:-}" ]]; then
+  CLAUDE_CMD="$CLAUDE_BIN"
+elif command -v claude >/dev/null 2>&1; then
+  CLAUDE_CMD="claude"
+elif [[ -d "$REAL_HOME/.local/share/claude/versions" ]]; then
+  CLAUDE_CMD="$(ls -1t "$REAL_HOME/.local/share/claude/versions"/* 2>/dev/null | head -1 || true)"
+elif [[ -d /home/Arnab/.local/share/claude/versions ]]; then
+  CLAUDE_CMD="$(ls -1t /home/Arnab/.local/share/claude/versions/* 2>/dev/null | head -1 || true)"
+else
+  CLAUDE_CMD=""
+fi
+
+if [[ -z "$CLAUDE_CMD" || ! -x "$CLAUDE_CMD" ]]; then
+  echo "claude-delegate: Claude Code binary not found; set CLAUDE_BIN" >&2
+  exit 2
+fi
 
 agent_id=""
 session_id=""
@@ -95,6 +115,13 @@ for entry in .credentials.json .claude.json agents skills plugins commands mcp-n
   fi
 done
 
+# Claude Code keeps the main account/session metadata at ~/.claude.json
+# outside ~/.claude on native installs. Without this, the private HOME
+# starts unauthenticated even when the real profile is logged in.
+if [[ -e "$REAL_HOME/.claude.json" || -L "$REAL_HOME/.claude.json" ]]; then
+  ln -s "$REAL_HOME/.claude.json" "$TEMP_HOME/.claude.json"
+fi
+
 # Minimal settings.json with our env block.
 cat > "$TEMP_HOME/.claude/settings.json" <<JSON
 {
@@ -111,4 +138,4 @@ ANTHROPIC_BASE_URL="$PROXY_URL" \
 ANTHROPIC_CUSTOM_HEADERS="$headers" \
 AGENTWEAVE_PROXY_URL="$PROXY_URL" \
 HOME="$TEMP_HOME" \
-  exec "$CLAUDE_BIN" "$@"
+  exec "$CLAUDE_CMD" "$@"

--- a/scripts/validate-claude-delegate.sh
+++ b/scripts/validate-claude-delegate.sh
@@ -13,7 +13,7 @@
 # Env:
 #   AGENTWEAVE_PROXY_URL  default: http://192.168.1.70:30400
 #   TEMPO_API_URL         default: http://192.168.1.70:31989
-#   CLAUDE_BIN            default: claude
+#   CLAUDE_BIN            optional; otherwise wrapper autodetects
 #   VALIDATE_TIMEOUT      default: 60 (seconds to wait for Tempo to index)
 
 set -euo pipefail
@@ -21,7 +21,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROXY_URL="${AGENTWEAVE_PROXY_URL:-http://192.168.1.70:30400}"
 TEMPO_URL="${TEMPO_API_URL:-http://192.168.1.70:31989}"
-CLAUDE_BIN_VAL="${CLAUDE_BIN:-claude}"
 TIMEOUT="${VALIDATE_TIMEOUT:-60}"
 
 PROMPT="say only the word OK"
@@ -49,7 +48,15 @@ TASK="validate-claude-delegate dry run"
 ts "session_id=${SESSION_ID}"
 ts "running claude via wrapper"
 
-CLAUDE_BIN="$CLAUDE_BIN_VAL" "$REPO_ROOT/scripts/claude-delegate.sh" \
+env_args=()
+if [[ -n "${CLAUDE_BIN:-}" ]]; then
+  env_args+=(CLAUDE_BIN="$CLAUDE_BIN")
+fi
+if [[ -n "${CLAUDE_REAL_HOME:-}" ]]; then
+  env_args+=(CLAUDE_REAL_HOME="$CLAUDE_REAL_HOME")
+fi
+
+env "${env_args[@]}" "$REPO_ROOT/scripts/claude-delegate.sh" \
   --agent-id "$AGENT_ID" \
   --session-id "$SESSION_ID" \
   --parent "$PARENT" \

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -1832,6 +1832,8 @@ def _set_request_attrs(
     # Apply global session context (env-var defaults) — but don't overwrite
     # per-request values that were already set explicitly above.
     _explicit_session_attrs: set[str] = set()
+    if agent_id:
+        _explicit_session_attrs.update({schema.PROV_AGENT_ID, schema.PROV_WAS_ASSOCIATED_WITH})
     if session_id is not None:
         _explicit_session_attrs.update({schema.SESSION_ID, schema.PROV_SESSION_ID})
     if project is not None:


### PR DESCRIPTION
## Summary
- harden `claude-delegate.sh` so delegated Claude Code can run from OpenClaw by autodetecting the real Claude home and native binary
- keep private Claude HOME authenticated by linking root `~/.claude.json`
- prevent global AgentWeave session context from overwriting explicit per-request `prov.agent.id`
- let `validate-claude-delegate.sh` use wrapper autodetection instead of forcing `claude` on PATH

## Validation
- `cd sdk/python && .venv/bin/python -m pytest tests/test_proxy.py -k legacy_global_force -q`
- `./scripts/validate-claude-delegate.sh --prompt 'say only the word OK' --model claude-sonnet-4-6`\n- rebuilt/pushed `localhost:5000/agentweave-proxy:latest` and rolled `agentweave/agentweave-proxy` locally\n\nTempo validation confirmed `prov.agent.id=claude-code-nas-subagent` for delegated Claude Code.