### PR TITLE
fix(bridge): subscribe to onModelDiagnosticEvent so codex turns get prov.llm.model

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -4,7 +4,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node"
 import { resourceFromAttributes } from "@opentelemetry/resources"
 import { BatchSpanProcessor, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base"
 // @ts-ignore — provided by host at runtime, not in plugin's local node_modules
-import { onDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime"
+import { onDiagnosticEvent, onModelDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime"
 import { resolveCost } from "./pricing.js"
 
 interface ActiveTurn {
@@ -98,12 +98,35 @@ function initSdk(config: BridgeConfig): void {
 }
 
 function subscribeToDiagnosticEvents(listener: (evt: unknown) => void): () => void {
-  // openclaw/plugin-sdk's onDiagnosticEvent registers against the
-  // Symbol-keyed state added in OpenClaw v2026.5.x, replacing the
-  // string-keyed globalThis singleton this plugin used to poke directly.
-  const unsubscribe = (onDiagnosticEvent as (l: (evt: unknown) => void) => () => void)(listener)
+  // Two openclaw plugin-sdk subscriptions:
+  //
+  // 1. `onDiagnosticEvent` covers the public (untrusted) event stream —
+  //    message/session lifecycle, queue events, etc. used to manage spans.
+  // 2. `onModelDiagnosticEvent` is the narrow opt-in over the trusted
+  //    `model.*` family (call.started/completed/error, usage, failover).
+  //    Without it, the embedded codex runner's `model.call.completed`
+  //    events never reach the bridge and codex turn spans land in
+  //    AgentWeave without `prov.llm.{provider,model}` (issue: codex traffic
+  //    silently buckets as "unknown" on the dashboard).
+  //
+  // `onModelDiagnosticEvent` was added to the plugin-sdk in a separate
+  // openclaw PR; older runtimes export only `onDiagnosticEvent`, so we
+  // guard the call to keep the bridge compatible.
+  const unsubMain = (onDiagnosticEvent as (l: (evt: unknown) => void) => () => void)(listener)
   console.log("[agentweave-bridge] subscribed to diagnostic events via plugin-sdk")
-  return unsubscribe
+  let unsubModel: (() => void) | undefined
+  if (typeof onModelDiagnosticEvent === "function") {
+    unsubModel = (onModelDiagnosticEvent as (l: (evt: unknown) => void) => () => void)(listener)
+    console.log("[agentweave-bridge] subscribed to model.* trusted events via plugin-sdk")
+  } else {
+    console.warn(
+      "[agentweave-bridge] openclaw plugin-sdk is missing onModelDiagnosticEvent — codex turn spans will not be enriched with prov.llm.model. Upgrade openclaw to a build that exports it.",
+    )
+  }
+  return () => {
+    unsubMain()
+    if (unsubModel) unsubModel()
+  }
 }
 
 function getSpanSessionId(turn: ActiveTurn): string | undefined {


### PR DESCRIPTION
## Why

PR #196 added a handler for \`model.call.completed\` in the agentweave-bridge plugin so codex turns would get \`prov.llm.{provider,model}\` stamped on the turn span. The handler was correct — but it never fires, because the openclaw plugin-sdk \`onDiagnosticEvent\` API filters out every event whose dispatcher metadata is \`trusted: true\` (\`src/infra/diagnostic-events.ts:879-886\` in openclaw/openclaw):

\`\`\`ts
export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => void): () => void {
  return onInternalDiagnosticEvent((event, metadata) => {
    if (metadata.trusted || event.type === \"log.record\") {
      return;
    }
    listener(event);
  });
}
\`\`\`

The embedded codex/Responses runner emits the entire \`model.*\` lifecycle (\`model.call.{started,completed,error}\`, \`model.usage\`, \`model.failover\`) via \`emitTrustedDiagnosticEvent\`. So the bridge's \`model.call.completed\` handler from #196 AND its pre-existing \`model.usage\` handler are both dead code against the trusted emit paths.

Concretely on the NAS today: Nix codex turns produce \`openclaw.turn\` spans in Tempo with no \`prov.llm.model\`/\`prov.llm.provider\` attribute, so the AgentWeave overview dashboard buckets them as \"unknown\" instead of \`gpt-5.5\`.

## Fix on the openclaw side

[arniesaha/openclaw#2](https://github.com/arniesaha/openclaw/pull/2) adds a focused, opt-in plugin-sdk API \`onModelDiagnosticEvent\` that exposes exactly the five model lifecycle event types to plugins while keeping the safety contract of the existing \`onDiagnosticEvent\` untouched.

## This PR

Subscribes the bridge to both APIs:

- \`onDiagnosticEvent\` — unchanged, covers the public/untrusted stream (message/session lifecycle, queue events).
- \`onModelDiagnosticEvent\` — NEW opt-in over the trusted \`model.*\` family.

Guarded with \`typeof === \"function\"\` so the bridge remains compatible with older openclaw runtimes that don't export it yet (logs a clear warning instead of crashing).

## Validation

Locally, after rebuilding openclaw with the new SDK function and restarting the gateway, bridge logs show **both** subscriptions on startup:

\`\`\`
[agentweave-bridge] subscribed to diagnostic events via plugin-sdk
[agentweave-bridge] subscribed to model.* trusted events via plugin-sdk
\`\`\`

19/19 bridge vitest tests pass.

## Rollout note

This PR can land independently — the runtime guard means it's a no-op on older openclaw builds, with a warning. The dashboard \"unknown\" bucket will resolve to specific model names only after the openclaw side ships and is installed.