### PR TITLE
fix(bridge): codex turns get prov.llm.model + gpt-5.5 pricing

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/pricing.ts
+++ b/plugins/openclaw-agentweave-bridge/src/pricing.ts
@@ -31,6 +31,9 @@ const PRICING: Record<string, PriceEntry> = {
   "gpt-5.3":                    [ 2.50, 10.00],
   "gpt-5.3-codex":              [ 2.50, 10.00],
   "gpt-5.4":                    [ 2.50, 10.00],
+  "gpt-5.4-mini":               [ 0.25,  2.00],
+  "gpt-5.5":                    [ 2.50, 10.00],
+  "gpt-5.5-mini":               [ 0.25,  2.00],
   // ── MiniMax (official pay-as-you-go, highspeed tier) ──────────────────────
   "minimax-m2.7-highspeed":     [ 0.60,  2.40, 0.06, 0.375],
   "minimax-m2.5-highspeed":     [ 0.60,  2.40, 0.03, 0.375],

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -462,6 +462,30 @@ export function createAgentWeaveBridgeService() {
               break
             }
 
+            case "model.call.completed": {
+              // OpenClaw's embedded codex/Responses runner emits this — NOT
+              // `model.usage` (which only fires from the legacy openai-compat
+              // HTTP path). Without a handler, codex turn spans land in
+              // Tempo without `prov.llm.{provider,model}`, so the dashboard's
+              // "Calls by Model" panel can't bucket them.
+              //
+              // The event does NOT carry token counts today, so we only
+              // stamp identity attributes here. Cost stays at whatever
+              // `model.usage` set later in the turn (often 0 for codex
+              // until openclaw enriches this event with usage). Followup
+              // tracked separately.
+              const sessionKey = e.sessionKey ?? ""
+              const sessionId = e.sessionId ?? ""
+              const match = findTurnForModelUsage(sessionKey, sessionId)
+              if (!match) break
+              const provider = e.provider ?? ""
+              const model = e.model ?? ""
+              if (!provider && !model) break
+              if (provider) match.turn.span.setAttribute("prov.llm.provider", provider)
+              if (model) match.turn.span.setAttribute("prov.llm.model", model)
+              break
+            }
+
             case "tool.loop": {
               const sessionKey = e.sessionKey ?? ""
               const turn = activeTurns.get(sessionKey)

--- a/sdk/python/agentweave/pricing.py
+++ b/sdk/python/agentweave/pricing.py
@@ -70,6 +70,9 @@ _DEFAULT_PRICING: dict[str, _PriceEntry] = {
     "gpt-5.3":                    (2.50, 10.00),
     "gpt-5.3-codex":              (2.50, 10.00),
     "gpt-5.4":                    (2.50, 10.00),
+    "gpt-5.4-mini":               (0.25,  2.00),
+    "gpt-5.5":                    (2.50, 10.00),
+    "gpt-5.5-mini":               (0.25,  2.00),
 
     # ── MiniMax (input, output, cache_read, cache_write) ─────────────────────
     # Official pay-as-you-go prices: https://platform.minimax.io/docs/guides/pricing-paygo


### PR DESCRIPTION
## Why

In the AgentWeave overview dashboard, Nix's codex/gpt-5.5 traffic was being silently bucketed as \"unknown\" in **Calls by Model** and contributed \$0 to **Total Cost**, even though Nix was clearly running on codex. Two separate gaps, both fixed here:

## What was broken

**1. Bridge had no handler for \`model.call.completed\`**

The OpenClaw embedded codex/Responses runner (the path that backs \`openai-codex-responses\` — i.e. the Codex subscription path) emits \`model.call.completed\` diagnostic events, not \`model.usage\`. The bridge only handled \`model.usage\` (legacy openai-compat HTTP path), so codex turn spans landed in Tempo as \`openclaw.turn\` **without** \`prov.llm.provider\` / \`prov.llm.model\`.

Because the bridge sets its OTel resource \`service.name = \"agentweave-proxy\"\` (\`plugins/openclaw-agentweave-bridge/src/service.ts:91\`), the dashboard's TraceQL query \`{ resource.service.name = \"agentweave-proxy\" && name != \"llm.unknown\" }\` picks up the bridge's \`openclaw.turn\` spans alongside the proxy's \`llm.*\` spans. Without a model attribute, Grafana's groupBy on Name bucketed them as \"unknown\" — exactly matching the dashboard symptom (one \"unknown\" per Nix codex turn).

Sample affected trace (Nix turn, 15:14:52 PT today):
\`\`\`
openclaw.turn  traceID=783683ff9a51bbc7f9112a36d8a71777
  prov.agent.id=nix-v1
  prov.session.id=agent:main:main
  prov.project=nix
  ⟵ no prov.llm.model
  ⟵ no prov.llm.provider
  ⟵ no cost.usd
\`\`\`

**Fix**: handle \`model.call.completed\` in the bridge; stamp \`prov.llm.provider\` + \`prov.llm.model\` on the matching active turn span.

The event does not currently carry token counts (only identity + timing), so \`cost.usd\` stays at whatever \`model.usage\` set later in the turn (often 0 for codex until openclaw enriches the event with usage data). Follow-up tracked separately to add usage to \`model.call.completed\` in openclaw.

**2. \`gpt-5.5\` missing from the pricing table**

Bridge \`pricing.ts\` had gpt-5.3, gpt-5.3-codex, gpt-5.4 — no gpt-5.5. Same gap in the proxy-side \`pricing.py\` (the two tables are hand-mirrored per the comment in \`pricing.ts\`). Even when usage is supplied, cost was computing to 0 for gpt-5.5 calls.

**Fix**: add prices for gpt-5.5, gpt-5.5-mini, and gpt-5.4-mini (which was also missing) to both tables. Prices match the existing gpt-5.x family.

## Tests

- \`plugins/openclaw-agentweave-bridge\`: 19/19 vitest passing
- \`sdk/python tests/test_pricing.py\`: 38/38 passing
- Live: bridge installed to \`~/.openclaw/user-plugins/agentweave-bridge\`, rebuilt, openclaw restarted. Waiting for next Nix codex turn to confirm \`prov.llm.model=gpt-5.5\` lands on the span.

## Follow-up (openclaw-side, separate)

\`model.call.completed\` should carry token usage (and ideally costUsd if openclaw computes it). Once that lands, the bridge can also stamp \`cost.usd\` + token attrs and the cost-by-model panels will be accurate for codex too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)