### PR TITLE
docs: align developer preview version truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,27 @@ No cloud, no SaaS, no enterprise tier. Just the tool.
 
 ## Install
 
+AgentWeave is in developer preview. Start with a local proxy and a local OTLP
+collector; private dogfood deployments live in runbooks, not in the public
+quickstart.
+
 | SDK | Language | Install |
 |-----|----------|---------|
 | [sdk/python](./sdk/python) | Python | `pip install agentweave-sdk` |
 | [sdk/js](./sdk/js) | TypeScript / JavaScript | `npm install agentweave-sdk` |
 | [sdk/go](./sdk/go) | Go | `go get github.com/arniesaha/agentweave-go` |
+
+### Local proxy path
+
+```bash
+pip install "agentweave-sdk[proxy]"
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+export ANTHROPIC_BASE_URL=http://localhost:4000/v1
+```
+
+Use your normal provider API key in the client environment. Proxy-side key
+injection and private NodePort URLs are dogfood-only conveniences, not required
+for the public developer-preview path.
 
 ## Quickstart (Python)
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,75 +1,66 @@
-# AgentWeave — Project Status
-*Last updated: March 20, 2026*
+# AgentWeave Project Status
 
----
+Last updated: 2026-05-27
 
-## Current State (v0.2.x)
+## Current Release Line
 
-### Proxy
-- Multi-provider transparent proxy: Anthropic, OpenAI, Google Gemini
-- Deployed on k3s NAS: NodePort 30400 (nix-v1), 30401 (max-v1), 30402 (nix-subagent-v1)
-- Reads `AGENTWEAVE_AGENT_TYPE` from env — auto-tags spans with `prov.agent.type`
-- Session context via `POST /session` or env vars: `AGENTWEAVE_SESSION_ID`, `AGENTWEAVE_PARENT_SESSION_ID`, `AGENTWEAVE_TASK_LABEL`, `AGENTWEAVE_AGENT_TYPE`
-- Prefer per-session-key isolation for concurrent agents: include `session_key` in `POST /session` and send `x-agentweave-session-key` + optional `x-agentweave-task-label` on each proxied LLM request
-- Attribution precedence: explicit per-request headers beat legacy global forced context (issue #189). For delegated Claude Code launches, use `scripts/claude-delegate.sh`. See `docs/attribution-runbook.md`.
-- Sub-agent attribution: `prov.parent.session.id`, `prov.agent.type`, `prov.task.label`
-- traceparent passthrough: reads incoming `traceparent` header, sets `prov.trace.parent` on span, forwards downstream
-- Benchmarks: ~6ms p50 overhead on LLM calls (<2%)
+AgentWeave is in developer preview on the `0.3.x` line.
 
-### Dashboard (v25)
-- Live at agentweave.arnabsaha.com (NodePort 30896)
-- Overview tab: LLM calls, cost, latency by model over time
-- Session Explorer tab: interactive multi-level sub-agent graph with parent→child edges
-- Session replay: click any node → session ID auto-fills → "Open in Grafana" opens Tempo Explore
-- Nodes coloured by agent type (main = purple, subagent = teal)
-- Time range filter: 15m / 1h / 3h / 6h / 24h / 7d
-- Fullscreen mode with body scroll lock
-- Mobile-friendly stat cards (responsive font sizing)
+| Component | Current version/source | Status |
+|---|---:|---|
+| Python SDK / proxy | `0.3.0` in `sdk/python/pyproject.toml` | Active |
+| TypeScript SDK | `0.3.0` in `sdk/js/package.json` | Active |
+| Go SDK | tag-based module `github.com/arniesaha/agentweave-go` | Preview |
+| Dashboard | built from `dashboard/` | Dogfooded |
 
-### Python SDK (`agentweave-sdk==0.1.1` on PyPI)
-- `@trace_tool`, `@trace_agent`, `@trace_llm` decorators
-- `auto_instrument()` — zero-decorator patching for Anthropic + OpenAI SDKs
-- W3C PROV-O OTel spans, W3C TraceContext propagation
-- Sub-agent attribution parameters: `parent_session_id`, `agent_type`, `turn_depth`
-- 240 tests passing
+## Public Developer-Preview Path
 
-### TypeScript SDK (`agentweave-sdk` on npm)
-- Same decorator API as Python: `traceAgent`, `traceTool`, `traceLlm`
-- W3C trace context propagation
-- 10 tests passing
+The public quickstart should stay local-first:
 
-### Go SDK (`go get github.com/arniesaha/agentweave-go`)
-- `TraceTool`, `TraceAgent`, `TraceLlm`
-- 4 tests passing
+```bash
+pip install "agentweave-sdk[proxy]"
+agentweave proxy start --port 4000 --endpoint http://localhost:4318
+export ANTHROPIC_BASE_URL=http://localhost:4000/v1
+```
 
-### Dogfooding (Live)
-- Nix (NAS OpenClaw): all LLM calls traced via NodePort 30400, tagged `nix-v1 / main`
-- Max (Mac Mini): all LLM calls traced via NodePort 30401, tagged `max-v1 / main`
-- Sub-agents (Claude Code spawns): traced via NodePort 30402, tagged `nix-subagent-v1 / subagent`
-- Grafana + Tempo: `http://192.168.1.70:30300`
+Use normal provider API keys in the local environment. Private NAS NodePorts,
+tunnels, and proxy-side credential injection belong in dogfood runbooks rather
+than public setup docs.
 
----
+## What Works Today
 
-## Recently Closed Issues
-| # | Title | Closed |
-|---|-------|--------|
-| #100 | feat: session-level distributed tracing (#44) | Mar 20, 2026 |
-| #99 | fix: compute_cost called without cache token counts | Mar 19, 2026 |
-| #98 | docs: update stale docs | Mar 19, 2026 |
-| #97 | README: update screenshots + framework example backlinks | Mar 18, 2026 |
-| #96 | Dashboard: sub-agent edges not rendered | Mar 18, 2026 |
+- Multi-provider transparent proxy paths for Anthropic, OpenAI-compatible, and
+  Gemini-compatible APIs.
+- Python SDK decorators and `auto_instrument()` for Anthropic/OpenAI clients.
+- TypeScript and Go SDKs with basic tracing APIs.
+- OpenClaw bridge dogfooding with session, agent, model, token, and cost
+  attribution.
+- Dashboard views for overview, routing, session graph, and replay.
+- Framework examples for LangGraph, CrewAI, AutoGen, and OpenAI Agents SDK.
 
-## Open Issues
-| # | Title | Notes |
-|---|-------|-------|
-| #31 | feat: evals, prompt management, and review framework | Post-core — deferred |
-| #2 | ci: publish to PyPI on version tags via GitHub Actions | Nice-to-have |
-| #91 | ci: npm publish workflow for TypeScript SDK | Nice-to-have |
+## Launch-Readiness Focus
 
----
+The developer-preview milestone is about confidence before broader public
+distribution:
 
-## Repo
+1. Agentic install/debugging through `agentweave doctor`.
+2. Compatibility matrix and smoke checks for common agent frameworks.
+3. Docs/version/source-of-truth consistency.
+4. Dogfood trace data-quality gate.
+5. Sanitized dogfood demo traces and public screenshots.
+
+## Private Dogfood Deployment
+
+Arnab's live dogfood stack runs on private infrastructure and is intentionally
+not the public install path. Internal details such as LAN IPs, Kubernetes
+ClusterIPs, and Cloudflare tunnel hosts should stay in deployment runbooks.
+
+Useful private runbooks:
+
+- `docs/DEPLOYMENT-RUNBOOK.md`
+- `docs/attribution-runbook.md`
+- `docs/project-tracking.md`
+
+## Repository
+
 https://github.com/arniesaha/agentweave
-
-## Local Path
-`/home/Arnab/dev/agentweave`

--- a/docs/proxy-setup.md
+++ b/docs/proxy-setup.md
@@ -3,16 +3,17 @@
 The AgentWeave proxy is a transparent HTTP server that sits between your agents and the Anthropic API. Every LLM call gets an OTel span — no SDK changes required.
 
 ```
-Claude Code (Mac Mini) ──┐
-Claude Code (NAS)     ──┤
-OpenClaw/Nix          ──┤──→ agentweave-proxy :4000 ──→ api.anthropic.com
-Max / pi-agent        ──┤         │
-Nix A2A Server        ──┤    OTel spans → Tempo
-Max A2A Server        ──┘
+Claude Code ──┐
+OpenClaw    ──┤──→ agentweave-proxy :4000 ──→ api.anthropic.com
+Python app  ──┘         │
+                   OTel spans → Tempo / Jaeger / Langfuse
 ```
 
-All clients share a single proxy instance (k8s NodePort 30400). Per-request
-`X-AgentWeave-Agent-Id` headers handle attribution.
+For a local developer-preview install, run the proxy on `localhost:4000` and
+point clients at `http://localhost:4000`. Shared k8s NodePorts and proxy-side
+credential injection are private dogfood deployment choices, not requirements.
+Per-request `X-AgentWeave-Agent-Id` headers handle attribution when several
+agents share one proxy.
 
 ## Prerequisites
 
@@ -63,7 +64,7 @@ systemctl --user enable --now agentweave-proxy
 
 ## Wire up your agents
 
-### OpenClaw / Nix (NAS)
+### OpenClaw
 
 Add to `~/.openclaw/openclaw.json`:
 
@@ -72,7 +73,7 @@ Add to `~/.openclaw/openclaw.json`:
   "models": {
     "providers": {
       "anthropic": {
-        "baseUrl": "http://192.168.1.70:30400",
+        "baseUrl": "http://localhost:4000",
         "headers": {
           "X-AgentWeave-Agent-Id": "nix-v1",
           "X-AgentWeave-Agent-Type": "main"
@@ -86,14 +87,14 @@ Add to `~/.openclaw/openclaw.json`:
 
 Then reload: `openclaw gateway restart`
 
-### Claude Code (Mac Mini or NAS)
+### Claude Code
 
 Add to `~/.claude/settings.json`:
 
 ```json
 {
   "env": {
-    "ANTHROPIC_BASE_URL": "http://192.168.1.70:30400",
+    "ANTHROPIC_BASE_URL": "http://localhost:4000",
     "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-mac\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code"
   }
 }
@@ -101,16 +102,16 @@ Add to `~/.claude/settings.json`:
 
 New Claude Code sessions will route through the proxy. See [claude-code-proxy.md](claude-code-proxy.md) for full details.
 
-### Max / pi-agent (Mac Mini)
+### Any shell-launched agent
 
-Set in `~/max/projects/agent-max/.env`:
+Set in the agent environment:
 
 ```bash
-ANTHROPIC_BASE_URL=http://192.168.1.70:30400
+ANTHROPIC_BASE_URL=http://localhost:4000
 ```
 
-The AgentWeave JS SDK handles per-request attribution headers automatically.
-Restart: `launchctl stop com.arnab.agent-max && launchctl start com.arnab.agent-max`
+The AgentWeave JS SDK or client default headers can add per-request attribution
+headers automatically.
 
 ### Any Python agent (Anthropic SDK)
 
@@ -128,7 +129,7 @@ With the single-proxy architecture, the `X-AgentWeave-Agent-Id` header is how ev
 
 ```python
 client = anthropic.Anthropic(
-    base_url="http://192.168.1.70:30400",
+    base_url="http://localhost:4000",
     default_headers={"X-AgentWeave-Agent-Id": "my-agent-v1"},
 )
 ```
@@ -192,7 +193,7 @@ Clients that already hold a valid API key or OAuth token send it directly. The p
 
 ```bash
 # Claude Code — key comes from ~/.claude/settings.json or ANTHROPIC_API_KEY
-curl http://192.168.1.70:30400/v1/messages \
+curl http://localhost:4000/v1/messages \
   -H "x-api-key: $ANTHROPIC_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
@@ -204,7 +205,7 @@ External clients that don't hold their own API key can send a dummy key (`dummy`
 
 ```bash
 # External script — no real key needed locally
-curl http://192.168.1.70:30400/v1/messages \
+curl http://localhost:4000/v1/messages \
   -H "x-api-key: dummy" \
   -H "X-AgentWeave-Agent-Id: gpu-pc-v1" \
   -H "Content-Type: application/json" \
@@ -229,7 +230,7 @@ kubectl rollout restart deployment/agentweave-proxy -n agentweave
 **Verify key injection is active:**
 
 ```bash
-curl http://192.168.1.70:30400/health
+curl http://localhost:4000/health
 # Should include: "key_injection": {"anthropic": true}
 ```
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,8 +15,8 @@ AgentWeave is currently in **0.x.y pre-release**. During this phase:
 
 | Component | Current Version | Location |
 |-----------|----------------|----------|
-| Proxy + Python SDK | `0.2.0` | `sdk/python/pyproject.toml` |
-| TypeScript SDK | `0.2.5` | `sdk/js/package.json` |
+| Proxy + Python SDK | `0.3.0` | `sdk/python/pyproject.toml`, `sdk/python/agentweave/__init__.py`, `sdk/python/agentweave/proxy.py` |
+| TypeScript SDK | `0.3.0` | `sdk/js/package.json` |
 | Go SDK | `v0.x.y` | `sdk/go/go.mod` (tag-based) |
 | Docker image | matches proxy version | built from `deploy/docker/Dockerfile` |
 
@@ -45,7 +45,7 @@ AgentWeave is currently in **0.x.y pre-release**. During this phase:
 
 ### Bumping a version
 
-1. **Proxy + Python SDK** — update `version` in `sdk/python/pyproject.toml`
+1. **Proxy + Python SDK** — update `version` in `sdk/python/pyproject.toml`, `sdk/python/agentweave/__init__.py`, and `sdk/python/agentweave/proxy.py`
 2. **TypeScript SDK** — update `version` in `sdk/js/package.json`
 3. **Go SDK** — create a git tag: `git tag sdk/go/v0.x.y && git push origin sdk/go/v0.x.y`
 4. **Docker image** — rebuilt automatically; tag matches proxy version

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -405,7 +405,9 @@ def hooks_uninstall(
 @app.command("version")
 def version() -> None:
     """Show the AgentWeave version."""
-    console.print("[bold]agentweave[/bold] v0.1.0")
+    from agentweave import __version__
+
+    console.print(f"[bold]agentweave[/bold] v{__version__}")
 
 
 if __name__ == "__main__":

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -268,7 +268,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.2.0",
+    version="0.3.0",
 )
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -52,8 +52,8 @@ dev = [
 agentweave = "agentweave.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/arnabsaha/agentweave"
-Issues = "https://github.com/arnabsaha/agentweave/issues"
+Homepage = "https://github.com/arniesaha/agentweave"
+Issues = "https://github.com/arniesaha/agentweave/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["agentweave"]


### PR DESCRIPTION
## Summary
- align README and status docs around a local-first developer-preview path
- update Python/proxy/package metadata to the current `0.3.0` source of truth and correct repository URLs
- scrub public proxy setup examples away from private NAS URLs and point them at localhost defaults

## Verification
- `grep -RIn "arnabsaha/agentweave\|0\.2\.0\|0\.1\.1\|v25" README.md docs/STATUS.md docs/versioning.md docs/proxy-setup.md sdk/python/pyproject.toml sdk/python/agentweave/__init__.py sdk/python/agentweave/proxy.py || true`
- `grep -RIn "192\.168\.1\.70\|10\.43\." docs/proxy-setup.md README.md docs/STATUS.md || true`
- `python3 -m pytest sdk/python/tests/test_proxy.py::TestDetectProvider sdk/python/tests/test_health.py`
- `git diff --check`

Fixes #204
