### PR TITLE
fix(scripts): wrapper binary resolution + validate inline-exec

### DIFF
--- a/scripts/claude-delegate.sh
+++ b/scripts/claude-delegate.sh
@@ -41,13 +41,21 @@ fi
 if [[ -n "${CLAUDE_BIN:-}" ]]; then
   CLAUDE_CMD="$CLAUDE_BIN"
 elif command -v claude >/dev/null 2>&1; then
-  CLAUDE_CMD="claude"
+  # Resolve to an absolute path — bare `[[ -x claude ]]` below only
+  # inspects the current working directory, not PATH.
+  CLAUDE_CMD="$(command -v claude)"
 elif [[ -d "$REAL_HOME/.local/share/claude/versions" ]]; then
   CLAUDE_CMD="$(ls -1t "$REAL_HOME/.local/share/claude/versions"/* 2>/dev/null | head -1 || true)"
 elif [[ -d /home/Arnab/.local/share/claude/versions ]]; then
   CLAUDE_CMD="$(ls -1t /home/Arnab/.local/share/claude/versions/* 2>/dev/null | head -1 || true)"
 else
   CLAUDE_CMD=""
+fi
+
+# If the resolved command is still a bare name (e.g. CLAUDE_BIN=claude),
+# look it up on PATH so the `-x` check has an absolute path to test.
+if [[ -n "$CLAUDE_CMD" && "$CLAUDE_CMD" != /* && "$CLAUDE_CMD" != ./* ]]; then
+  CLAUDE_CMD="$(command -v "$CLAUDE_CMD" 2>/dev/null || true)"
 fi
 
 if [[ -z "$CLAUDE_CMD" || ! -x "$CLAUDE_CMD" ]]; then

--- a/scripts/validate-claude-delegate.sh
+++ b/scripts/validate-claude-delegate.sh
@@ -48,15 +48,12 @@ TASK="validate-claude-delegate dry run"
 ts "session_id=${SESSION_ID}"
 ts "running claude via wrapper"
 
-env_args=()
-if [[ -n "${CLAUDE_BIN:-}" ]]; then
-  env_args+=(CLAUDE_BIN="$CLAUDE_BIN")
-fi
-if [[ -n "${CLAUDE_REAL_HOME:-}" ]]; then
-  env_args+=(CLAUDE_REAL_HOME="$CLAUDE_REAL_HOME")
-fi
-
-env "${env_args[@]}" "$REPO_ROOT/scripts/claude-delegate.sh" \
+# Run the wrapper inline so CLAUDE_BIN / CLAUDE_REAL_HOME are inherited
+# when set, and otherwise the wrapper's autodetection picks up `claude`
+# from PATH. Calling through `env` with an empty arg list misbehaves on
+# systems whose user-level `env` is a wrapper script (e.g.
+# ~/.local/bin/env that re-exports PATH) — it can swallow the command.
+"$REPO_ROOT/scripts/claude-delegate.sh" \
   --agent-id "$AGENT_ID" \
   --session-id "$SESSION_ID" \
   --parent "$PARENT" \


### PR DESCRIPTION
Two small follow-ups to #194's hardening, surfaced by re-running \`scripts/validate-claude-delegate.sh\` end-to-end after the deploy.

## What was broken

1. **\`claude-delegate.sh\` — \`-x\` on a bare command name** — when \`command -v claude\` succeeded, the wrapper set \`CLAUDE_CMD=\"claude\"\` and then guarded with \`[[ ! -x \"\$CLAUDE_CMD\" ]]\`. Bash's \`-x\` test on a bare name only inspects \`pwd\`, not \`PATH\`, so the wrapper bailed with \"Claude Code binary not found\" even when claude was on PATH and worked fine directly.

   Fixed by resolving via \`command -v\` to an absolute path, plus a defensive late-fallback if \`CLAUDE_BIN\` itself was passed as a bare name.

2. **\`validate-claude-delegate.sh\` — \`env\` shim with empty arg list** — the script invoked the wrapper through \`env \"\${env_args[@]}\" wrapper.sh ...\`. When \`env_args\` is empty (no \`CLAUDE_BIN\`/\`CLAUDE_REAL_HOME\` override), that collapses to \`env wrapper.sh ...\`. On systems whose user-level \`env\` is a shell shim (e.g. \`~/.local/bin/env\` on the NAS, which prepends \`~/.local/bin\` to \`PATH\`), the shim re-execs the rest as args to itself and the wrapper never runs.

   Fixed by calling the wrapper directly — env-var inheritance is enough; the wrapper does its own autodetection.

## Validation

End-to-end run with the proxy's \`_session_context\` deliberately seeded to \`prov.agent.id=nix-v1\` (mimicking a bridge main-turn POST):

\`\`\`
[15:37:38] claude returned: OK
[15:37:57] found trace cc32598a96424fc03b58ffe775f24834
  OK prov.agent.id=claude-code-nas-subagent
  OK prov.session.id=claude-code-validate-20260510-153735-899964
  OK prov.parent.session.id=nix-validate
  OK prov.project=agentweave
  OK prov.task.label=validate-claude-delegate dry run
[15:37:58] PASS — delegated attribution propagated end-to-end
\`\`\`

That confirms #194's proxy.py fix is doing its job on the deployed image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)