### PR TITLE
ci: preflight npm publish access

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,12 +7,13 @@ Runs on every push and pull request to `main`.
 - Matrix: Python 3.11, 3.12
 - Installs dev dependencies and runs `pytest`
 
-### `publish.yml` — PyPI + Docker Release
+### `publish.yml` — PyPI + npm + Docker Release
 Triggered by pushing a `v*` tag (e.g. `v0.2.0`).
 
 1. **Tests** — same matrix as `test.yml`
 2. **Publish** — builds sdist + wheel, publishes to PyPI via OIDC trusted publishing
-3. **Docker** — builds and pushes to `ghcr.io/arniesaha/agentweave:<version>` and `:latest`
+3. **npm** — builds `sdk/js` and publishes `agentweave-sdk`
+4. **Docker** — builds and pushes to `ghcr.io/arniesaha/agentweave:<version>` and `:latest`
 
 ## How to Release
 
@@ -51,3 +52,45 @@ Create a GitHub environment named **`pypi`** at:
 `Settings → Environments → New environment → "pypi"`
 
 This is referenced in `publish.yml` and required for OIDC token exchange.
+
+## Configuring npm Publishing
+
+The npm job publishes `sdk/js` as the public `agentweave-sdk` package. The
+workflow runs `scripts/npm-publish-preflight.sh --require-auth` before
+`npm publish` so auth and package-access problems fail with a useful message
+instead of a late `npm publish` error.
+
+### Required GitHub setup
+
+Create a GitHub environment named **`npm`** at:
+`Settings -> Environments -> New environment -> "npm"`
+
+Then configure one of these npm auth paths:
+
+1. **Current token-based path:** add a repository or environment secret named
+   `NPM_TOKEN`. It must be an npm automation token for a user that is listed as
+   a maintainer/collaborator on `agentweave-sdk`.
+2. **Future trusted-publishing path:** configure npm trusted publishing for the
+   `arniesaha/agentweave` `publish.yml` workflow and then remove token-based
+   auth from `publish.yml`.
+
+### Diagnosing npm 404 during publish
+
+If the workflow fails with:
+
+```text
+404 Not Found - PUT https://registry.npmjs.org/agentweave-sdk
+```
+
+and `npm view agentweave-sdk version` still shows the previous release, the
+package was not published. For an existing package, that usually means the
+token authenticates as a user that cannot publish `agentweave-sdk`, or the token
+is stale. Fix the npm-side maintainer/token setup, then rerun the tag workflow.
+
+Useful local checks:
+
+```bash
+npm view agentweave-sdk version --registry https://registry.npmjs.org
+NODE_AUTH_TOKEN=... npm whoami --registry https://registry.npmjs.org
+NODE_AUTH_TOKEN=... npm access ls-collaborators agentweave-sdk --json
+```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,13 +95,18 @@ jobs:
         working-directory: sdk/js
         run: npm ci
 
+      - name: Preflight npm publish access
+        run: bash scripts/npm-publish-preflight.sh --require-auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Build
         working-directory: sdk/js
         run: npm run build
 
       - name: Publish to npm
         working-directory: sdk/js
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -135,6 +140,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Validate compatibility smoke script
         run: |
           bash -n scripts/compatibility-smoke.sh
@@ -145,6 +156,11 @@ jobs:
           python -m pip install pytest
           python -m py_compile scripts/trace_quality_gate.py tests/test_trace_quality_gate.py
           python -m pytest tests/test_trace_quality_gate.py
+
+      - name: Validate npm publish preflight script
+        run: |
+          bash -n scripts/npm-publish-preflight.sh
+          bash scripts/npm-publish-preflight.sh
 
   # ── Docker ──────────────────────────────────────────────
   docker:

--- a/scripts/npm-publish-preflight.sh
+++ b/scripts/npm-publish-preflight.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_auth=false
+if [[ "${1:-}" == "--require-auth" ]]; then
+  require_auth=true
+elif [[ "${1:-}" != "" ]]; then
+  echo "usage: $0 [--require-auth]" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+package_dir="$repo_root/sdk/js"
+registry="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org}"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "error: npm CLI is not available on PATH; install Node.js/npm before running the publish preflight." >&2
+  exit 1
+fi
+
+package_name="$(cd "$package_dir" && node -p "require('./package.json').name")"
+package_version="$(cd "$package_dir" && node -p "require('./package.json').version")"
+
+echo "npm publish preflight"
+echo "  package:  $package_name@$package_version"
+echo "  registry: $registry"
+
+if ! npm view "$package_name" name --registry "$registry" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+error: npm package '$package_name' is not visible at $registry.
+
+This usually means the package name is wrong, the package has not been created
+on npm yet, or the workflow token is pointed at the wrong registry. Create or
+claim the package on npm before publishing this release.
+EOF
+  exit 1
+fi
+
+if npm view "$package_name@$package_version" version --registry "$registry" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+error: npm package '$package_name@$package_version' already exists.
+
+npm versions are immutable. Bump sdk/js/package.json before publishing again.
+EOF
+  exit 1
+fi
+
+if [[ "$require_auth" != true ]]; then
+  echo "ok: registry/package checks passed; authenticated checks skipped"
+  exit 0
+fi
+
+if [[ -z "${NODE_AUTH_TOKEN:-}" ]] && [[ -z "$(npm config get //registry.npmjs.org/:_authToken 2>/dev/null || true)" ]]; then
+  cat >&2 <<EOF
+error: npm auth token is not configured.
+
+Set the GitHub Actions NPM_TOKEN secret to an npm automation token for a user
+with publish access to '$package_name', or migrate the workflow to npm trusted
+publishing and remove token-based auth.
+EOF
+  exit 1
+fi
+
+if ! npm_user="$(npm whoami --registry "$registry" 2>/tmp/agentweave-npm-whoami.err)"; then
+  cat >&2 <<EOF
+error: npm auth failed for $registry.
+
+The configured token cannot authenticate with npm. Rotate NPM_TOKEN or configure
+npm trusted publishing before retrying the release.
+
+npm whoami output:
+$(cat /tmp/agentweave-npm-whoami.err)
+EOF
+  exit 1
+fi
+
+collaborators_json="$(mktemp)"
+if ! npm access ls-collaborators "$package_name" --registry "$registry" --json >"$collaborators_json" 2>/tmp/agentweave-npm-access.err; then
+  cat >&2 <<EOF
+error: npm user '$npm_user' cannot read collaborator access for '$package_name'.
+
+The token may authenticate but still lack maintainer/publish rights for this
+package. Add '$npm_user' as a maintainer for '$package_name' or replace
+NPM_TOKEN with a token from a maintainer account.
+
+npm access output:
+$(cat /tmp/agentweave-npm-access.err)
+EOF
+  exit 1
+fi
+
+if ! node -e '
+const fs = require("fs");
+const collaborators = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const user = process.argv[2];
+process.exit(Object.prototype.hasOwnProperty.call(collaborators, user) ? 0 : 1);
+' "$collaborators_json" "$npm_user"; then
+  cat >&2 <<EOF
+error: npm user '$npm_user' is not listed as a collaborator for '$package_name'.
+
+Add '$npm_user' as a maintainer for '$package_name' on npm, then retry the tag
+publish workflow. No secret values were printed.
+EOF
+  exit 1
+fi
+
+echo "ok: npm auth and package access preflight passed for '$npm_user'"


### PR DESCRIPTION
## Summary

Fixes #213.

Adds a small npm publish preflight so release tags fail before `npm publish` when npm auth or package access is misconfigured. The preflight checks:

- npm CLI availability
- registry visibility for `agentweave-sdk`
- target version has not already been published
- `npm whoami` works with the configured token
- authenticated npm user is listed as a collaborator for `agentweave-sdk`

Also updates release docs with the npm environment/secret setup, the likely cause of the `404 Not Found - PUT https://registry.npmjs.org/agentweave-sdk` failure, and local commands for diagnosis.

## Validation

- `bash -n scripts/npm-publish-preflight.sh`
- `bash scripts/npm-publish-preflight.sh` fails locally with the expected `npm CLI is not available on PATH` diagnostic on this NAS shell

## Manual follow-up

The repo still needs npm-side access fixed before `agentweave-sdk@0.3.1` can be published: rotate/fix `NPM_TOKEN` for a maintainer account, add the token user as an npm collaborator, or migrate the workflow to npm trusted publishing.
