### PR TITLE
feat(cli): add doctor diagnostics

### DIFF
--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -21,6 +21,14 @@ app.add_typer(hooks_app)
 console = Console()
 
 
+def _doctor_status_markup(status: str) -> str:
+    if status == "pass":
+        return "[green]PASS[/green]"
+    if status == "warn":
+        return "[yellow]WARN[/yellow]"
+    return "[red]FAIL[/red]"
+
+
 def _get_provider():
     """Return the current TracerProvider (if any)."""
     from opentelemetry import trace as otel_trace
@@ -395,6 +403,67 @@ def hooks_uninstall(
         console.print("[green]AgentWeave hooks uninstalled successfully![/green]")
         for change in changes_made:
             console.print(f"  - {change}")
+
+
+# ---------------------------------------------------------------------------
+# agentweave doctor
+# ---------------------------------------------------------------------------
+
+
+@app.command("doctor")
+def doctor(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of a table.",
+    ),
+    check_proxy: bool = typer.Option(
+        False,
+        "--check-proxy",
+        help="Query the configured proxy /health endpoint.",
+    ),
+    proxy_url: Optional[str] = typer.Option(
+        None,
+        "--proxy-url",
+        help="Proxy URL to use with --check-proxy. Defaults to AGENTWEAVE_PROXY_URL or provider base URL.",
+    ),
+    timeout: float = typer.Option(
+        2.0,
+        "--timeout",
+        min=0.1,
+        help="Proxy health check timeout in seconds.",
+    ),
+) -> None:
+    """Run local install and configuration diagnostics."""
+    from agentweave.doctor import doctor_payload_json, has_failures, run_doctor
+
+    checks = run_doctor(check_proxy=check_proxy, proxy_url=proxy_url, timeout_seconds=timeout)
+
+    if json_output:
+        typer.echo(doctor_payload_json(checks))
+    else:
+        table = Table(title="AgentWeave Doctor")
+        table.add_column("Status", no_wrap=True)
+        table.add_column("Check", style="cyan")
+        table.add_column("Message")
+        table.add_column("Suggested fix", style="dim")
+
+        for check in checks:
+            table.add_row(
+                _doctor_status_markup(check.status),
+                check.name,
+                check.message,
+                check.suggestion or "",
+            )
+        console.print(table)
+
+        if has_failures(checks):
+            console.print("\n[red]Doctor found hard failures.[/red]")
+        else:
+            console.print("\n[green]No hard failures found.[/green]")
+
+    if has_failures(checks):
+        raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/agentweave/doctor.py
+++ b/sdk/python/agentweave/doctor.py
@@ -1,0 +1,342 @@
+"""Local diagnostics for AgentWeave installs.
+
+The doctor command is intentionally conservative: it inspects local Python
+metadata and environment configuration, validates URL shape, and only performs
+network I/O when explicitly requested.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import os
+import platform
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+
+Status = str
+
+PASS: Status = "pass"
+WARN: Status = "warn"
+FAIL: Status = "fail"
+
+PROVIDER_BASE_URLS = (
+    "ANTHROPIC_BASE_URL",
+    "OPENAI_BASE_URL",
+    "GOOGLE_BASE_URL",
+    "GOOGLE_GENAI_BASE_URL",
+)
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    """Single diagnostic result emitted by ``agentweave doctor``."""
+
+    name: str
+    status: Status
+    message: str
+    suggestion: str | None = None
+    details: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def doctor_payload(checks: list[DoctorCheck]) -> dict[str, object]:
+    """Return the stable JSON payload for doctor automation."""
+    return {
+        "ok": not has_failures(checks),
+        "summary": {
+            PASS: sum(1 for check in checks if check.status == PASS),
+            WARN: sum(1 for check in checks if check.status == WARN),
+            FAIL: sum(1 for check in checks if check.status == FAIL),
+        },
+        "checks": [check.to_dict() for check in checks],
+    }
+
+
+def doctor_payload_json(checks: list[DoctorCheck]) -> str:
+    return json.dumps(doctor_payload(checks), indent=2, sort_keys=True)
+
+
+def has_failures(checks: list[DoctorCheck]) -> bool:
+    return any(check.status == FAIL for check in checks)
+
+
+def run_doctor(
+    *,
+    env: Mapping[str, str] | None = None,
+    check_proxy: bool = False,
+    proxy_url: str | None = None,
+    timeout_seconds: float = 2.0,
+) -> list[DoctorCheck]:
+    """Run local AgentWeave diagnostic checks."""
+    effective_env = env if env is not None else os.environ
+    checks: list[DoctorCheck] = [
+        _check_python_version(),
+        _check_package_metadata(),
+    ]
+    checks.extend(_check_provider_base_urls(effective_env))
+    checks.append(_check_otlp_endpoint(effective_env))
+    checks.extend(_check_identity_env(effective_env))
+    checks.append(_check_proxy_token(effective_env))
+    checks.append(_check_proxy_health(effective_env, proxy_url, timeout_seconds) if check_proxy else _check_proxy_health_skipped())
+    return checks
+
+
+def _check_python_version() -> DoctorCheck:
+    version = sys.version_info
+    version_label = platform.python_version()
+    if version >= (3, 11):
+        return DoctorCheck(
+            name="python.version",
+            status=PASS,
+            message=f"Python {version_label} is supported.",
+            details={"version": version_label},
+        )
+    return DoctorCheck(
+        name="python.version",
+        status=FAIL,
+        message=f"Python {version_label} is not supported.",
+        suggestion="Use Python 3.11 or newer.",
+        details={"version": version_label},
+    )
+
+
+def _check_package_metadata() -> DoctorCheck:
+    try:
+        version = importlib.metadata.version("agentweave-sdk")
+    except importlib.metadata.PackageNotFoundError:
+        return DoctorCheck(
+            name="package.metadata",
+            status=WARN,
+            message="Package metadata for agentweave-sdk was not found.",
+            suggestion="Install the SDK with `pip install -e sdk/python` or `pip install agentweave-sdk`.",
+        )
+    return DoctorCheck(
+        name="package.metadata",
+        status=PASS,
+        message=f"agentweave-sdk {version} metadata is readable.",
+        details={"version": version},
+    )
+
+
+def _check_provider_base_urls(env: Mapping[str, str]) -> list[DoctorCheck]:
+    checks: list[DoctorCheck] = []
+    configured = {name: env.get(name, "").strip() for name in PROVIDER_BASE_URLS if env.get(name, "").strip()}
+
+    if not configured:
+        return [
+            DoctorCheck(
+                name="provider.base_urls",
+                status=WARN,
+                message="No provider base URL points at an AgentWeave proxy.",
+                suggestion="Set ANTHROPIC_BASE_URL, OPENAI_BASE_URL, or GOOGLE_GENAI_BASE_URL to your proxy URL.",
+            )
+        ]
+
+    for name, value in configured.items():
+        url_error = _url_validation_error(value)
+        if url_error:
+            checks.append(
+                DoctorCheck(
+                    name=f"provider.{name.lower()}",
+                    status=FAIL,
+                    message=f"{name} is not a valid HTTP URL: {url_error}.",
+                    suggestion=f"Set {name}=http://localhost:4000 or another reachable AgentWeave proxy URL.",
+                    details={"value": value},
+                )
+            )
+        else:
+            checks.append(
+                DoctorCheck(
+                    name=f"provider.{name.lower()}",
+                    status=PASS,
+                    message=f"{name} is configured.",
+                    details={"value": value},
+                )
+            )
+    return checks
+
+
+def _check_otlp_endpoint(env: Mapping[str, str]) -> DoctorCheck:
+    value = env.get("AGENTWEAVE_OTLP_ENDPOINT", "").strip()
+    if not value:
+        return DoctorCheck(
+            name="otel.endpoint",
+            status=WARN,
+            message="AGENTWEAVE_OTLP_ENDPOINT is not set; SDK/proxy defaults may be used.",
+            suggestion="Set AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318 for a local collector.",
+        )
+
+    url_error = _url_validation_error(value)
+    if url_error:
+        return DoctorCheck(
+            name="otel.endpoint",
+            status=FAIL,
+            message=f"AGENTWEAVE_OTLP_ENDPOINT is not a valid HTTP URL: {url_error}.",
+            suggestion="Set AGENTWEAVE_OTLP_ENDPOINT to a full http(s) URL, such as http://localhost:4318.",
+            details={"value": value},
+        )
+    return DoctorCheck(
+        name="otel.endpoint",
+        status=PASS,
+        message="AGENTWEAVE_OTLP_ENDPOINT is configured.",
+        details={"value": value},
+    )
+
+
+def _check_identity_env(env: Mapping[str, str]) -> list[DoctorCheck]:
+    checks: list[DoctorCheck] = []
+    for name, label in (
+        ("AGENTWEAVE_AGENT_ID", "agent identity"),
+        ("AGENTWEAVE_PROJECT", "project attribution"),
+    ):
+        value = env.get(name, "").strip()
+        if value:
+            checks.append(
+                DoctorCheck(
+                    name=f"identity.{name.lower()}",
+                    status=PASS,
+                    message=f"{name} is set for {label}.",
+                    details={"value": value},
+                )
+            )
+        else:
+            checks.append(
+                DoctorCheck(
+                    name=f"identity.{name.lower()}",
+                    status=WARN,
+                    message=f"{name} is not set; spans may be harder to group.",
+                    suggestion=f"Set {name} to a stable {label} value.",
+                )
+            )
+    return checks
+
+
+def _check_proxy_token(env: Mapping[str, str]) -> DoctorCheck:
+    token = env.get("AGENTWEAVE_PROXY_TOKEN", "").strip()
+    provider_urls = [env.get(name, "").strip() for name in PROVIDER_BASE_URLS if env.get(name, "").strip()]
+
+    if token:
+        return DoctorCheck(
+            name="proxy.auth_token",
+            status=PASS,
+            message="AGENTWEAVE_PROXY_TOKEN is set.",
+        )
+
+    if provider_urls and any(not _is_local_url(url) for url in provider_urls if not _url_validation_error(url)):
+        return DoctorCheck(
+            name="proxy.auth_token",
+            status=WARN,
+            message="AGENTWEAVE_PROXY_TOKEN is not set while a non-local provider proxy URL is configured.",
+            suggestion="Set AGENTWEAVE_PROXY_TOKEN for shared LAN or remote proxy deployments.",
+        )
+
+    return DoctorCheck(
+        name="proxy.auth_token",
+        status=PASS,
+        message="AGENTWEAVE_PROXY_TOKEN is not set, which is acceptable for local-only proxy use.",
+    )
+
+
+def _check_proxy_health_skipped() -> DoctorCheck:
+    return DoctorCheck(
+        name="proxy.health",
+        status=WARN,
+        message="Proxy health check skipped.",
+        suggestion="Run `agentweave doctor --check-proxy` to query the configured proxy /health endpoint.",
+    )
+
+
+def _check_proxy_health(env: Mapping[str, str], proxy_url: str | None, timeout_seconds: float) -> DoctorCheck:
+    base_url = (proxy_url or env.get("AGENTWEAVE_PROXY_URL") or _first_provider_url(env) or "").strip()
+    if not base_url:
+        return DoctorCheck(
+            name="proxy.health",
+            status=WARN,
+            message="No proxy URL found for health check.",
+            suggestion="Pass --proxy-url or set AGENTWEAVE_PROXY_URL / ANTHROPIC_BASE_URL.",
+        )
+
+    url_error = _url_validation_error(base_url)
+    if url_error:
+        return DoctorCheck(
+            name="proxy.health",
+            status=FAIL,
+            message=f"Proxy URL is not a valid HTTP URL: {url_error}.",
+            suggestion="Pass --proxy-url http://localhost:4000.",
+            details={"value": base_url},
+        )
+
+    health_url = f"{base_url.rstrip('/')}/health"
+    try:
+        with urlopen(health_url, timeout=timeout_seconds) as response:
+            status_code = int(getattr(response, "status", 200))
+            body = response.read(2048).decode("utf-8", errors="replace")
+    except HTTPError as exc:
+        return DoctorCheck(
+            name="proxy.health",
+            status=FAIL,
+            message=f"Proxy /health returned HTTP {exc.code}.",
+            suggestion="Start or repair the AgentWeave proxy, then retry `agentweave doctor --check-proxy`.",
+            details={"url": health_url, "status_code": exc.code},
+        )
+    except URLError as exc:
+        return DoctorCheck(
+            name="proxy.health",
+            status=WARN,
+            message=f"Proxy /health was not reachable: {exc.reason}.",
+            suggestion="Start the proxy with `agentweave proxy start` or pass the correct --proxy-url.",
+            details={"url": health_url},
+        )
+    except OSError as exc:
+        return DoctorCheck(
+            name="proxy.health",
+            status=WARN,
+            message=f"Proxy /health was not reachable: {exc}.",
+            suggestion="Start the proxy with `agentweave proxy start` or pass the correct --proxy-url.",
+            details={"url": health_url},
+        )
+
+    if 200 <= status_code < 300:
+        return DoctorCheck(
+            name="proxy.health",
+            status=PASS,
+            message="Proxy /health is reachable.",
+            details={"url": health_url, "status_code": status_code, "body": body[:512]},
+        )
+    return DoctorCheck(
+        name="proxy.health",
+        status=FAIL,
+        message=f"Proxy /health returned HTTP {status_code}.",
+        suggestion="Check proxy logs and upstream configuration.",
+        details={"url": health_url, "status_code": status_code, "body": body[:512]},
+    )
+
+
+def _first_provider_url(env: Mapping[str, str]) -> str | None:
+    for name in PROVIDER_BASE_URLS:
+        value = env.get(name, "").strip()
+        if value:
+            return value
+    return None
+
+
+def _url_validation_error(value: str) -> str | None:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"}:
+        return "scheme must be http or https"
+    if not parsed.netloc:
+        return "host is missing"
+    return None
+
+
+def _is_local_url(value: str) -> bool:
+    hostname = (urlparse(value).hostname or "").lower()
+    return hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(".local")

--- a/sdk/python/tests/test_doctor.py
+++ b/sdk/python/tests/test_doctor.py
@@ -1,0 +1,125 @@
+"""Tests for agentweave doctor diagnostics."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+from urllib.error import URLError
+
+import pytest
+
+pytest.importorskip("typer", reason="CLI deps not installed")
+
+
+def _healthy_env() -> dict[str, str]:
+    return {
+        "ANTHROPIC_BASE_URL": "http://localhost:4000",
+        "AGENTWEAVE_OTLP_ENDPOINT": "http://localhost:4318",
+        "AGENTWEAVE_AGENT_ID": "test-agent",
+        "AGENTWEAVE_PROJECT": "test-project",
+        "AGENTWEAVE_PROXY_TOKEN": "secret",
+    }
+
+
+def test_doctor_warning_only_has_zero_exit(monkeypatch):
+    from typer.testing import CliRunner
+    import agentweave.doctor as doctor_module
+    from agentweave.cli import app
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("GOOGLE_BASE_URL", raising=False)
+    monkeypatch.delenv("GOOGLE_GENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("AGENTWEAVE_OTLP_ENDPOINT", raising=False)
+    monkeypatch.delenv("AGENTWEAVE_AGENT_ID", raising=False)
+    monkeypatch.delenv("AGENTWEAVE_PROJECT", raising=False)
+    monkeypatch.delenv("AGENTWEAVE_PROXY_TOKEN", raising=False)
+    monkeypatch.delenv("AGENTWEAVE_PROXY_URL", raising=False)
+
+    checks = doctor_module.run_doctor()
+    assert any(check.status == "warn" for check in checks)
+    assert not doctor_module.has_failures(checks)
+
+    result = CliRunner().invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "No hard failures found" in result.output
+
+
+def test_doctor_fails_for_invalid_urls(monkeypatch):
+    import agentweave.doctor as doctor_module
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    checks = doctor_module.run_doctor(
+        env={
+            **_healthy_env(),
+            "ANTHROPIC_BASE_URL": "localhost:4000",
+            "AGENTWEAVE_OTLP_ENDPOINT": "not-a-url",
+        }
+    )
+
+    failures = [check for check in checks if check.status == "fail"]
+    assert {check.name for check in failures} == {
+        "provider.anthropic_base_url",
+        "otel.endpoint",
+    }
+    assert doctor_module.has_failures(checks)
+
+
+def test_doctor_json_exit_nonzero_on_hard_failure(monkeypatch):
+    from typer.testing import CliRunner
+    from agentweave.cli import app
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+
+    result = CliRunner().invoke(
+        app,
+        ["doctor", "--json"],
+        env={
+            **_healthy_env(),
+            "AGENTWEAVE_OTLP_ENDPOINT": "ftp://collector",
+        },
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["summary"]["fail"] == 1
+    assert any(check["name"] == "otel.endpoint" for check in payload["checks"])
+
+
+def test_doctor_healthy_with_proxy_check(monkeypatch):
+    import agentweave.doctor as doctor_module
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, limit):
+            return b'{"ok": true}'
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    monkeypatch.setattr(doctor_module, "urlopen", lambda url, timeout: FakeResponse())
+
+    checks = doctor_module.run_doctor(env=_healthy_env(), check_proxy=True)
+
+    assert {check.status for check in checks} == {"pass"}
+    assert not doctor_module.has_failures(checks)
+
+
+def test_doctor_unreachable_proxy_is_warning(monkeypatch):
+    import agentweave.doctor as doctor_module
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    monkeypatch.setattr(doctor_module, "urlopen", lambda url, timeout: (_ for _ in ()).throw(URLError("refused")))
+
+    checks = doctor_module.run_doctor(env=_healthy_env(), check_proxy=True)
+    proxy_check = next(check for check in checks if check.name == "proxy.health")
+
+    assert proxy_check.status == "warn"
+    assert not doctor_module.has_failures(checks)


### PR DESCRIPTION
## Summary
- add `agentweave doctor` CLI diagnostics with table and JSON output
- check package metadata, key AgentWeave/provider env vars, URL syntax, and optional proxy `/health`
- return non-zero only for hard failures while allowing warning-only configs

## Verification
- `python3 -m pytest sdk/python/tests/test_doctor.py sdk/python/tests/test_health.py`

Fixes #202
