### PR TITLE
docs: add sanitized dogfood demo traces

### DIFF
--- a/docs/demo-traces.md
+++ b/docs/demo-traces.md
@@ -1,0 +1,82 @@
+# Demo Traces
+
+AgentWeave's strongest public demo is dogfooding: AgentWeave observing agents
+that are improving AgentWeave. Public demos must use sanitized fixtures rather
+than private production traces.
+
+The developer-preview fixture lives in:
+
+```text
+examples/05-dogfood-demo/demo-trace.json
+```
+
+It is designed to support screenshot/demo work for:
+
+- overview pages showing total agents, spans, LLM calls, cost, and errors
+- session views showing parent/child agent causality
+- replay views showing LLM calls, tool calls, and a recoverable tool error
+
+## Local Preview
+
+From the repo root:
+
+```bash
+python -m http.server 8050
+```
+
+Open:
+
+```text
+http://localhost:8050/examples/05-dogfood-demo/
+```
+
+This preview works offline except for browser loading itself. It does not need
+AgentWeave services, Grafana, Tempo, private URLs, or API keys.
+
+## Fixture Contract
+
+The fixture is not a full OpenTelemetry export. It is a stable, public demo
+contract that dashboard demo-mode or docs tooling can adapt:
+
+- `privacy` documents what has been removed
+- `trace.summary` powers overview metrics
+- `agents` powers session graph nodes and parent/child edges
+- `spans` powers replay timelines
+- `attributes["prov.llm.model"]`, token fields, and `cost.usd` power model and
+  cost attribution
+- `events` carries sanitized exception details
+
+Prefer additive changes. Existing keys should remain stable so screenshots and
+demo-mode code do not churn.
+
+## Sanitization Rules
+
+Public demo traces must not include:
+
+- raw prompt or completion text
+- private hostnames, tunnels, dashboards, or LAN/Kubernetes IPs
+- absolute local paths
+- API keys, access tokens, account ids, customer data, or real private trace ids
+
+Use summaries such as `input_summary` and `output_summary` when a screenshot
+needs to explain intent.
+
+## Validation
+
+Run these checks before using the fixture in public material:
+
+```bash
+python -m json.tool examples/05-dogfood-demo/demo-trace.json >/tmp/agentweave-demo-trace.json
+python - <<'PY'
+from pathlib import Path
+needles = ["arnab" + "saha.com", "192" + ".168.", "10" + ".43.", "/" + "home/", "/" + "Users/", "sk" + "-"]
+for root in [Path("examples/05-dogfood-demo"), Path("docs/demo-traces.md")]:
+    paths = root.rglob("*") if root.is_dir() else [root]
+    for path in paths:
+        if path.is_file() and any(needle in path.read_text(errors="ignore") for needle in needles):
+            raise SystemExit(f"private value found in {path}")
+PY
+```
+
+The privacy scan should exit cleanly. If it fails, replace the value with
+`localhost`, `example.invalid`, a relative path, or a redacted summary.

--- a/examples/05-dogfood-demo/README.md
+++ b/examples/05-dogfood-demo/README.md
@@ -1,0 +1,86 @@
+# Example 05: Public Dogfood Demo
+
+This package is the public-safe version of the "AgentWeave building
+AgentWeave" story. It is meant for developer preview screenshots, docs, and
+conference/demo recordings without depending on private NAS infrastructure or
+raw production traces.
+
+The fixture shows:
+
+- parent/child agent causality from a maintainer agent to three child agents
+- model attribution across Anthropic, OpenAI, and Google-style calls
+- token and cost attribution per LLM span
+- one recoverable tool error that demonstrates debugging value
+- redacted input/output summaries instead of private prompt text
+
+## Files
+
+- `demo-trace.json` - sanitized fixture data for dashboard/demo-mode import
+- `index.html` - small static viewer for staging public screenshots
+- `screenshot-checklist.md` - screenshot checklist for overview/session/replay assets
+
+## Run The Local Demo
+
+From the repo root:
+
+```bash
+python -m http.server 8050
+```
+
+Then open:
+
+```text
+http://localhost:8050/examples/05-dogfood-demo/
+```
+
+No AgentWeave proxy, Grafana, Tempo, private tunnel, or cloud credentials are
+required. The viewer reads only `demo-trace.json`.
+
+## Use As Dashboard Fixture Source
+
+Dashboard/demo-mode work can consume `demo-trace.json` directly. The fixture is
+structured around stable public concepts:
+
+- `agents[]` defines session graph nodes and `parent_session_id` edges
+- `spans[]` defines replay order, status, duration, and redacted IO summaries
+- `attributes["prov.llm.*"]` defines provider/model/token fields
+- `attributes["cost.usd"]` defines per-call cost attribution
+- `events[]` carries the sanitized exception event for the error span
+
+Keep any renderer tolerant of extra fields so this fixture can evolve without
+breaking screenshots.
+
+## Privacy Boundary
+
+The fixture intentionally does not include:
+
+- raw prompt or completion text
+- private hostnames, tunnels, dashboards, or NAS URLs
+- absolute local file paths
+- API keys, tokens, account ids, or customer data
+- real trace ids from private dogfooding runs
+
+If you update the fixture, run:
+
+```bash
+python -m json.tool examples/05-dogfood-demo/demo-trace.json >/tmp/agentweave-demo-trace.json
+python - <<'PY'
+from pathlib import Path
+needles = ["arnab" + "saha.com", "192" + ".168.", "10" + ".43.", "/" + "home/", "/" + "Users/", "sk" + "-"]
+for path in Path("examples/05-dogfood-demo").rglob("*"):
+    if path.is_file() and any(needle in path.read_text(errors="ignore") for needle in needles):
+        raise SystemExit(f"private value found in {path}")
+PY
+```
+
+The privacy scan should exit cleanly.
+
+## Screenshot Story
+
+Use this fixture to capture three public assets:
+
+- Overview: AgentWeave can summarize an agentic run across agents, tokens,
+  cost, and errors.
+- Session: AgentWeave preserves causality across delegated child agents.
+- Replay: AgentWeave makes a tool validation failure explainable without
+  leaking private prompt text.

--- a/examples/05-dogfood-demo/demo-trace.json
+++ b/examples/05-dogfood-demo/demo-trace.json
@@ -1,0 +1,322 @@
+{
+  "schema_version": "agentweave.demo_trace.v1",
+  "demo_id": "agentweave-public-dogfood-demo-2026-05-27",
+  "title": "AgentWeave building AgentWeave",
+  "description": "Sanitized dogfood fixture for public screenshots and local demos. The trace shows a maintainer agent delegating to child agents, attributing model cost, and surfacing a tool validation error without private prompt text.",
+  "privacy": {
+    "sanitized": true,
+    "contains_private_prompt_text": false,
+    "contains_private_file_paths": false,
+    "contains_private_urls": false,
+    "redaction_policy": [
+      "Prompt and completion bodies are replaced with intent summaries.",
+      "Hostnames use localhost or example.invalid only.",
+      "Repository paths are relative or generic.",
+      "Secrets, tokens, account ids, and user data are omitted."
+    ]
+  },
+  "screenshot_sources": {
+    "local_viewer": "http://localhost:8050/examples/05-dogfood-demo/",
+    "fixture_file": "examples/05-dogfood-demo/demo-trace.json",
+    "recommended_assets": [
+      "screenshots/public-demo-overview.png",
+      "screenshots/public-demo-session.png",
+      "screenshots/public-demo-replay.png"
+    ]
+  },
+  "trace": {
+    "trace_id": "demo-trace-agentweave-000001",
+    "root_session_id": "demo-session-maintainer-001",
+    "started_at": "2026-05-27T17:00:00.000Z",
+    "ended_at": "2026-05-27T17:00:21.820Z",
+    "project": "agentweave",
+    "summary": {
+      "agent_count": 4,
+      "span_count": 11,
+      "llm_call_count": 4,
+      "tool_call_count": 3,
+      "error_count": 1,
+      "total_tokens": 18940,
+      "total_cost_usd": 0.0867
+    }
+  },
+  "agents": [
+    {
+      "agent_id": "maintainer-agent",
+      "agent_type": "orchestrator",
+      "session_id": "demo-session-maintainer-001",
+      "parent_session_id": null,
+      "task_label": "prepare developer preview demo package"
+    },
+    {
+      "agent_id": "docs-worker",
+      "agent_type": "subagent",
+      "session_id": "demo-session-docs-001",
+      "parent_session_id": "demo-session-maintainer-001",
+      "task_label": "write public demo instructions"
+    },
+    {
+      "agent_id": "fixture-worker",
+      "agent_type": "subagent",
+      "session_id": "demo-session-fixture-001",
+      "parent_session_id": "demo-session-maintainer-001",
+      "task_label": "generate sanitized trace fixture"
+    },
+    {
+      "agent_id": "review-worker",
+      "agent_type": "subagent",
+      "session_id": "demo-session-review-001",
+      "parent_session_id": "demo-session-maintainer-001",
+      "task_label": "review privacy and screenshot readiness"
+    }
+  ],
+  "spans": [
+    {
+      "span_id": "span-001",
+      "parent_span_id": null,
+      "name": "agent.maintainer_agent",
+      "kind": "agent",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:00.000Z",
+      "duration_ms": 21820,
+      "attributes": {
+        "prov.agent.id": "maintainer-agent",
+        "prov.agent.type": "orchestrator",
+        "prov.session.id": "demo-session-maintainer-001",
+        "prov.project": "agentweave",
+        "prov.task.label": "prepare developer preview demo package"
+      },
+      "redacted_io": {
+        "input_summary": "User asks for a public dogfood demo package.",
+        "output_summary": "Creates sanitized fixture, docs, and screenshot checklist."
+      }
+    },
+    {
+      "span_id": "span-002",
+      "parent_span_id": "span-001",
+      "name": "llm.plan_demo_package",
+      "kind": "llm",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:01.050Z",
+      "duration_ms": 3120,
+      "attributes": {
+        "prov.agent.id": "maintainer-agent",
+        "prov.session.id": "demo-session-maintainer-001",
+        "prov.llm.provider": "anthropic",
+        "prov.llm.model": "claude-sonnet-4-6",
+        "prov.llm.prompt_tokens": 4820,
+        "prov.llm.completion_tokens": 930,
+        "prov.llm.total_tokens": 5750,
+        "cost.usd": 0.0335
+      },
+      "redacted_io": {
+        "input_summary": "Summarize requirements and split work among child agents.",
+        "output_summary": "Plan includes fixture, documentation, and screenshot checklist."
+      }
+    },
+    {
+      "span_id": "span-003",
+      "parent_span_id": "span-001",
+      "name": "tool.search_open_issues",
+      "kind": "tool",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:04.420Z",
+      "duration_ms": 740,
+      "attributes": {
+        "prov.agent.id": "maintainer-agent",
+        "prov.session.id": "demo-session-maintainer-001",
+        "tool.name": "github.search_issues",
+        "tool.input.redacted": true
+      },
+      "redacted_io": {
+        "input_summary": "Search for overlapping public demo and screenshot issues.",
+        "output_summary": "Finds issue 206 as the demo package owner."
+      }
+    },
+    {
+      "span_id": "span-004",
+      "parent_span_id": "span-001",
+      "name": "agent.docs_worker",
+      "kind": "agent",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:05.300Z",
+      "duration_ms": 8240,
+      "attributes": {
+        "prov.agent.id": "docs-worker",
+        "prov.agent.type": "subagent",
+        "prov.session.id": "demo-session-docs-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.project": "agentweave",
+        "prov.task.label": "write public demo instructions"
+      },
+      "redacted_io": {
+        "input_summary": "Draft instructions for running the demo without private infrastructure.",
+        "output_summary": "Produces README and screenshot checklist guidance."
+      }
+    },
+    {
+      "span_id": "span-005",
+      "parent_span_id": "span-004",
+      "name": "llm.write_demo_docs",
+      "kind": "llm",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:05.920Z",
+      "duration_ms": 2840,
+      "attributes": {
+        "prov.agent.id": "docs-worker",
+        "prov.session.id": "demo-session-docs-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.llm.provider": "openai",
+        "prov.llm.model": "gpt-4.1-mini",
+        "prov.llm.prompt_tokens": 3180,
+        "prov.llm.completion_tokens": 1210,
+        "prov.llm.total_tokens": 4390,
+        "cost.usd": 0.0044
+      },
+      "redacted_io": {
+        "input_summary": "Turn acceptance criteria into public docs.",
+        "output_summary": "Documents localhost viewer, fixture usage, and privacy checks."
+      }
+    },
+    {
+      "span_id": "span-006",
+      "parent_span_id": "span-001",
+      "name": "agent.fixture_worker",
+      "kind": "agent",
+      "status": "error",
+      "started_at": "2026-05-27T17:00:05.520Z",
+      "duration_ms": 10380,
+      "attributes": {
+        "prov.agent.id": "fixture-worker",
+        "prov.agent.type": "subagent",
+        "prov.session.id": "demo-session-fixture-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.project": "agentweave",
+        "prov.task.label": "generate sanitized trace fixture"
+      },
+      "redacted_io": {
+        "input_summary": "Create synthetic trace data that preserves causality and costs.",
+        "output_summary": "Initial fixture fails privacy validation, then is corrected."
+      }
+    },
+    {
+      "span_id": "span-007",
+      "parent_span_id": "span-006",
+      "name": "llm.generate_fixture",
+      "kind": "llm",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:06.180Z",
+      "duration_ms": 3920,
+      "attributes": {
+        "prov.agent.id": "fixture-worker",
+        "prov.session.id": "demo-session-fixture-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.llm.provider": "google",
+        "prov.llm.model": "gemini-2.5-pro",
+        "prov.llm.prompt_tokens": 6020,
+        "prov.llm.completion_tokens": 1640,
+        "prov.llm.total_tokens": 7660,
+        "cost.usd": 0.0388
+      },
+      "redacted_io": {
+        "input_summary": "Generate public demo spans with model and cost attribution.",
+        "output_summary": "Creates a fixture containing one invalid private URL placeholder."
+      }
+    },
+    {
+      "span_id": "span-008",
+      "parent_span_id": "span-006",
+      "name": "tool.validate_fixture_privacy",
+      "kind": "tool",
+      "status": "error",
+      "started_at": "2026-05-27T17:00:10.340Z",
+      "duration_ms": 410,
+      "attributes": {
+        "prov.agent.id": "fixture-worker",
+        "prov.session.id": "demo-session-fixture-001",
+        "tool.name": "fixture_privacy_validator",
+        "error.type": "SanitizationError",
+        "error.message": "Fixture contained a non-public host placeholder.",
+        "error.recoverable": true
+      },
+      "events": [
+        {
+          "name": "exception",
+          "timestamp": "2026-05-27T17:00:10.690Z",
+          "attributes": {
+            "exception.type": "SanitizationError",
+            "exception.message": "Replace private host placeholder with localhost or example.invalid."
+          }
+        }
+      ],
+      "redacted_io": {
+        "input_summary": "Validate fixture against public-demo privacy rules.",
+        "output_summary": "Rejects one host placeholder before any screenshot asset is produced."
+      }
+    },
+    {
+      "span_id": "span-009",
+      "parent_span_id": "span-006",
+      "name": "tool.rewrite_fixture_hosts",
+      "kind": "tool",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:11.010Z",
+      "duration_ms": 530,
+      "attributes": {
+        "prov.agent.id": "fixture-worker",
+        "prov.session.id": "demo-session-fixture-001",
+        "tool.name": "fixture_sanitizer",
+        "tool.output.changed_fields": 1
+      },
+      "redacted_io": {
+        "input_summary": "Replace rejected host placeholder.",
+        "output_summary": "Fixture now uses only localhost and example.invalid references."
+      }
+    },
+    {
+      "span_id": "span-010",
+      "parent_span_id": "span-001",
+      "name": "agent.review_worker",
+      "kind": "agent",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:13.860Z",
+      "duration_ms": 5140,
+      "attributes": {
+        "prov.agent.id": "review-worker",
+        "prov.agent.type": "subagent",
+        "prov.session.id": "demo-session-review-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.project": "agentweave",
+        "prov.task.label": "review privacy and screenshot readiness"
+      },
+      "redacted_io": {
+        "input_summary": "Review whether the demo fixture is safe to publish.",
+        "output_summary": "Approves fixture after checking causality, cost, and privacy boundaries."
+      }
+    },
+    {
+      "span_id": "span-011",
+      "parent_span_id": "span-010",
+      "name": "llm.review_public_readiness",
+      "kind": "llm",
+      "status": "ok",
+      "started_at": "2026-05-27T17:00:14.260Z",
+      "duration_ms": 2460,
+      "attributes": {
+        "prov.agent.id": "review-worker",
+        "prov.session.id": "demo-session-review-001",
+        "prov.parent_session_id": "demo-session-maintainer-001",
+        "prov.llm.provider": "anthropic",
+        "prov.llm.model": "claude-haiku-4-5",
+        "prov.llm.prompt_tokens": 920,
+        "prov.llm.completion_tokens": 220,
+        "prov.llm.total_tokens": 1140,
+        "cost.usd": 0.01
+      },
+      "redacted_io": {
+        "input_summary": "Check screenshot readiness and demo claims.",
+        "output_summary": "Confirms the fixture supports overview, session, and replay screenshots."
+      }
+    }
+  ]
+}

--- a/examples/05-dogfood-demo/index.html
+++ b/examples/05-dogfood-demo/index.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AgentWeave Public Dogfood Demo</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f5ef;
+        --ink: #1b1f24;
+        --muted: #607080;
+        --line: #d8d1c2;
+        --panel: #fffdf8;
+        --accent: #2f6f73;
+        --blue: #365d9d;
+        --red: #b94b4b;
+        --gold: #a66b19;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font: 15px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 32px 24px 48px;
+      }
+
+      header {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 24px;
+        align-items: end;
+        border-bottom: 1px solid var(--line);
+        padding-bottom: 24px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: 36px;
+        line-height: 1.05;
+        letter-spacing: 0;
+      }
+
+      h2 {
+        font-size: 18px;
+        margin-bottom: 12px;
+      }
+
+      .subtitle {
+        margin-top: 10px;
+        max-width: 720px;
+        color: var(--muted);
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--panel);
+        padding: 7px 11px;
+        color: var(--accent);
+        font-weight: 700;
+        white-space: nowrap;
+      }
+
+      .grid {
+        display: grid;
+        gap: 18px;
+      }
+
+      .stats {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        margin: 24px 0;
+      }
+
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 16px;
+      }
+
+      .stat-label {
+        color: var(--muted);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .stat-value {
+        display: block;
+        margin-top: 6px;
+        font-size: 25px;
+        font-weight: 760;
+      }
+
+      .section {
+        margin-top: 28px;
+      }
+
+      .agents {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+      }
+
+      .agent {
+        min-height: 150px;
+      }
+
+      .agent small,
+      .span small {
+        display: block;
+        margin-top: 6px;
+        color: var(--muted);
+      }
+
+      .agent-title {
+        font-weight: 760;
+      }
+
+      .agent-type {
+        margin-top: 10px;
+        color: var(--blue);
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      .timeline {
+        display: grid;
+        gap: 10px;
+      }
+
+      .span {
+        display: grid;
+        grid-template-columns: 130px 1fr 120px 110px;
+        gap: 14px;
+        align-items: center;
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-left: 5px solid var(--accent);
+        border-radius: 8px;
+        padding: 12px 14px;
+      }
+
+      .span.llm {
+        border-left-color: var(--blue);
+      }
+
+      .span.tool {
+        border-left-color: var(--gold);
+      }
+
+      .span.error {
+        border-left-color: var(--red);
+      }
+
+      .kind {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      .cost {
+        font-variant-numeric: tabular-nums;
+        font-weight: 760;
+      }
+
+      code {
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: #f1ede3;
+        padding: 2px 5px;
+        font: 13px/1.3 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+
+      .privacy {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 18px;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      @media (max-width: 860px) {
+        header,
+        .privacy {
+          grid-template-columns: 1fr;
+        }
+
+        .stats,
+        .agents {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .span {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>AgentWeave building AgentWeave</h1>
+          <p class="subtitle">
+            Sanitized dogfood trace fixture for public screenshots. It preserves
+            parent/child causality, model/cost attribution, and a recoverable
+            tool error without exposing private prompts, paths, or URLs.
+          </p>
+        </div>
+        <div class="badge">public demo fixture</div>
+      </header>
+
+      <section class="grid stats" id="stats"></section>
+
+      <section class="section">
+        <h2>Session Causality</h2>
+        <div class="grid agents" id="agents"></div>
+      </section>
+
+      <section class="section">
+        <h2>Replay Timeline</h2>
+        <div class="timeline" id="timeline"></div>
+      </section>
+
+      <section class="section privacy">
+        <div class="card">
+          <h2>Screenshot Targets</h2>
+          <ul>
+            <li>Overview: totals, agents, costs, and error count.</li>
+            <li>Session: maintainer to docs/fixture/review child agents.</li>
+            <li>Replay: LLM calls, tool call, and recoverable validation error.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h2>Privacy Boundary</h2>
+          <ul id="privacy"></ul>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const money = new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 4
+      });
+
+      function renderStats(summary) {
+        const stats = [
+          ["Agents", summary.agent_count],
+          ["Spans", summary.span_count],
+          ["LLM calls", summary.llm_call_count],
+          ["Errors", summary.error_count],
+          ["Cost", money.format(summary.total_cost_usd)]
+        ];
+        document.querySelector("#stats").innerHTML = stats
+          .map(([label, value]) => `<div class="card"><span class="stat-label">${label}</span><span class="stat-value">${value}</span></div>`)
+          .join("");
+      }
+
+      function renderAgents(agents) {
+        document.querySelector("#agents").innerHTML = agents
+          .map((agent) => `
+            <article class="card agent">
+              <div class="agent-title">${agent.agent_id}</div>
+              <small><code>${agent.session_id}</code></small>
+              <div class="agent-type">${agent.agent_type}</div>
+              <small>parent: ${agent.parent_session_id ? `<code>${agent.parent_session_id}</code>` : "none"}</small>
+              <small>${agent.task_label}</small>
+            </article>
+          `)
+          .join("");
+      }
+
+      function renderTimeline(spans) {
+        document.querySelector("#timeline").innerHTML = spans
+          .map((span) => {
+            const attrs = span.attributes || {};
+            const model = attrs["prov.llm.model"] || attrs["tool.name"] || attrs["prov.agent.type"] || "span";
+            const tokens = attrs["prov.llm.total_tokens"] ? `${attrs["prov.llm.total_tokens"]} tokens` : `${span.duration_ms} ms`;
+            const cost = typeof attrs["cost.usd"] === "number" ? money.format(attrs["cost.usd"]) : "";
+            return `
+              <article class="span ${span.kind} ${span.status === "error" ? "error" : ""}">
+                <div><div class="kind">${span.kind}</div><small>${span.status}</small></div>
+                <div><strong>${span.name}</strong><small>${span.redacted_io.output_summary}</small></div>
+                <div><code>${model}</code><small>${tokens}</small></div>
+                <div class="cost">${cost}</div>
+              </article>
+            `;
+          })
+          .join("");
+      }
+
+      async function main() {
+        const response = await fetch("./demo-trace.json");
+        const data = await response.json();
+        renderStats(data.trace.summary);
+        renderAgents(data.agents);
+        renderTimeline(data.spans);
+        document.querySelector("#privacy").innerHTML = data.privacy.redaction_policy
+          .map((item) => `<li>${item}</li>`)
+          .join("");
+      }
+
+      main().catch((error) => {
+        document.body.innerHTML = `<main><h1>Demo failed to load</h1><p>${error.message}</p></main>`;
+      });
+    </script>
+  </body>
+</html>

--- a/examples/05-dogfood-demo/screenshot-checklist.md
+++ b/examples/05-dogfood-demo/screenshot-checklist.md
@@ -1,0 +1,88 @@
+# Public Demo Screenshot Checklist
+
+Use `demo-trace.json` as the source for public developer-preview screenshots.
+Do not capture screenshots from Arnab's private Grafana, Tempo, NAS, or tunnel
+hosts for public materials.
+
+## Before Capture
+
+- Run the local viewer with `python -m http.server 8050`.
+- Open `http://localhost:8050/examples/05-dogfood-demo/`.
+- Confirm the page loads from `demo-trace.json`, not production traces.
+- Confirm the browser address bar, bookmarks bar, and private extensions are
+  hidden or cropped out.
+- Confirm no private hostnames, IPs, file paths, prompts, or tokens are visible.
+
+## Overview Asset
+
+Target filename: `screenshots/public-demo-overview.png`
+
+Must show:
+
+- title: `AgentWeave building AgentWeave`
+- agent count
+- span count
+- LLM call count
+- total cost
+- error count
+
+Avoid:
+
+- raw JSON
+- terminal panes containing local paths
+- private Grafana sidebar or data-source names
+
+## Session Asset
+
+Target filename: `screenshots/public-demo-session.png`
+
+Must show:
+
+- `maintainer-agent` as orchestrator/root
+- `docs-worker`, `fixture-worker`, and `review-worker` as child agents
+- `parent_session_id` edges or equivalent visual grouping
+- task labels that are generic enough for public docs
+
+Avoid:
+
+- private agent names from live dogfooding
+- real user conversation text
+- private project paths
+
+## Replay Asset
+
+Target filename: `screenshots/public-demo-replay.png`
+
+Must show:
+
+- ordered agent, LLM, and tool spans
+- at least two different model labels
+- token/cost attribution on LLM spans
+- `tool.validate_fixture_privacy` as a recoverable error
+- redacted input/output summaries, not raw prompts
+
+Avoid:
+
+- full prompts or completions
+- real stack traces
+- screenshots that imply the error is an AgentWeave product failure
+
+## Final Privacy Pass
+
+Before committing new screenshot files, inspect them manually and rerun:
+
+```bash
+python -m json.tool examples/05-dogfood-demo/demo-trace.json >/tmp/agentweave-demo-trace.json
+python - <<'PY'
+from pathlib import Path
+needles = ["arnab" + "saha.com", "192" + ".168.", "10" + ".43.", "/" + "home/", "/" + "Users/", "sk" + "-"]
+for root in [Path("examples/05-dogfood-demo"), Path("screenshots/README.md")]:
+    paths = root.rglob("*") if root.is_dir() else [root]
+    for path in paths:
+        if path.is_file() and any(needle in path.read_text(errors="ignore") for needle in needles):
+            raise SystemExit(f"private value found in {path}")
+PY
+```
+
+The privacy scan should exit cleanly. Existing legacy screenshot docs may still
+mention older private demo context until they are separately cleaned up.


### PR DESCRIPTION
## Summary
- add sanitized public dogfood demo trace fixture and local static viewer
- document the demo trace contract and privacy boundary
- add screenshot checklist for public overview/session/replay assets

## Verification
- `python3 -m json.tool examples/05-dogfood-demo/demo-trace.json >/tmp/agentweave-demo-trace.json`
- privacy scan for private hostnames/IPs/paths/secrets passed
- `git diff --check`

Fixes #206
