### PR TITLE
fix(bridge): add install doctor and execution context attrs

### DIFF
--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -160,8 +160,9 @@ cd ~/.openclaw/plugins/agentweave-bridge && npm install
       "agentweave-bridge": {
         "path": "/home/user/clawd/plugins/openclaw-agentweave-bridge",
         "config": {
-          "otlpEndpoint": "http://192.168.1.70:30418",
-          "agentId": "nix-v1",
+          "otlpEndpoint": "http://localhost:4318",
+          "proxyUrl": "http://localhost:4000",
+          "agentId": "openclaw-v1",
           "project": "my-project",
           "enabled": true
         }
@@ -170,6 +171,22 @@ cd ~/.openclaw/plugins/agentweave-bridge && npm install
   }
 }
 ```
+
+Use hostnames or LAN addresses that are reachable from each OpenClaw machine.
+For fleet installs, give each machine a stable `agentId` such as
+`openclaw-laptop`, `openclaw-ci`, or `openclaw-worker-01`.
+
+3. Restart OpenClaw and verify the bridge on that machine:
+
+```bash
+AGENTWEAVE_PROXY_URL=http://localhost:4000 \
+AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318 \
+agentweave doctor
+```
+
+The `openclaw.bridge` check should pass when the plugin is registered and
+enabled. It warns when OpenClaw and AgentWeave configuration hints are present
+but the bridge is missing or disabled.
 
 ### What the plugin does
 

--- a/plugins/openclaw-agentweave-bridge/INSTALL.md
+++ b/plugins/openclaw-agentweave-bridge/INSTALL.md
@@ -5,8 +5,8 @@ OpenClaw plugin that creates root OTel spans per user message, enabling full con
 ## Prerequisites
 
 - OpenClaw installed (`openclaw` CLI available)
-- AgentWeave proxy running (NodePort 30400)
-- Grafana Tempo receiving OTLP (NodePort 30418)
+- AgentWeave proxy running, for example `http://localhost:4000`
+- An OTLP/Tempo collector reachable over HTTP, for example `http://localhost:4318`
 
 ## Step 1 — Install plugin dependencies
 
@@ -26,8 +26,9 @@ Edit `~/.openclaw/openclaw.json` and add the plugin under `plugins.entries`:
       "agentweave-bridge": {
         "path": "/absolute/path/to/agentweave/plugins/openclaw-agentweave-bridge",
         "config": {
-          "otlpEndpoint": "http://192.168.1.70:30418",
-          "agentId": "nix-v1",
+          "otlpEndpoint": "http://localhost:4318",
+          "proxyUrl": "http://localhost:4000",
+          "agentId": "openclaw-v1",
           "project": "agentweave",
           "enabled": true
         }
@@ -42,9 +43,13 @@ Edit `~/.openclaw/openclaw.json` and add the plugin under `plugins.entries`:
 | Field | Required | Default | Description |
 |---|---|---|---|
 | `otlpEndpoint` | ✅ | — | OTLP HTTP endpoint for Grafana Tempo |
-| `agentId` | ❌ | `"nix-v1"` | Agent identifier stamped on all spans |
+| `proxyUrl` | ❌ | `AGENTWEAVE_PROXY_URL` | AgentWeave proxy URL injected into sub-agent provider env vars |
+| `agentId` | ❌ | `"nix-v1"` | Agent identifier stamped on all spans; set this explicitly per machine |
 | `project` | ❌ | — | Project tag for filtering in AgentWeave dashboard |
 | `enabled` | ❌ | `true` | Set to `false` to disable without removing config |
+
+For shared hosts, replace `localhost` with the proxy or collector host that is
+reachable from that machine, such as `http://agentweave-proxy.internal:4000`.
 
 ## Step 3 — Restart OpenClaw
 
@@ -52,24 +57,47 @@ Edit `~/.openclaw/openclaw.json` and add the plugin under `plugins.entries`:
 openclaw gateway restart
 ```
 
-## Step 4 — Verify traces appear
+## Step 4 — Verify the local install
 
-Send a message to your OpenClaw agent. Within ~10 seconds, open Grafana Explore:
+Run AgentWeave doctor on the same machine:
+
+```bash
+AGENTWEAVE_PROXY_URL=http://localhost:4000 \
+AGENTWEAVE_OTLP_ENDPOINT=http://localhost:4318 \
+agentweave doctor
+```
+
+The `openclaw.bridge` check should pass. If it warns, confirm that
+`~/.openclaw/openclaw.json` has a `plugins.entries.agentweave-bridge` entry and
+that `config.enabled` is not `false`.
+
+Then send a message to your OpenClaw agent. Within ~10 seconds, open Grafana Explore:
 
 ```
-http://192.168.1.70:30300/explore
+http://localhost:3000/explore
 ```
 
 Run a TraceQL query:
 ```
-{ resource.service.name = "agentweave-proxy" && span.prov.agent.id = "nix-v1" }
+{ resource.service.name = "agentweave-proxy" && span.prov.agent.id = "openclaw-v1" }
 ```
 
 You should see an `openclaw.turn` root span for the message, with LLM call spans as children.
 
 Or use the AgentWeave dashboard Session Explorer:
-- Open `agentweave.arnabsaha.com` → Sessions tab
+- Open your AgentWeave dashboard → Sessions tab
 - Click your session node → "Open in Grafana"
+
+## Fleet rollout checklist
+
+Repeat these steps on every OpenClaw machine:
+
+1. Copy or clone `plugins/openclaw-agentweave-bridge` to a stable local path.
+2. Run `npm install` in the plugin directory.
+3. Add the `agentweave-bridge` entry to that machine's `openclaw.json`.
+4. Set machine-specific `agentId` / `project` values.
+5. Restart OpenClaw.
+6. Run `agentweave doctor` and confirm `openclaw.bridge` passes.
 
 ## How it works
 

--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -129,6 +129,56 @@ describe("createAgentWeaveBridgeService", () => {
     expect(process.env.AGENTWEAVE_SESSION_ID).toBe("agent:main:test-session")
   })
 
+  it("sets cwd and repository on message.queued when provided by the event", () => {
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:repo-session",
+      sessionId: "repo-session",
+      channel: "cli",
+      source: "user",
+      cwd: "/home/arnab/dev/agentweave",
+      repository: "arniesaha/agentweave",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.cwd", "/home/arnab/dev/agentweave")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.repository", "arniesaha/agentweave")
+  })
+
+  it("omits cwd and repository on message.queued when the event does not provide them", () => {
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:no-repo-session",
+      sessionId: "no-repo-session",
+      channel: "cli",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.cwd", expect.anything())
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.repository", expect.anything())
+  })
+
+  it("sets cwd and repository on session.state subagent roots when provided by the event", () => {
+    fire({
+      type: "session.state",
+      sessionKey: "agent:main:parent:subagent:worker-c",
+      sessionId: "worker-c",
+      state: "processing",
+      raw_data: {
+        cwd: "/home/arnab/dev/agentweave/plugins/openclaw-agentweave-bridge",
+        repository: "arniesaha/agentweave",
+      },
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.cwd", "/home/arnab/dev/agentweave/plugins/openclaw-agentweave-bridge")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.repository", "arniesaha/agentweave")
+  })
+
   it("ends span on message.processed (completed) and cleans env", () => {
     fire({ type: "message.queued", sessionKey: "agent:main:sk-2", sessionId: "sess-b", channel: "cli", source: "user", ts: Date.now(), seq: 1 })
     fire({ type: "message.processed", sessionKey: "agent:main:sk-2", sessionId: "sess-b", channel: "cli", outcome: "completed", durationMs: 1200, ts: Date.now(), seq: 2 })

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -133,6 +133,24 @@ function getSpanSessionId(turn: ActiveTurn): string | undefined {
   return (turn.span as any)?._attributes?.["session.id"] as string | undefined
 }
 
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") continue
+    const trimmed = value.trim()
+    if (trimmed) return trimmed
+  }
+  return undefined
+}
+
+function applyExecutionContextAttrs(span: Span, evt: Record<string, unknown>): void {
+  const rawData = (evt.raw_data ?? evt.rawData) as Record<string, unknown> | undefined
+  const cwd = firstString(evt.cwd, rawData?.cwd)
+  const repository = firstString(evt.repository, rawData?.repository)
+
+  if (cwd) span.setAttribute("prov.cwd", cwd)
+  if (repository) span.setAttribute("prov.repository", repository)
+}
+
 function findTurnForModelUsage(sessionKey: string, sessionId: string): { key: string; turn: ActiveTurn; reason: string } | null {
   const activeKeys = Array.from(activeTurns.keys())
 
@@ -198,7 +216,7 @@ export function createAgentWeaveBridgeService() {
       initSdk(config)
 
       unsubscribe = subscribeToDiagnosticEvents((evt: unknown) => {
-        const e = evt as { type?: string; sessionKey?: string; sessionId?: string; channel?: string; source?: string; outcome?: string; error?: string; durationMs?: number; provider?: string; model?: string; costUsd?: number; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }; toolName?: string; level?: string; detector?: string; count?: number; queueDepth?: number; taskLabel?: string }
+        const e = evt as { type?: string; sessionKey?: string; sessionId?: string; channel?: string; source?: string; outcome?: string; error?: string; durationMs?: number; provider?: string; model?: string; costUsd?: number; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }; toolName?: string; level?: string; detector?: string; count?: number; queueDepth?: number; taskLabel?: string; cwd?: string; repository?: string; raw_data?: { cwd?: string; repository?: string }; rawData?: { cwd?: string; repository?: string } }
         console.log("[agentweave-bridge] event:", e.type, "sessionKey:", e.sessionKey, "source:", e.source)
         try {
           switch (e.type) {
@@ -224,6 +242,7 @@ export function createAgentWeaveBridgeService() {
               if (config.project) span.setAttribute("prov.project", config.project)
               const taskLabel = e.taskLabel?.trim()
               if (taskLabel) span.setAttribute("prov.task.label", taskLabel)
+              applyExecutionContextAttrs(span, e as Record<string, unknown>)
 
               // Link sub-agent to parent session
               if (agentType === "subagent") {
@@ -360,6 +379,7 @@ export function createAgentWeaveBridgeService() {
                   span.setAttribute("prov.agent.type", "subagent")
                   span.setAttribute("prov.activity.type", "agent_turn")
                   if (config.project) span.setAttribute("prov.project", config.project)
+                  applyExecutionContextAttrs(span, e as Record<string, unknown>)
                   // Link to active main session as parent
                   const mainKey = Array.from(activeTurns.keys()).find(k =>
                     k.startsWith("agent:main:") && !k.includes(":subagent:"))

--- a/sdk/python/agentweave/doctor.py
+++ b/sdk/python/agentweave/doctor.py
@@ -13,6 +13,7 @@ import os
 import platform
 import sys
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Mapping
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse, urlunparse
@@ -85,6 +86,7 @@ def run_doctor(
     checks.append(_check_otlp_endpoint(effective_env))
     checks.extend(_check_identity_env(effective_env))
     checks.append(_check_proxy_token(effective_env))
+    checks.append(_check_openclaw_bridge(effective_env))
     checks.append(_check_proxy_health(effective_env, proxy_url, timeout_seconds) if check_proxy else _check_proxy_health_skipped())
     return checks
 
@@ -245,6 +247,83 @@ def _check_proxy_token(env: Mapping[str, str]) -> DoctorCheck:
     )
 
 
+def _check_openclaw_bridge(env: Mapping[str, str]) -> DoctorCheck:
+    config_path = _openclaw_config_path(env)
+    has_openclaw_hint = _has_openclaw_hint(env, config_path)
+    has_agentweave_hint = _has_agentweave_hint(env)
+
+    if not has_openclaw_hint:
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=PASS,
+            message="OpenClaw config was not detected.",
+        )
+
+    if not config_path or not config_path.exists():
+        status = WARN if has_agentweave_hint else PASS
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=status,
+            message="OpenClaw hints are present, but openclaw.json was not found.",
+            suggestion=(
+                "Set OPENCLAW_CONFIG_PATH or install the agentweave-bridge plugin in ~/.openclaw/openclaw.json."
+                if status == WARN
+                else None
+            ),
+            details={"config_path": str(config_path) if config_path else None},
+        )
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=WARN,
+            message=f"OpenClaw config could not be read: {exc}.",
+            suggestion="Check openclaw.json permissions, then rerun `agentweave doctor`.",
+            details={"config_path": str(config_path)},
+        )
+    except json.JSONDecodeError as exc:
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=WARN,
+            message=f"OpenClaw config is not valid JSON: {exc.msg}.",
+            suggestion="Fix openclaw.json, then rerun `agentweave doctor`.",
+            details={"config_path": str(config_path), "line": exc.lineno, "column": exc.colno},
+        )
+
+    bridge_entry = _find_openclaw_bridge_entry(config)
+    if bridge_entry is None:
+        status = WARN if has_agentweave_hint else PASS
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=status,
+            message="OpenClaw config does not include the agentweave-bridge plugin.",
+            suggestion=(
+                "Install plugins/openclaw-agentweave-bridge and add it under plugins.entries in openclaw.json."
+                if status == WARN
+                else None
+            ),
+            details={"config_path": str(config_path)},
+        )
+
+    if _bridge_entry_disabled(bridge_entry):
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=WARN,
+            message="OpenClaw agentweave-bridge plugin is configured but disabled.",
+            suggestion="Set the bridge plugin config `enabled` value to true and restart OpenClaw.",
+            details={"config_path": str(config_path)},
+        )
+
+    return DoctorCheck(
+        name="openclaw.bridge",
+        status=PASS,
+        message="OpenClaw agentweave-bridge plugin is configured.",
+        details={"config_path": str(config_path)},
+    )
+
+
 def _check_proxy_health_skipped() -> DoctorCheck:
     return DoctorCheck(
         name="proxy.health",
@@ -326,6 +405,74 @@ def _first_provider_url(env: Mapping[str, str]) -> str | None:
         if value:
             return value
     return None
+
+
+def _has_agentweave_hint(env: Mapping[str, str]) -> bool:
+    if any(env.get(name, "").strip() for name in PROVIDER_BASE_URLS):
+        return True
+    return any(name.startswith("AGENTWEAVE_") and value.strip() for name, value in env.items())
+
+
+def _has_openclaw_hint(env: Mapping[str, str], config_path: Path | None) -> bool:
+    if any(name.startswith("OPENCLAW_") and value.strip() for name, value in env.items()):
+        return True
+    return bool(config_path and config_path.exists())
+
+
+def _openclaw_config_path(env: Mapping[str, str]) -> Path | None:
+    explicit_path = env.get("OPENCLAW_CONFIG_PATH", "").strip() or env.get("OPENCLAW_CONFIG", "").strip()
+    if explicit_path:
+        return Path(explicit_path).expanduser()
+
+    openclaw_home = env.get("OPENCLAW_HOME", "").strip()
+    if openclaw_home:
+        return Path(openclaw_home).expanduser() / "openclaw.json"
+
+    home = env.get("HOME", "").strip()
+    if not home:
+        return None
+    return Path(home).expanduser() / ".openclaw" / "openclaw.json"
+
+
+def _find_openclaw_bridge_entry(config: object) -> object | None:
+    if not isinstance(config, dict):
+        return None
+    plugins = config.get("plugins")
+    if not isinstance(plugins, dict):
+        return None
+    entries = plugins.get("entries")
+    if not isinstance(entries, dict):
+        return None
+
+    for name, entry in entries.items():
+        if _looks_like_bridge_reference(name) or _entry_references_bridge(entry):
+            return entry
+    return None
+
+
+def _entry_references_bridge(entry: object) -> bool:
+    if isinstance(entry, str):
+        return _looks_like_bridge_reference(entry)
+    if not isinstance(entry, dict):
+        return False
+    return any(
+        _looks_like_bridge_reference(str(entry.get(key, "")))
+        for key in ("id", "name", "package", "path")
+    )
+
+
+def _looks_like_bridge_reference(value: str) -> bool:
+    normalized = value.lower()
+    return "agentweave-bridge" in normalized or "openclaw-agentweave-bridge" in normalized
+
+
+def _bridge_entry_disabled(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("enabled") is False:
+        return True
+    config = entry.get("config")
+    return isinstance(config, dict) and config.get("enabled") is False
 
 
 def _proxy_root_url(value: str) -> str:

--- a/sdk/python/tests/test_doctor.py
+++ b/sdk/python/tests/test_doctor.py
@@ -132,3 +132,68 @@ def test_doctor_unreachable_proxy_is_warning(monkeypatch):
 
     assert proxy_check.status == "warn"
     assert not doctor_module.has_failures(checks)
+
+
+def test_doctor_warns_when_openclaw_bridge_missing_with_agentweave_hints(monkeypatch, tmp_path):
+    import agentweave.doctor as doctor_module
+
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "models": {
+                    "providers": {
+                        "anthropic": {
+                            "baseUrl": "http://localhost:4000/v1",
+                        }
+                    }
+                },
+                "plugins": {"entries": {}},
+            }
+        )
+    )
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    checks = doctor_module.run_doctor(
+        env={
+            **_healthy_env(),
+            "OPENCLAW_CONFIG_PATH": str(config_path),
+        }
+    )
+
+    bridge_check = next(check for check in checks if check.name == "openclaw.bridge")
+    assert bridge_check.status == "warn"
+    assert "does not include" in bridge_check.message
+    assert not doctor_module.has_failures(checks)
+
+
+def test_doctor_passes_when_openclaw_bridge_is_configured(monkeypatch, tmp_path):
+    import agentweave.doctor as doctor_module
+
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "entries": {
+                        "agentweave-bridge": {
+                            "path": "/opt/openclaw/plugins/openclaw-agentweave-bridge",
+                            "config": {"enabled": True},
+                        }
+                    }
+                }
+            }
+        )
+    )
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    checks = doctor_module.run_doctor(
+        env={
+            **_healthy_env(),
+            "OPENCLAW_CONFIG_PATH": str(config_path),
+        }
+    )
+
+    bridge_check = next(check for check in checks if check.name == "openclaw.bridge")
+    assert bridge_check.status == "pass"
+    assert "is configured" in bridge_check.message


### PR DESCRIPTION
## Summary

Adds the next bridge fidelity/distribution slice for #186 and #188.

- adds `prov.cwd` and `prov.repository` stamping on OpenClaw root spans when diagnostic events provide that context
- supports both top-level `cwd` / `repository` and `raw_data` / `rawData` payload shapes
- adds bridge tests for message and sub-agent root spans
- extends `agentweave doctor` with an `openclaw.bridge` check that warns when OpenClaw + AgentWeave hints are present but the bridge is missing/disabled
- updates OpenClaw bridge install docs with local-first proxy/OTLP examples, doctor verification, and fleet rollout checklist

## Verification

- `python3 -m pytest sdk/python/tests/test_doctor.py`
- `git diff --check`

Not run locally: bridge npm tests, because this NAS shell has `node` but no `npm` on PATH. CI should run the JS/plugin checks.

Refs #186.
Closes #188.
