### PR TITLE
feat(k8s): add OTel collector fanout path

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -15,7 +15,10 @@ All clients (Nix, Max, Claude Code, A2A servers)
 └───────────────────────────────┘
         │
         ▼ OTLP HTTP
-  tempo.monitoring.svc.cluster.local:4318
+  agentweave-otel-collector.monitoring.svc.cluster.local:4318
+        │
+        ├── Tempo (canonical raw traces)
+        └── Langfuse (optional eval/prompt sink after v3 migration)
         │
         ▼
    api.anthropic.com (upstream)
@@ -51,10 +54,18 @@ kubectl create secret generic agentweave-proxy \
 kubectl apply -f deploy/k8s/namespace.yaml
 kubectl apply -f deploy/k8s/configmap.yaml
 kubectl apply -f deploy/k8s/secret.yaml      # or use kubectl create secret above
+kubectl apply -f deploy/k8s/monitoring/otel-collector-secret.yaml
+kubectl apply -f deploy/k8s/monitoring/otel-collector.yaml
 kubectl apply -f deploy/k8s/deployment.yaml
 kubectl apply -f deploy/k8s/service.yaml
 kubectl apply -f deploy/k8s/dashboard-deployment.yaml
 ```
+
+The default collector manifest exports to Tempo only, so it is safe to place in
+front of the current proxy before the Langfuse upgrade. After Langfuse is on
+v3.22+ and a real `LANGFUSE_OTLP_AUTH_HEADER` secret exists, apply
+`deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml` and restart the
+collector to mirror traces to Langfuse.
 
 ### Dashboard nginx credentials
 

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -4,8 +4,10 @@ metadata:
   name: agentweave-proxy
   namespace: agentweave
 data:
-  # OTLP HTTP endpoint for trace export
-  AGENTWEAVE_OTLP_ENDPOINT: "http://tempo.monitoring.svc.cluster.local:4318"
+  # OTLP HTTP endpoint for trace export.
+  # Dogfood deployments should send to the collector fanout, which keeps Tempo
+  # canonical and can optionally mirror selected spans to Langfuse.
+  AGENTWEAVE_OTLP_ENDPOINT: "http://agentweave-otel-collector.monitoring.svc.cluster.local:4318"
 
   # AGENTWEAVE_AGENT_ID intentionally unset. proxy.py already falls back to
   # "unattributed" (or "unattributed:<project>" when project is known, #199)

--- a/deploy/k8s/monitoring/kustomization.yaml
+++ b/deploy/k8s/monitoring/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namespace: monitoring
 
 resources:
+  - otel-collector-secret.yaml
+  - otel-collector.yaml
   - minio.yaml
   - minio-init-job.yaml
   - tempo-configmap-minio.yaml

--- a/deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml
+++ b/deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml
@@ -1,0 +1,51 @@
+# Apply this file only after Langfuse is upgraded to v3.22+ and a real
+# LANGFUSE_OTLP_AUTH_HEADER secret exists in the monitoring namespace.
+#
+# It intentionally uses the same resource names as otel-collector.yaml so that
+# `kubectl apply -f otel-collector-langfuse-fanout.yaml` switches the collector
+# from Tempo-only export to Tempo + Langfuse fanout.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentweave-otel-collector
+  namespace: monitoring
+  labels:
+    app: agentweave-otel-collector
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 256
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 384
+        spike_limit_mib: 128
+
+    exporters:
+      otlphttp/tempo:
+        endpoint: http://tempo.monitoring.svc.cluster.local:4318
+
+      otlphttp/langfuse:
+        endpoint: http://langfuse.apps.svc.cluster.local:3000/api/public/otel
+        headers:
+          Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
+          x-langfuse-ingestion-version: "4"
+
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlphttp/tempo, otlphttp/langfuse, debug]

--- a/deploy/k8s/monitoring/otel-collector-secret.yaml
+++ b/deploy/k8s/monitoring/otel-collector-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: agentweave-otel-collector
+  namespace: monitoring
+type: Opaque
+stringData:
+  # Base64 value for "pk-lf-...:sk-lf-..." with a "Basic " prefix.
+  # Create the real secret out-of-band:
+  #   echo -n "pk-lf-...:sk-lf-..." | base64 -w 0
+  #   kubectl -n monitoring create secret generic agentweave-otel-collector \
+  #     --from-literal=LANGFUSE_OTLP_AUTH_HEADER="Basic <base64>" \
+  #     --dry-run=client -o yaml | kubectl apply -f -
+  LANGFUSE_OTLP_AUTH_HEADER: "Basic CHANGE_ME"

--- a/deploy/k8s/monitoring/otel-collector.yaml
+++ b/deploy/k8s/monitoring/otel-collector.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentweave-otel-collector
+  namespace: monitoring
+  labels:
+    app: agentweave-otel-collector
+spec:
+  type: ClusterIP
+  selector:
+    app: agentweave-otel-collector
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentweave-otel-collector
+  namespace: monitoring
+  labels:
+    app: agentweave-otel-collector
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+    processors:
+      batch:
+        timeout: 5s
+        send_batch_size: 256
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 384
+        spike_limit_mib: 128
+
+    exporters:
+      otlphttp/tempo:
+        endpoint: http://tempo.monitoring.svc.cluster.local:4318
+
+      debug:
+        verbosity: basic
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [otlphttp/tempo, debug]
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentweave-otel-collector
+  namespace: monitoring
+  labels:
+    app: agentweave-otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentweave-otel-collector
+  template:
+    metadata:
+      labels:
+        app: agentweave-otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.126.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config=/conf/collector.yaml
+          env:
+            - name: LANGFUSE_OTLP_AUTH_HEADER
+              valueFrom:
+                secretKeyRef:
+                  name: agentweave-otel-collector
+                  key: LANGFUSE_OTLP_AUTH_HEADER
+                  optional: true
+          ports:
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 4317
+              name: otlp-grpc
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /conf
+      volumes:
+        - name: config
+          configMap:
+            name: agentweave-otel-collector

--- a/docs/DEPLOYMENT-RUNBOOK.md
+++ b/docs/DEPLOYMENT-RUNBOOK.md
@@ -6,15 +6,17 @@
 
 ## The Big Picture
 
-AgentWeave is a **transparent LLM observability layer**. It sits between your AI agents and the LLM APIs, recording every call as an OpenTelemetry span in Tempo, then visualizing them on a React dashboard backed by Prometheus spanmetrics.
+AgentWeave is a **transparent LLM observability layer**. It sits between your AI agents and the LLM APIs, recording every call as an OpenTelemetry span. Dogfood traffic routes through an OpenTelemetry Collector so Tempo can remain the canonical trace backend while optional sinks such as Langfuse receive mirrored traces for eval workflows.
 
 ```
 Your Agent Code (with per-request X-AgentWeave-* headers)
     ↓
 AgentWeave Proxy (single instance, port 30400)
     ├── forwards request to Anthropic/OpenAI/Gemini
-    ├── writes OTel span → Tempo (:30418 OTLP)
-    └── Tempo → Prometheus remote_write → Grafana
+    ├── writes OTel span → OTel Collector (:4318 OTLP)
+    └── Collector
+        ├── Tempo → Prometheus remote_write → Grafana
+        └── Langfuse (optional, after v3 migration)
 ```
 
 ---
@@ -53,6 +55,7 @@ Tempo is the exception: it uses the official `grafana/tempo` image (public), so 
 ### Namespace: `monitoring`
 | Deployment | Purpose |
 |------------|---------|
+| `agentweave-otel-collector` | OTLP fanout for AgentWeave traces |
 | `tempo` | Trace storage (on Mac Mini node) |
 | `minio` | S3-compatible storage (unused — MinIO config exists but we use local-path) |
 | `kube-prometheus-stack` | Grafana + Prometheus (pre-existing, not AgentWeave-managed) |
@@ -117,7 +120,15 @@ kubectl delete pod -n agentweave -l app=agentweave-proxy
 
 ---
 
-## Tempo Configuration
+## Collector + Tempo Configuration
+
+The proxy writes to `agentweave-otel-collector.monitoring.svc.cluster.local:4318`.
+The default collector config exports to Tempo only. After Langfuse is upgraded
+to v3.22+ and a project API key is available, apply
+`deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml` to mirror traces
+to Langfuse.
+
+Tempo remains the canonical raw trace backend and the dashboard query source.
 
 Config lives in `ConfigMap/tempo-config` in `monitoring` namespace. Key lessons from today:
 

--- a/docs/claude-code-proxy.md
+++ b/docs/claude-code-proxy.md
@@ -6,7 +6,9 @@ LLM call tracing in the AgentWeave dashboard alongside all other agent spans.
 ## Prerequisites
 
 - Single `agentweave-proxy` k8s service deployed on NAS (`192.168.1.70:30400`)
-- Tempo OTLP endpoint reachable at `192.168.1.70:30418`
+- OTLP endpoint reachable by the proxy/bridge. Dogfood proxy traffic now routes
+  to `agentweave-otel-collector.monitoring.svc.cluster.local:4318`, which
+  forwards to Tempo and can mirror to Langfuse after the Langfuse v3 migration.
 
 ## Setup — Mac Mini (192.168.1.149)
 

--- a/docs/langfuse-dual-export.md
+++ b/docs/langfuse-dual-export.md
@@ -1,0 +1,128 @@
+# Langfuse Dual Export Spike
+
+Issue: <https://github.com/arniesaha/agentweave/issues/218>
+
+## Decision
+
+Keep Tempo as the canonical AgentWeave trace backend. Add Langfuse as an
+optional second sink for LLM/product workflows: prompt iteration, sessions,
+datasets, human review, LLM-as-judge scores, and context-handoff evals.
+
+AgentWeave stays backend-agnostic and continues emitting portable OpenTelemetry
+spans with `prov.*` and `gen_ai.*` attributes.
+
+## Current NAS State
+
+Checked on 2026-05-30:
+
+- Langfuse runs in namespace `apps` as `deploy/langfuse`.
+- Public URL is `https://langfuse.arnabsaha.com` behind Cloudflare Access.
+- LAN URL is `http://192.168.1.70:30893`.
+- Runtime image is `langfuse/langfuse:2`; app logs report v2.95.x behavior.
+- Storage is Postgres-only: `deploy/langfuse-postgres` and
+  `pvc/langfuse-postgres-pvc`.
+- No ClickHouse, Redis/Valkey, S3/blob storage, OpenTelemetry Collector, or
+  Alloy deployment is currently in the trace path.
+
+## Why Not Replace Tempo
+
+Tempo is infrastructure tracing: raw OTLP storage, TraceQL, spanmetrics, and the
+current AgentWeave dashboard. Langfuse is product/eval observability: sessions,
+prompts, datasets, scores, and annotations.
+
+Replacing Tempo would force a dashboard and storage migration before we know
+whether Langfuse improves the Nexus/context-handoff review loop. Dual export
+keeps the working system intact.
+
+## Target Path
+
+```text
+AgentWeave SDK/proxy/bridge
+  -> agentweave-otel-collector.monitoring.svc.cluster.local:4318
+      -> tempo.monitoring.svc.cluster.local:4318
+      -> langfuse.apps.svc.cluster.local:3000/api/public/otel
+         (enabled only after Langfuse v3.22+ migration)
+```
+
+## Langfuse Upgrade Constraint
+
+Do not upgrade the current Helm release by changing `image.tag` from `2` to `3`.
+Langfuse v3 adds required infrastructure:
+
+- Langfuse web container
+- Langfuse worker container
+- Postgres
+- ClickHouse
+- Redis/Valkey
+- S3/blob storage
+
+The safe path is staged:
+
+1. Back up Postgres and the current Helm/Kubernetes state.
+2. Keep v2 running.
+3. Deploy the v3 stack separately, pinned first to the Langfuse-recommended
+   bridge version for v2 migrations.
+4. Validate the v3 UI and ingestion against the existing Postgres plus new
+   ClickHouse/Redis/S3 dependencies.
+5. Shift traffic only after new events land and background migrations are
+   healthy.
+
+## Backup Taken
+
+Before any migration work, a logical Postgres backup was created:
+
+```text
+/home/Arnab/clawd/backups/langfuse/langfuse-postgres-20260530-123107.dump
+```
+
+`pg_restore -l` successfully listed the archive.
+
+## Attributes to Add or Verify
+
+Trace-level attributes should be repeated on every span for Langfuse filtering:
+
+- `langfuse.trace.name`
+- `langfuse.session.id`
+- `langfuse.trace.metadata.project`
+- `langfuse.trace.metadata.agent_id`
+- `langfuse.trace.metadata.agent_type`
+- `langfuse.trace.metadata.parent_session_id`
+- `langfuse.trace.metadata.repository`
+
+LLM observation attributes:
+
+- `langfuse.observation.type=generation`
+- `langfuse.observation.model.name`
+- `langfuse.observation.usage_details`
+- `langfuse.observation.cost_details`
+- `langfuse.observation.input`
+- `langfuse.observation.output`
+
+Only send inputs/outputs when capture flags and the privacy boundary allow it.
+
+## Nexus Evaluation Candidates
+
+For context-handoff reviews, score:
+
+- handoff completeness
+- preserved constraints
+- missing or hallucinated assumptions
+- context size and compression ratio
+- stale-context usage
+- tool-result grounding
+- downstream task success
+- cost and latency impact of extra context
+
+These scores belong in Langfuse. Raw trace trees and service-level metrics stay
+in Tempo.
+
+## Rollout Sequence
+
+1. Apply the Tempo-only collector and point AgentWeave proxy at it.
+2. Verify traces still land in Tempo and the dashboard stays healthy.
+3. Upgrade Langfuse from v2 to v3 using a staged migration.
+4. Create a Langfuse project API key and update
+   `secret/agentweave-otel-collector` in `monitoring`.
+5. Apply `deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml`.
+6. Restart the collector and verify the same trace appears in Tempo and
+   Langfuse.

--- a/docs/openclaw-integration.md
+++ b/docs/openclaw-integration.md
@@ -160,7 +160,7 @@ cd ~/.openclaw/plugins/agentweave-bridge && npm install
       "agentweave-bridge": {
         "path": "/home/user/clawd/plugins/openclaw-agentweave-bridge",
         "config": {
-          "otlpEndpoint": "http://localhost:4318",
+          "otlpEndpoint": "http://agentweave-otel-collector.monitoring.svc.cluster.local:4318",
           "proxyUrl": "http://localhost:4000",
           "agentId": "openclaw-v1",
           "project": "my-project",

--- a/plugins/openclaw-agentweave-bridge/INSTALL.md
+++ b/plugins/openclaw-agentweave-bridge/INSTALL.md
@@ -6,7 +6,7 @@ OpenClaw plugin that creates root OTel spans per user message, enabling full con
 
 - OpenClaw installed (`openclaw` CLI available)
 - AgentWeave proxy running, for example `http://localhost:4000`
-- An OTLP/Tempo collector reachable over HTTP, for example `http://localhost:4318`
+- An OTLP collector or Tempo endpoint reachable over HTTP, for example `http://localhost:4318`
 
 ## Step 1 — Install plugin dependencies
 
@@ -42,7 +42,7 @@ Edit `~/.openclaw/openclaw.json` and add the plugin under `plugins.entries`:
 
 | Field | Required | Default | Description |
 |---|---|---|---|
-| `otlpEndpoint` | ✅ | — | OTLP HTTP endpoint for Grafana Tempo |
+| `otlpEndpoint` | ✅ | — | OTLP HTTP endpoint. In dogfood, point this at the AgentWeave collector; the dashboard still reads from Tempo. |
 | `proxyUrl` | ❌ | `AGENTWEAVE_PROXY_URL` | AgentWeave proxy URL injected into sub-agent provider env vars |
 | `agentId` | ❌ | `"nix-v1"` | Agent identifier stamped on all spans; set this explicitly per machine |
 | `project` | ❌ | — | Project tag for filtering in AgentWeave dashboard |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 REGISTRY="${AGENTWEAVE_REGISTRY:-localhost:5000}"
 IMAGE="${REGISTRY}/agentweave-proxy:latest"
 NAMESPACE="${AGENTWEAVE_NAMESPACE:-agentweave}"
+MONITORING_NAMESPACE="${AGENTWEAVE_MONITORING_NAMESPACE:-monitoring}"
 NODE_IP="${AGENTWEAVE_NODE_IP:-192.168.1.70}"
 PROXY_NODEPORT="${AGENTWEAVE_PROXY_NODEPORT:-30400}"
 HEALTH_URL="http://${NODE_IP}:${PROXY_NODEPORT}/health"
@@ -45,6 +46,15 @@ else
 fi
 
 kubectl apply -f "${REPO_ROOT}/deploy/k8s/namespace.yaml"
+
+# Deploy the Tempo-only collector before repointing/restarting the proxy. The
+# Langfuse fanout overlay is applied manually after Langfuse v3 migration and a
+# real project API key are ready.
+kubectl apply -f "${REPO_ROOT}/deploy/k8s/monitoring/otel-collector.yaml"
+kubectl rollout status deployment/agentweave-otel-collector \
+  -n "${MONITORING_NAMESPACE}" --timeout="${ROLLOUT_TIMEOUT}" \
+  || fail "OTel collector rollout did not complete within ${ROLLOUT_TIMEOUT}"
+
 kubectl apply -f "${REPO_ROOT}/deploy/k8s/configmap.yaml"
 kubectl apply -f "${REPO_ROOT}/deploy/k8s/service.yaml"
 kubectl apply -f "${REPO_ROOT}/deploy/k8s/deployment.yaml"


### PR DESCRIPTION
## Summary

- add a dogfood OpenTelemetry Collector in `monitoring` as the new AgentWeave OTLP target
- keep the default collector config Tempo-only so it is safe before Langfuse v3 is migrated
- add a separate Langfuse fanout ConfigMap that can be applied after Langfuse v3.22+ and project keys exist
- document the Tempo-canonical / Langfuse-eval-sink architecture and Langfuse v2->v3 constraint

## Validation

```bash
python3 - <<'PY'
import yaml
files = [
  'deploy/k8s/monitoring/otel-collector.yaml',
  'deploy/k8s/monitoring/otel-collector-secret.yaml',
  'deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml',
  'deploy/k8s/configmap.yaml',
]
for p in files:
    list(yaml.safe_load_all(open(p)))
print('yaml ok')
PY

KUBECONFIG=/home/Arnab/.kube/config kubectl apply --dry-run=client \
  -f deploy/k8s/monitoring/otel-collector-secret.yaml \
  -f deploy/k8s/monitoring/otel-collector.yaml \
  -f deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml \
  -f deploy/k8s/configmap.yaml

git diff --check
```

Note: I did not deploy this to the live dogfood proxy yet. Langfuse is still v2.95.x, and the fanout file should not be applied until #219 completes.

Closes #220.
