### PR TITLE
feat(cli): add local proxy lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ quickstart.
 
 ```bash
 pip install "agentweave-sdk[proxy]"
-agentweave proxy start --port 4000 --endpoint http://localhost:4318
+agentweave start --port 4000 --endpoint http://localhost:4318
 export ANTHROPIC_BASE_URL=http://localhost:4000/v1
 ```
+
+Use `agentweave status` to inspect the local proxy and `agentweave stop` when
+you are done. `agentweave proxy start` remains available for foreground runs.
 
 Use your normal provider API key in the client environment. Proxy-side key
 injection and private NodePort URLs are dogfood-only conveniences, not required

--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -1,8 +1,9 @@
-"""AgentWeave CLI — ``agentweave trace show/list/export``."""
+"""AgentWeave CLI — local lifecycle, proxy, hooks, and trace helpers."""
 
 from __future__ import annotations
 
 import json
+import time
 from typing import Optional
 
 import typer
@@ -38,6 +39,123 @@ def _get_provider():
     if isinstance(provider, TracerProvider):
         return provider
     return None
+
+
+def _format_started_at(started_at: float) -> str:
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(started_at))
+
+
+# ---------------------------------------------------------------------------
+# agentweave start / stop / status
+# ---------------------------------------------------------------------------
+
+
+@app.command("start")
+def start(
+    port: int = typer.Option(4000, "--port", "-p", help="Port to listen on."),
+    host: str = typer.Option("127.0.0.1", "--host", help="Host to bind to."),
+    endpoint: Optional[str] = typer.Option(
+        None,
+        "--endpoint",
+        "-e",
+        help="OTLP HTTP endpoint (e.g. http://localhost:4318). Overrides AGENTWEAVE_OTLP_ENDPOINT.",
+    ),
+    agent_id: Optional[str] = typer.Option(
+        None, "--agent-id", help="Default agent ID tag for all traced calls."
+    ),
+    capture_prompts: bool = typer.Option(
+        False,
+        "--capture-prompts",
+        help="Record first 512 chars of prompt and response in span attributes.",
+    ),
+    auth_token: Optional[str] = typer.Option(
+        None,
+        "--auth-token",
+        help="Bearer token required on incoming requests. Also reads from AGENTWEAVE_PROXY_TOKEN env var.",
+    ),
+) -> None:
+    """Start a CLI-managed local AgentWeave proxy in the background."""
+    from agentweave.lifecycle import start_proxy_process
+
+    try:
+        state = start_proxy_process(
+            host=host,
+            port=port,
+            endpoint=endpoint,
+            agent_id=agent_id,
+            capture_prompts=capture_prompts,
+            auth_token=auth_token,
+        )
+    except RuntimeError as exc:
+        console.print(f"[yellow]{exc}[/yellow]")
+        console.print("Run [bold]agentweave status[/bold] or [bold]agentweave stop[/bold].")
+        raise typer.Exit(code=1)
+
+    console.print(f"[green]AgentWeave proxy started[/green] pid=[bold]{state.pid}[/bold]")
+    console.print(f"  URL      : [cyan]{state.url}[/cyan]")
+    console.print(f"  Logs     : [dim]{state.log_file}[/dim]")
+    console.print(f"  Started  : [dim]{_format_started_at(state.started_at)}[/dim]")
+    console.print()
+    console.print(f"  Set in your agent: [bold]ANTHROPIC_BASE_URL={state.url}[/bold]")
+
+
+@app.command("stop")
+def stop(
+    timeout: float = typer.Option(
+        5.0,
+        "--timeout",
+        min=0.1,
+        help="Seconds to wait for graceful proxy shutdown.",
+    ),
+) -> None:
+    """Stop the CLI-managed local AgentWeave proxy."""
+    from agentweave.lifecycle import stop_proxy_process
+
+    result, state = stop_proxy_process(timeout_seconds=timeout)
+    if result == "stopped" and state:
+        console.print(f"[green]AgentWeave proxy stopped[/green] pid=[bold]{state.pid}[/bold]")
+        return
+    if result == "killed" and state:
+        console.print(f"[yellow]AgentWeave proxy was force-stopped[/yellow] pid=[bold]{state.pid}[/bold]")
+        return
+    if result == "stale" and state:
+        console.print(f"[yellow]Removed stale proxy state[/yellow] pid=[bold]{state.pid}[/bold]")
+        return
+    console.print("[yellow]AgentWeave proxy is not running.[/yellow]")
+
+
+@app.command("status")
+def status(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit machine-readable JSON instead of text.",
+    ),
+) -> None:
+    """Show status for the CLI-managed local AgentWeave proxy."""
+    from agentweave.lifecycle import current_status, state_file
+
+    current, state = current_status()
+    payload = {
+        "status": current,
+        "state_file": str(state_file()),
+        "proxy": state.to_dict() if state else None,
+    }
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if current == "running" and state:
+        console.print(f"[green]AgentWeave proxy is running[/green] pid=[bold]{state.pid}[/bold]")
+        console.print(f"  URL      : [cyan]{state.url}[/cyan]")
+        console.print(f"  Logs     : [dim]{state.log_file}[/dim]")
+        console.print(f"  Started  : [dim]{_format_started_at(state.started_at)}[/dim]")
+        return
+    if current == "stale" and state:
+        console.print(f"[yellow]AgentWeave proxy state is stale[/yellow] pid=[bold]{state.pid}[/bold]")
+        console.print("Run [bold]agentweave stop[/bold] to remove the stale state file.")
+        return
+    console.print("[yellow]AgentWeave proxy is not running.[/yellow]")
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/agentweave/lifecycle.py
+++ b/sdk/python/agentweave/lifecycle.py
@@ -1,0 +1,233 @@
+"""Local AgentWeave proxy lifecycle helpers.
+
+These helpers intentionally manage only a developer-preview local proxy
+process. They do not try to be a service manager, and they keep state in a
+small per-user file so the CLI can report and stop the process it started.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+STATE_ENV_VAR = "AGENTWEAVE_STATE_DIR"
+
+
+@dataclass(frozen=True)
+class ProxyState:
+    """Persisted state for a CLI-managed local proxy."""
+
+    pid: int
+    host: str
+    port: int
+    url: str
+    command: list[str]
+    log_file: str
+    started_at: float
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ProxyState":
+        return cls(
+            pid=int(payload["pid"]),
+            host=str(payload["host"]),
+            port=int(payload["port"]),
+            url=str(payload["url"]),
+            command=[str(part) for part in payload["command"]],
+            log_file=str(payload["log_file"]),
+            started_at=float(payload["started_at"]),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def state_dir() -> Path:
+    """Return the per-user AgentWeave state directory."""
+
+    override = os.getenv(STATE_ENV_VAR)
+    if override:
+        return Path(override).expanduser()
+
+    if sys.platform == "win32":
+        base = os.getenv("LOCALAPPDATA") or os.getenv("APPDATA")
+        return Path(base).expanduser() / "AgentWeave" if base else Path.home() / "AppData" / "Local" / "AgentWeave"
+
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "agentweave"
+
+    base = os.getenv("XDG_STATE_HOME")
+    return Path(base).expanduser() / "agentweave" if base else Path.home() / ".local" / "state" / "agentweave"
+
+
+def state_file() -> Path:
+    return state_dir() / "proxy.json"
+
+
+def log_file() -> Path:
+    return state_dir() / "proxy.log"
+
+
+def read_state() -> ProxyState | None:
+    path = state_file()
+    if not path.exists():
+        return None
+    try:
+        return ProxyState.from_dict(json.loads(path.read_text()))
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def write_state(state: ProxyState) -> None:
+    path = state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state.to_dict(), indent=2, sort_keys=True) + "\n")
+
+
+def clear_state() -> None:
+    try:
+        state_file().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def is_process_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def current_status() -> tuple[str, ProxyState | None]:
+    """Return ``running``, ``stale``, or ``stopped`` with any known state."""
+
+    state = read_state()
+    if not state:
+        return "stopped", None
+    if is_process_running(state.pid):
+        return "running", state
+    return "stale", state
+
+
+def start_proxy_process(
+    *,
+    host: str,
+    port: int,
+    endpoint: str | None = None,
+    agent_id: str | None = None,
+    capture_prompts: bool = False,
+    auth_token: str | None = None,
+) -> ProxyState:
+    """Start a detached local proxy process and persist its state."""
+
+    existing_status, existing_state = current_status()
+    if existing_status == "running" and existing_state:
+        raise RuntimeError(f"AgentWeave proxy is already running as pid {existing_state.pid}.")
+    if existing_status == "stale":
+        clear_state()
+
+    path = log_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        sys.executable,
+        "-m",
+        "agentweave.cli",
+        "proxy",
+        "start",
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+    if endpoint:
+        command.extend(["--endpoint", endpoint])
+    if agent_id:
+        command.extend(["--agent-id", agent_id])
+    if capture_prompts:
+        command.append("--capture-prompts")
+    if auth_token:
+        command.extend(["--auth-token", auth_token])
+
+    env = os.environ.copy()
+    stdout = path.open("ab")
+    creationflags = 0
+    popen_kwargs: dict[str, object] = {}
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(subprocess, "DETACHED_PROCESS", 0)
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=subprocess.STDOUT,
+            env=env,
+            close_fds=os.name != "nt",
+            creationflags=creationflags,
+            **popen_kwargs,
+        )
+    finally:
+        stdout.close()
+
+    state = ProxyState(
+        pid=process.pid,
+        host=host,
+        port=port,
+        url=f"http://localhost:{port}",
+        command=command,
+        log_file=str(path),
+        started_at=time.time(),
+    )
+    write_state(state)
+    return state
+
+
+def stop_proxy_process(*, timeout_seconds: float = 5.0) -> tuple[str, ProxyState | None]:
+    """Stop the CLI-managed proxy if it is still running."""
+
+    status, state = current_status()
+    if not state:
+        return "stopped", None
+    if status == "stale":
+        clear_state()
+        return "stale", state
+
+    try:
+        os.kill(state.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        clear_state()
+        return "stale", state
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if not is_process_running(state.pid):
+            clear_state()
+            return "stopped", state
+        time.sleep(0.1)
+
+    if os.name != "nt":
+        try:
+            os.kill(state.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            clear_state()
+            return "stopped", state
+
+    clear_state()
+    return "killed", state

--- a/sdk/python/tests/test_lifecycle.py
+++ b/sdk/python/tests/test_lifecycle.py
@@ -1,0 +1,139 @@
+"""Tests for local proxy lifecycle helpers and CLI commands."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("typer", reason="CLI deps not installed")
+
+
+def test_start_proxy_process_writes_state(monkeypatch, tmp_path):
+    import agentweave.lifecycle as lifecycle
+
+    launched = {}
+
+    class FakeProcess:
+        pid = 12345
+
+    def fake_popen(command, **kwargs):
+        launched["command"] = command
+        launched["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setenv(lifecycle.STATE_ENV_VAR, str(tmp_path))
+    monkeypatch.setattr(lifecycle.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(lifecycle, "is_process_running", lambda pid: False)
+
+    state = lifecycle.start_proxy_process(
+        host="127.0.0.1",
+        port=4100,
+        endpoint="http://localhost:4318",
+        agent_id="local-dev",
+        capture_prompts=True,
+        auth_token="secret",
+    )
+
+    assert state.pid == 12345
+    assert state.url == "http://localhost:4100"
+    assert launched["command"][:4] == [
+        lifecycle.sys.executable,
+        "-m",
+        "agentweave.cli",
+        "proxy",
+    ]
+    assert launched["command"][4:] == [
+        "start",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "4100",
+        "--endpoint",
+        "http://localhost:4318",
+        "--agent-id",
+        "local-dev",
+        "--capture-prompts",
+        "--auth-token",
+        "secret",
+    ]
+    assert lifecycle.state_file().exists()
+
+    payload = json.loads(lifecycle.state_file().read_text())
+    assert payload["pid"] == 12345
+    assert payload["port"] == 4100
+    assert payload["log_file"].endswith("proxy.log")
+
+
+def test_start_proxy_process_refuses_running_state(monkeypatch, tmp_path):
+    import agentweave.lifecycle as lifecycle
+
+    monkeypatch.setenv(lifecycle.STATE_ENV_VAR, str(tmp_path))
+    lifecycle.write_state(
+        lifecycle.ProxyState(
+            pid=999,
+            host="127.0.0.1",
+            port=4000,
+            url="http://localhost:4000",
+            command=["agentweave", "proxy", "start"],
+            log_file=str(tmp_path / "proxy.log"),
+            started_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lifecycle, "is_process_running", lambda pid: True)
+
+    with pytest.raises(RuntimeError, match="already running"):
+        lifecycle.start_proxy_process(host="127.0.0.1", port=4000)
+
+
+def test_stop_proxy_process_clears_stale_state(monkeypatch, tmp_path):
+    import agentweave.lifecycle as lifecycle
+
+    monkeypatch.setenv(lifecycle.STATE_ENV_VAR, str(tmp_path))
+    lifecycle.write_state(
+        lifecycle.ProxyState(
+            pid=999,
+            host="127.0.0.1",
+            port=4000,
+            url="http://localhost:4000",
+            command=["agentweave", "proxy", "start"],
+            log_file=str(tmp_path / "proxy.log"),
+            started_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lifecycle, "is_process_running", lambda pid: False)
+
+    result, state = lifecycle.stop_proxy_process()
+
+    assert result == "stale"
+    assert state is not None
+    assert state.pid == 999
+    assert not lifecycle.state_file().exists()
+
+
+def test_status_cli_json_uses_state_dir(monkeypatch, tmp_path):
+    from typer.testing import CliRunner
+
+    import agentweave.lifecycle as lifecycle
+    from agentweave.cli import app
+
+    monkeypatch.setenv(lifecycle.STATE_ENV_VAR, str(tmp_path))
+    lifecycle.write_state(
+        lifecycle.ProxyState(
+            pid=123,
+            host="127.0.0.1",
+            port=4000,
+            url="http://localhost:4000",
+            command=["agentweave", "proxy", "start"],
+            log_file=str(tmp_path / "proxy.log"),
+            started_at=1.0,
+        )
+    )
+    monkeypatch.setattr(lifecycle, "is_process_running", lambda pid: True)
+
+    result = CliRunner().invoke(app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "running"
+    assert payload["proxy"]["pid"] == 123


### PR DESCRIPTION
## Summary

Adds a PR-sized first slice of #129: local CLI lifecycle commands for the developer-preview proxy.

- adds `agentweave start` to launch a background local proxy
- adds `agentweave status` to inspect the managed proxy state
- adds `agentweave stop` to terminate/clean up the managed proxy
- stores state/log paths in a per-user state directory, overridable by `AGENTWEAVE_STATE_DIR`
- updates README quickstart to use `agentweave start` while keeping `agentweave proxy start` for foreground runs

## Verification

- `python3 -m pytest sdk/python/tests/test_lifecycle.py`
