### PR TITLE
docs: add compatibility smoke matrix

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,66 +1,78 @@
-# Cross-SDK Compatibility Matrix
+# Agent Framework Compatibility
 
-This table shows which proxy versions are compatible with which SDK versions.
+AgentWeave's developer-preview compatibility target is: an agent framework can
+route LLM calls through the AgentWeave proxy with minimal or no application
+code changes, and the resulting spans carry enough provenance to debug agent
+identity, session context, model usage, tokens, and cost.
 
-## Current State
+This page is public and local-first. The examples below assume:
 
-| Component | Version | Notes |
-|-----------|---------|-------|
-| Proxy | `0.3.0` | Supports `/session` endpoint, sub-agent attribution headers |
-| Python SDK | `0.3.0` | `@trace_tool`, `@trace_agent`, `@trace_llm`, `W3C` propagation |
-| TypeScript SDK | `0.3.0` | Same decorator API as Python SDK |
-| Go SDK | `0.1.0` | `TraceTool`, `TraceAgent`, `TraceLlm` |
-
----
-
-## Compatibility Table
-
-The proxy and SDKs communicate via:
-1. **HTTP headers** — `X-AgentWeave-*` headers from SDK to proxy
-2. **OTLP spans** — proxy emits to Tempo; SDKs optionally emit directly
-3. **W3C TraceContext** — `traceparent` header for distributed tracing
-
-| Proxy Version | Python SDK | TypeScript SDK | Go SDK | Notes |
-|---------------|-----------|----------------|--------|-------|
-| `0.3.x` | `0.3.x` | `0.3.x` | `0.1.x` | Current. `/session` endpoint available |
-| `0.2.x` | `0.2.x` | `0.2.x` | `0.1.x` | `/session` endpoint available |
-| `0.1.x` | `0.1.x` | `0.1.x` | `0.1.x` | No `/session` endpoint, no sub-agent attribution |
-
-### Minimum Compatible Versions
-
-To use sub-agent session attribution (PR #90):
-- Proxy `>= 0.2.0`
-- Any SDK version (headers are passed through transparently)
-
-To use parent session attribution headers (`X-AgentWeave-Parent-Session-Id`):
-- Proxy `>= 0.2.0` (added in PR #81)
-
----
-
-## The Stable Interface
-
-The proxy HTTP API is the compatibility boundary between the proxy and SDKs:
-
-```
-GET  /health          → {"status": "ok", "version": "x.y.z"}
-POST /session         → set session context for span attribution
-GET  /session         → return current session context
-POST /v1/messages     → Anthropic pass-through
-POST /v1/chat/completions → OpenAI pass-through
-POST /v1beta/models/* → Google Gemini pass-through
+```bash
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+export AGENTWEAVE_PROXY_URL=http://localhost:4000/v1
 ```
 
-SDKs do not call these endpoints directly — they set environment variables that point agents at the proxy. The proxy intercepts the standard provider API calls transparently.
+Use your normal provider API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or
+`GEMINI_API_KEY`). AgentWeave does not require a private network, private
+dashboard URL, or proxy-side key injection for these quickstarts.
 
----
+## Smoke Test Command
 
-## Pre-1.0 Compatibility Note
+The offline compatibility smoke checks validate that the documented examples
+exist, parse, and still point framework clients at the local proxy defaults.
+They do not call upstream LLM APIs and do not require provider keys.
 
-Until `1.0.0`, any version bump may introduce breaking changes. Pin to an exact proxy version in production:
-
-```yaml
-# deploy/k8s/deployment.yaml
-image: localhost:5000/agentweave-proxy:0.3.0  # pin exact version
+```bash
+scripts/compatibility-smoke.sh
 ```
 
-After `1.0.0`, minor versions will be backward-compatible within a major version.
+The smoke suite is a fast guardrail, not a full certification run. A full
+compatibility pass should run each example against a local proxy and an OTLP
+collector, then inspect emitted spans for the attributes listed below.
+
+## Compatibility Matrix
+
+Last updated: 2026-05-27.
+
+| Integration | Install | Minimal quickstart | Expected span attributes | Caveats | Last-tested signal |
+|-------------|---------|--------------------|--------------------------|---------|--------------------|
+| LangGraph | `pip install -r examples/langgraph/requirements.txt` | `cd examples/langgraph && AGENTWEAVE_PROXY_URL=http://localhost:4000/v1 OPENAI_API_KEY=... python langgraph_example.py` | `prov.agent.id` when decorators are enabled; `prov.llm.model=gpt-4o-mini`; `prov.project`; `prov.session.id` when supplied by headers/env; `prov.llm.prompt_tokens`, `prov.llm.completion_tokens`, `prov.llm.total_tokens`, `cost.usd` when the upstream response includes usage. | Proxy mode captures LLM calls. Graph node/tool spans need decorators or framework callbacks if you want full graph topology. | 2026-05-27: offline smoke validates example syntax and proxy wiring. |
+| CrewAI | `pip install -r examples/crewai/requirements.txt` | `cd examples/crewai && AGENTWEAVE_PROXY_URL=http://localhost:4000/v1 OPENAI_API_KEY=... python crew_example.py` | LLM spans with `prov.llm.model`; token/cost fields when available; `prov.agent.id`, `prov.project`, and `prov.session.id` when set via AgentWeave headers/env. | Crew/agent/task boundaries are not automatically separate spans in proxy-only mode. Add SDK decorators around `crew.kickoff()` or framework callbacks for richer hierarchy. | 2026-05-27: offline smoke validates example syntax and proxy wiring. |
+| AutoGen | `pip install -r examples/autogen/requirements.txt` | `cd examples/autogen && AGENTWEAVE_PROXY_URL=http://localhost:4000/v1 OPENAI_API_KEY=... python autogen_example.py` | LLM spans with `prov.llm.model`; token/cost fields when available; session/project/agent attributes when passed by headers/env. | Conversable-agent turn boundaries are not inferred by the proxy. Use explicit `X-AgentWeave-Session-Id` and `X-AgentWeave-Agent-Id` when multiple AutoGen agents share a proxy. | 2026-05-27: offline smoke validates example syntax and proxy wiring. |
+| OpenAI Agents SDK | `pip install -r examples/openai-agents-sdk/requirements.txt` | `cd examples/openai-agents-sdk && AGENTWEAVE_PROXY_URL=http://localhost:4000/v1 OPENAI_API_KEY=... python agents_example.py` | LLM spans with `prov.llm.model`; token/cost fields when available; tool/agent identity when added through SDK decorators or headers. | Proxy mode sees OpenAI chat-completions traffic. Higher-level agent/tool semantics depend on the SDK's model client path and may require explicit instrumentation for full topology. | 2026-05-27: offline smoke validates example syntax and proxy wiring. |
+| Claude Code | `pip install -e sdk/python[proxy]` for the local proxy; configure Claude Code with `ANTHROPIC_BASE_URL=http://localhost:4000/v1` | Start the proxy, then run Claude Code with `ANTHROPIC_BASE_URL` pointing at the proxy and `ANTHROPIC_API_KEY` set normally. | `prov.llm.model`; Anthropic token fields; `prov.agent.id`, `prov.agent.type`, `prov.project`, `prov.session.id`, and `prov.parent_session_id` when hooks or wrapper scripts pass AgentWeave headers. | Claude Code integration quality depends on wrapper/hook propagation. Without headers, LLM calls are still traced but may appear as unattributed client traffic. | 2026-05-27: documented path verified by local dogfooding; public smoke coverage is header/config only. |
+| OpenClaw bridge | OpenClaw plugin/package install path; bridge uses the AgentWeave proxy and headers from OpenClaw runtime context. | Configure OpenClaw agents to send provider traffic through the proxy and propagate `X-AgentWeave-*` headers on delegated calls. | `prov.agent.id`, `prov.agent.type`, `prov.project`, `prov.session.id`, `prov.parent_session_id`, `prov.llm.model`, token fields, and `cost.usd` when usage is available. | Bridge installs are environment-specific today. Public docs should avoid private hostnames and show localhost/k8s-neutral proxy addresses. | 2026-05-27: dogfooded in OpenClaw; needs a public bridge smoke harness before marking certified. |
+| Plain Anthropic SDK | `pip install anthropic agentweave-sdk[proxy]` | `ANTHROPIC_BASE_URL=http://localhost:4000/v1 ANTHROPIC_API_KEY=... python your_app.py` | `prov.llm.provider=anthropic`; `prov.llm.model`; `prov.llm.prompt_tokens`, `prov.llm.completion_tokens`, `prov.llm.total_tokens`; `cost.usd`; optional session/project/agent headers. | Streaming support and response-shape edge cases should be tested per SDK version. Proxy mode only traces calls that use the configured base URL. | 2026-05-27: supported proxy route documented; full version certification pending. |
+| Plain OpenAI SDK | `pip install openai agentweave-sdk[proxy]` | `OPENAI_BASE_URL=http://localhost:4000/v1 OPENAI_API_KEY=... python your_app.py` | `prov.llm.provider=openai`; `prov.llm.model`; token fields from `usage`; `cost.usd`; optional session/project/agent headers. | Some frameworks use custom client objects; confirm they honor `base_url` or `OPENAI_BASE_URL`. | 2026-05-27: covered by framework smoke examples using OpenAI-compatible clients. |
+| Plain Gemini SDK | `pip install google-genai agentweave-sdk[proxy]` | Configure Gemini SDK traffic to the proxy's Gemini-compatible route, then set `GEMINI_API_KEY` normally. | `prov.llm.provider=google`; `prov.llm.model`; token fields when the Gemini response includes usage metadata; optional session/project/agent headers. | Gemini SDK base URL configuration differs by package/version. Treat this as preview until a pinned example is added. | 2026-05-27: proxy route documented; public example and smoke coverage pending. |
+
+## Attribute Contract
+
+For developer preview, integrations should preserve this minimum span contract:
+
+| Attribute | Required when | Purpose |
+|-----------|---------------|---------|
+| `prov.llm.model` | Every LLM span | Groups cost, latency, and quality by model. |
+| `prov.llm.prompt_tokens` | Provider returns prompt usage | Cost and prompt-size analysis. |
+| `prov.llm.completion_tokens` | Provider returns completion usage | Cost and output-size analysis. |
+| `prov.llm.total_tokens` | Provider returns total usage or it can be derived | Cross-provider token rollups. |
+| `cost.usd` | Model pricing is known | Cost rollups by agent/session/model. |
+| `prov.agent.id` | Agent identity is known | Distinguishes orchestrators, workers, hooks, and tools. |
+| `prov.agent.type` | Agent role is known | Separates main agents, delegated agents, hooks, and subagents. |
+| `prov.project` | Project/app identity is known | Keeps unrelated systems separated in shared telemetry. |
+| `prov.session.id` | Conversation/task/session identity is known | Filters all spans for one agent run. |
+| `prov.parent_session_id` | Delegation crosses an agent boundary | Connects child agent sessions to parent sessions. |
+
+## Certification Levels
+
+| Level | Meaning |
+|-------|---------|
+| Documented | Public docs explain the integration path and caveats. |
+| Smoke checked | Offline scaffolding verifies example files, syntax, and proxy configuration. |
+| Dogfooded | Used in a real AgentWeave/OpenClaw workflow with useful spans. |
+| Certified | A clean checkout can run an automated provider or mocked-provider smoke test and assert emitted span attributes. |
+
+Current developer preview target: at least `Smoke checked` for framework
+examples and `Dogfooded` for Claude Code/OpenClaw bridge paths. `Certified`
+requires a mocked provider or local fixture proxy that can assert emitted OTLP
+spans without real API keys.

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,26 +15,23 @@ This directory contains two sets of examples:
 ## 🟡 Golden Path Scenarios
 
 These three demos each isolate a real production problem and show how
-AgentWeave makes it visible. Each runs against the live proxy at
-`http://192.168.1.70:30400/v1` and produces real traces in Grafana Tempo.
+AgentWeave makes it visible. Each can run against a local AgentWeave proxy and
+emit traces to any OpenTelemetry-compatible backend.
 
 ### Prerequisites
 
 ```bash
-# Point at the AgentWeave proxy (handles Anthropic auth internally)
-export ANTHROPIC_BASE_URL=http://192.168.1.70:30400/v1
-export ANTHROPIC_API_KEY=dummy   # proxy injects the real key — see note below
+# Point at the AgentWeave proxy.
+export ANTHROPIC_BASE_URL=http://localhost:4000/v1
+export ANTHROPIC_API_KEY=sk-ant-...
 
 # Python deps (from repo root)
 pip install anthropic
 pip install -e sdk/python/
 ```
 
-> **Proxy-side key injection:** Setting `ANTHROPIC_API_KEY=dummy` works when
-> the proxy operator has configured `AGENTWEAVE_ANTHROPIC_API_KEY` on the
-> proxy host. The proxy replaces the dummy value with the real credential
-> before forwarding to Anthropic. If you're running your own proxy without
-> this env var set, supply your real API key instead.
+If you are running your own proxy, use your normal provider API key. Private
+proxy-side credential injection is not required for these examples.
 
 ### Scenario overview
 
@@ -52,9 +49,8 @@ python examples/02-agent-delegation/main.py
 python examples/03-tool-failure/main.py
 ```
 
-After each run, traces appear in Grafana Tempo under
-`https://o11y.arnabsaha.com/explore`. Filter by `session.id` using the
-session ID printed at the end of each script.
+After each run, traces appear in your configured OTLP backend. Filter by
+`session.id` using the session ID printed at the end of each script.
 
 ### What to look for in the dashboard
 
@@ -102,6 +98,18 @@ python langgraph_example.py
 Traces are emitted via OTLP and visible in Grafana Tempo, Jaeger, Langfuse, or
 any OpenTelemetry-compatible backend.
 
+## Offline smoke checks
+
+From the repo root, run:
+
+```bash
+scripts/compatibility-smoke.sh
+```
+
+The smoke checks are offline-friendly: they validate the framework example
+files, Python syntax, local proxy defaults, and compatibility docs without
+calling provider APIs or requiring API keys.
+
 ## Framework examples
 
 | Framework | Directory | Description |
@@ -127,4 +135,4 @@ Your Agent ──base_url=http://localhost:4000/v1──> AgentWeave Proxy :4000
 ```
 
 Replace `http://localhost:4000/v1` with your proxy endpoint if deployed
-elsewhere (e.g. `http://192.168.1.70:30400/v1`).
+elsewhere.

--- a/scripts/compatibility-smoke.sh
+++ b/scripts/compatibility-smoke.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+"$PYTHON_BIN" - <<'PY'
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import sys
+
+root = Path.cwd()
+
+framework_examples = {
+    "LangGraph": {
+        "script": root / "examples/langgraph/langgraph_example.py",
+        "readme": root / "examples/langgraph/README.md",
+        "requirements": root / "examples/langgraph/requirements.txt",
+        "needles": ["AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1", "ChatOpenAI"],
+    },
+    "CrewAI": {
+        "script": root / "examples/crewai/crew_example.py",
+        "readme": root / "examples/crewai/README.md",
+        "requirements": root / "examples/crewai/requirements.txt",
+        "needles": ["AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1", "LLM("],
+    },
+    "AutoGen": {
+        "script": root / "examples/autogen/autogen_example.py",
+        "readme": root / "examples/autogen/README.md",
+        "requirements": root / "examples/autogen/requirements.txt",
+        "needles": ["AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1", "OpenAIChatCompletionClient"],
+    },
+    "OpenAI Agents SDK": {
+        "script": root / "examples/openai-agents-sdk/agents_example.py",
+        "readme": root / "examples/openai-agents-sdk/README.md",
+        "requirements": root / "examples/openai-agents-sdk/requirements.txt",
+        "needles": ["AGENTWEAVE_PROXY_URL", "http://localhost:4000/v1", "AsyncOpenAI"],
+    },
+}
+
+compat_doc = root / "docs/compatibility.md"
+required_doc_terms = [
+    "LangGraph",
+    "CrewAI",
+    "AutoGen",
+    "OpenAI Agents SDK",
+    "Claude Code",
+    "OpenClaw bridge",
+    "Plain Anthropic SDK",
+    "Plain OpenAI SDK",
+    "Plain Gemini SDK",
+    "prov.agent.id",
+    "prov.llm.model",
+    "prov.project",
+    "prov.session.id",
+    "cost.usd",
+    "Last-tested signal",
+]
+private_terms = [
+    "192.168.",
+    "arnabsaha.com",
+    "o11y.",
+    "30400",
+    "30418",
+    "proxy injects",
+]
+
+failures: list[str] = []
+
+if not compat_doc.exists():
+    failures.append("missing docs/compatibility.md")
+else:
+    text = compat_doc.read_text()
+    for term in required_doc_terms:
+        if term not in text:
+            failures.append(f"docs/compatibility.md missing {term!r}")
+    for term in private_terms:
+        if term in text:
+            failures.append(f"docs/compatibility.md contains private/local term {term!r}")
+
+for name, cfg in framework_examples.items():
+    for key in ("script", "readme", "requirements"):
+        if not cfg[key].exists():
+            failures.append(f"{name}: missing {cfg[key].relative_to(root)}")
+
+    script = cfg["script"]
+    if script.exists():
+        source = script.read_text()
+        try:
+            ast.parse(source, filename=str(script))
+        except SyntaxError as exc:
+            failures.append(f"{name}: syntax error in {script.relative_to(root)}: {exc}")
+        for needle in cfg["needles"]:
+            if needle not in source:
+                failures.append(f"{name}: {script.relative_to(root)} missing {needle!r}")
+
+    readme = cfg["readme"]
+    if readme.exists():
+        readme_text = readme.read_text()
+        if "http://localhost:4000/v1" not in readme_text:
+            failures.append(f"{name}: README missing local proxy quickstart")
+        for term in private_terms:
+            if term in readme_text:
+                failures.append(f"{name}: README contains private/local term {term!r}")
+
+if failures:
+    print("Compatibility smoke failed:")
+    for failure in failures:
+        print(f" - {failure}")
+    sys.exit(1)
+
+print("Compatibility smoke passed:")
+for name in framework_examples:
+    print(f" - {name}: example files, syntax, and local proxy wiring verified")
+print(" - docs/compatibility.md: matrix and public guidance verified")
+PY


### PR DESCRIPTION
## Summary
- replace the stale version matrix with a developer-preview agent framework compatibility matrix
- document expected span attributes, caveats, last-tested signals, and local-first quickstarts
- add offline `scripts/compatibility-smoke.sh` and point examples at local proxy defaults

## Verification
- `bash -n scripts/compatibility-smoke.sh`
- `scripts/compatibility-smoke.sh`
- `git diff --check`

Fixes #203
