### PR TITLE
Add Langfuse eval mapping

### DIFF
--- a/deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml
+++ b/deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml
@@ -35,7 +35,8 @@ data:
         endpoint: http://tempo.monitoring.svc.cluster.local:4318
 
       otlphttp/langfuse:
-        endpoint: http://langfuse.apps.svc.cluster.local:3000/api/public/otel
+        endpoint: http://langfuse-v3-web.apps.svc.cluster.local:3000/api/public/otel
+        compression: none
         headers:
           Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
           x-langfuse-ingestion-version: "4"

--- a/docs/langfuse-dual-export.md
+++ b/docs/langfuse-dual-export.md
@@ -40,8 +40,42 @@ keeps the working system intact.
 AgentWeave SDK/proxy/bridge
   -> agentweave-otel-collector.monitoring.svc.cluster.local:4318
       -> tempo.monitoring.svc.cluster.local:4318
-      -> langfuse.apps.svc.cluster.local:3000/api/public/otel
-         (enabled only after Langfuse v3.22+ migration)
+      -> langfuse-v3-web.apps.svc.cluster.local:3000/api/public/otel
+```
+
+## Current v3 State
+
+Checked on 2026-05-30:
+
+- Langfuse v2 remains live and untouched at `langfuse.arnabsaha.com`.
+- Langfuse v3 is live side-by-side as Helm release `langfuse-v3` in `apps`.
+- LAN URL is `http://192.168.1.70:30894`.
+- Public URL is `https://langfuse-v3.arnabsaha.com` behind Cloudflare Access.
+- v3 health reports `3.175.0`.
+- The AgentWeave collector exports to both Tempo and Langfuse v3.
+- Langfuse v3 ClickHouse contains fresh AgentWeave traces and `GENERATION`
+  observations.
+
+## OpenClaw/Mux Runtime Wiring
+
+When dogfooding from OpenClaw, make sure every runtime exporter points at the
+collector, not Tempo directly. Direct Tempo export bypasses Langfuse fanout.
+
+Current NAS runtime wiring:
+
+```bash
+# Mux uses the TypeScript AgentWeave SDK, which expects the full OTLP traces URL.
+AGENTWEAVE_OTLP_ENDPOINT=http://10.43.221.47:4318/v1/traces
+
+# openclaw-agentweave-bridge appends /v1/traces itself, so use the collector base.
+otlpEndpoint=http://10.43.221.47:4318
+```
+
+The collector ClusterIP can change if the Kubernetes Service is recreated, so
+verify it before debugging missing Langfuse traces:
+
+```bash
+kubectl get svc -n monitoring agentweave-otel-collector
 ```
 
 ## Langfuse Upgrade Constraint
@@ -116,13 +150,16 @@ For context-handoff reviews, score:
 These scores belong in Langfuse. Raw trace trees and service-level metrics stay
 in Tempo.
 
+Detailed mapping: [Langfuse Eval Mapping](./langfuse-eval-mapping.md).
+
 ## Rollout Sequence
 
 1. Apply the Tempo-only collector and point AgentWeave proxy at it.
 2. Verify traces still land in Tempo and the dashboard stays healthy.
-3. Upgrade Langfuse from v2 to v3 using a staged migration.
+3. Upgrade Langfuse from v2 to v3 using a staged migration. Done side-by-side
+   via `langfuse-v3`.
 4. Create a Langfuse project API key and update
-   `secret/agentweave-otel-collector` in `monitoring`.
-5. Apply `deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml`.
+   `secret/agentweave-otel-collector` in `monitoring`. Done.
+5. Apply `deploy/k8s/monitoring/otel-collector-langfuse-fanout.yaml`. Done.
 6. Restart the collector and verify the same trace appears in Tempo and
-   Langfuse.
+   Langfuse. Done.

--- a/docs/langfuse-eval-mapping.md
+++ b/docs/langfuse-eval-mapping.md
@@ -1,0 +1,76 @@
+# Langfuse Eval Mapping
+
+Issue: <https://github.com/arniesaha/agentweave/issues/221>
+
+## Boundary
+
+AgentWeave remains backend-neutral. The canonical span contract is still
+OpenTelemetry plus `prov.*` and `gen_ai.*` attributes. Langfuse receives a
+second, explicit `langfuse.*` mapping so its UI and APIs can filter traces,
+group sessions, and attach eval scores without becoming the source of truth.
+
+Tempo remains the raw trace store. Langfuse is the eval and review surface.
+
+## Attribute Mapping
+
+| Signal | AgentWeave attribute | Langfuse attribute | Level |
+| --- | --- | --- | --- |
+| Trace name | `prov.task.label` or `session.id` | `langfuse.trace.name` | Trace |
+| Session | `session.id`, `prov.session.id` | `langfuse.session.id` | Trace |
+| Project | `prov.project` | `langfuse.trace.metadata.project` | Trace metadata |
+| Agent ID | `prov.agent.id` | `langfuse.trace.metadata.agent_id` | Trace metadata |
+| Agent type | `prov.agent.type` | `langfuse.trace.metadata.agent_type` | Trace metadata |
+| Parent session | `prov.parent.session.id` | `langfuse.trace.metadata.parent_session_id` | Trace metadata |
+| Repository | `prov.repository` | `langfuse.trace.metadata.repository` | Trace metadata |
+| Task label | `prov.task.label` | `langfuse.trace.metadata.task_label` | Trace metadata |
+| Activity type | `prov.activity.type` | `langfuse.trace.metadata.activity_type` | Trace metadata |
+| LLM observation | `prov.activity.type=llm_call` | `langfuse.observation.type=generation` | Observation |
+| Agent observation | `prov.activity.type=agent_turn` | `langfuse.observation.type=agent` | Observation |
+| Tool observation | `prov.activity.type=tool_call` | `langfuse.observation.type=tool` | Observation |
+| Model | `prov.llm.model`, `gen_ai.request.model` | `langfuse.observation.model.name` | Observation |
+| Token usage | `gen_ai.usage.*` | `langfuse.observation.usage_details` | Observation |
+| Cost | `cost.usd` | `langfuse.observation.cost_details` | Observation |
+
+Prompt and response previews are exported to `langfuse.observation.input` and
+`langfuse.observation.output` only when prompt capture is explicitly enabled.
+PII scanning/redaction still runs before captured previews are stored.
+
+## Score Mapping
+
+Scores should be written to Langfuse via the Scores API or SDK after a trace is
+available. They should not be emitted as plain span attributes because Langfuse
+score records are first-class eval data.
+
+| Score | Scope | Type | Source |
+| --- | --- | --- | --- |
+| `handoff_relevance` | Trace | Numeric 0-1 | LLM-as-judge over handoff context vs task |
+| `handoff_completeness` | Trace | Numeric 0-1 | Required constraints preserved |
+| `handoff_freshness` | Trace | Numeric 0-1 | Context age and stale-reference checks |
+| `attribution_quality` | Trace | Numeric 0-1 | Parent/child session and agent labels present |
+| `continuity_score` | Trace | Numeric 0-1 | Downstream agent used the provided context correctly |
+| `replay_coverage` | Trace | Numeric 0-1 | Tempo/Nexus replay can reconstruct the task path |
+| `decision_grounding` | Observation or trace | Numeric 0-1 | Claims tied to tool outputs or cited context |
+| `task_success` | Trace | Boolean or numeric | Completed vs blocked/user-corrected |
+| `cost_to_success` | Trace | Numeric | Total cost divided by success outcome |
+| `latency_to_first_useful_action` | Trace | Numeric seconds | First non-trivial action after handoff |
+| `context_efficiency` | Trace | Numeric 0-1 | Useful context per token |
+| `user_intervention_count` | Trace | Numeric | Count of corrective user messages |
+| `regression_score` | Trace | Numeric 0-1 | Comparison to previous known-good run |
+
+## Privacy Boundary
+
+Default export is metadata, timings, token counts, and cost. Raw prompt/tool
+payloads are not exported unless capture flags enable them. Captured previews
+are capped and pass through the existing PII mode (`off`, `flag`, `redact`, or
+`block`). Secrets and API keys must never be written into score comments or
+trace metadata.
+
+## Current Implementation
+
+The Python SDK and proxy emit Langfuse-native trace/session metadata and
+observation types while preserving the existing `prov.*` and `gen_ai.*`
+attributes. The live collector fanout sends the same OTLP stream to Tempo and
+Langfuse v3.
+
+Next implementation slice: add a small score publisher that takes a trace ID
+and posts one or more Langfuse scores for context-handoff review.

--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -129,6 +129,89 @@ describe("createAgentWeaveBridgeService", () => {
     expect(process.env.AGENTWEAVE_SESSION_ID).toBe("agent:main:test-session")
   })
 
+  it("sets prov.harness=openclaw on message.queued root span", () => {
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:harness-session",
+      sessionId: "018f-openclaw-main-0001",
+      channel: "cli",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.harness", "openclaw")
+  })
+
+  it("sets prov.session.key to the qualified sessionKey on message.queued root span", () => {
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:key-session",
+      sessionId: "018f-openclaw-main-0002",
+      channel: "cli",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:key-session")
+  })
+
+  it("sets prov.harness=openclaw on session.state subagent root span", () => {
+    fire({
+      type: "session.state",
+      sessionKey: "agent:main:parent:subagent:worker-h",
+      sessionId: "018f-openclaw-sub-0001",
+      state: "processing",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.harness", "openclaw")
+  })
+
+  it("sets prov.session.key to the qualified sessionKey on session.state subagent root span", () => {
+    fire({
+      type: "session.state",
+      sessionKey: "agent:main:parent:subagent:worker-k",
+      sessionId: "018f-openclaw-sub-0002",
+      state: "processing",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:parent:subagent:worker-k")
+  })
+
+  it("sets prov.session.uuid to the canonical sessionId when it differs from sessionKey", () => {
+    // cron/isolated path: OpenClaw passes both a UUID sessionId and a route key.
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:uuid-session",
+      sessionId: "018f-openclaw-main-0009",
+      channel: "cron",
+      source: "cron-isolated",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.uuid", "018f-openclaw-main-0009")
+  })
+
+  it("omits prov.session.uuid when the event carries no distinct canonical sessionId", () => {
+    // interactive dispatch path: OpenClaw passes only sessionKey, no UUID.
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:no-uuid-session",
+      channel: "telegram",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.session.uuid", expect.anything())
+  })
+
   it("sets cwd and repository on message.queued when provided by the event", () => {
     fire({
       type: "message.queued",
@@ -159,6 +242,19 @@ describe("createAgentWeaveBridgeService", () => {
 
     expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.cwd", expect.anything())
     expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.repository", expect.anything())
+  })
+
+  it("sets prov.session.uuid on session.state subagent roots when the event carries a distinct canonical id", () => {
+    fire({
+      type: "session.state",
+      sessionKey: "agent:main:parent:subagent:worker-u",
+      sessionId: "018f-openclaw-sub-0009",
+      state: "processing",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.uuid", "018f-openclaw-sub-0009")
   })
 
   it("sets cwd and repository on session.state subagent roots when provided by the event", () => {

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -235,6 +235,19 @@ export function createAgentWeaveBridgeService() {
               span.setAttribute("session_id", sessionId)
               span.setAttribute("session.id", sessionId)
               span.setAttribute("prov.session.id", sessionId)
+              // Qualified route key kept separate from the (UUID-or-fallback)
+              // session id so Nexus can join native shipper rows by UUID while
+              // still seeing the route key (agentweave#187).
+              span.setAttribute("prov.session.key", sessionKey)
+              // Canonical OpenClaw session UUID, when the runtime supplies one
+              // distinct from the route key (cron/isolated path). Lets Nexus
+              // join AgentWeave spans to native-shipper rows by UUID without
+              // disturbing the route-key-based attribution above (agentweave#187).
+              const canonicalUuid = firstString(e.sessionId)
+              if (canonicalUuid && canonicalUuid !== sessionKey) {
+                span.setAttribute("prov.session.uuid", canonicalUuid)
+              }
+              span.setAttribute("prov.harness", "openclaw")
               span.setAttribute("prov.agent.id", agentId)
               span.setAttribute("prov.agent.type", agentType)
               span.setAttribute("prov.activity.type", "agent_turn")
@@ -375,6 +388,12 @@ export function createAgentWeaveBridgeService() {
                   span.setAttribute("session_id", sessionId)
                   span.setAttribute("session.id", sessionId)
                   span.setAttribute("prov.session.id", sessionId)
+                  span.setAttribute("prov.session.key", sessionKey)
+                  const canonicalUuid = firstString((e as any).sessionId)
+                  if (canonicalUuid && canonicalUuid !== sessionKey) {
+                    span.setAttribute("prov.session.uuid", canonicalUuid)
+                  }
+                  span.setAttribute("prov.harness", "openclaw")
                   span.setAttribute("prov.agent.id", subagentId)
                   span.setAttribute("prov.agent.type", "subagent")
                   span.setAttribute("prov.activity.type", "agent_turn")

--- a/sdk/python/agentweave/decorators.py
+++ b/sdk/python/agentweave/decorators.py
@@ -97,6 +97,33 @@ def _get_config_attrs() -> dict:
     return {}
 
 
+def _set_langfuse_trace_attrs(
+    span: Any,
+    *,
+    trace_name: str,
+    activity_type: str,
+    session_id: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+    agent_type: Optional[str] = None,
+) -> None:
+    """Set Langfuse-native metadata without changing AgentWeave's prov.* contract."""
+    span.set_attribute(schema.LANGFUSE_TRACE_NAME, trace_name)
+    span.set_attribute(schema.LANGFUSE_TRACE_METADATA_ACTIVITY_TYPE, activity_type)
+    if session_id:
+        span.set_attribute(schema.LANGFUSE_SESSION_ID, session_id)
+    if parent_session_id:
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_PARENT_SESSION_ID, parent_session_id)
+    if agent_type:
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_AGENT_TYPE, agent_type)
+    try:
+        from agentweave.config import AgentWeaveConfig
+        cfg = AgentWeaveConfig.get_or_none()
+        if cfg and cfg.agent_id:
+            span.set_attribute(schema.LANGFUSE_TRACE_METADATA_AGENT_ID, cfg.agent_id)
+    except Exception:
+        pass
+
+
 # ── Span lifecycle tracking & graceful shutdown ───────────────────────────────
 
 # Maps a unique key → open (not-yet-ended) span instance.
@@ -179,6 +206,7 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                 _open_spans[_span_key] = span
                 try:
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
+                    span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_TOOL)
                     for k, v in _get_config_attrs().items():
                         span.set_attribute(k, v)
                     _sid = current_session_id()
@@ -187,6 +215,12 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                         span.set_attribute(schema.PROV_SESSION_ID, _sid)
                     else:
                         warn_missing_session_id_once()
+                    _set_langfuse_trace_attrs(
+                        span,
+                        trace_name=_sid or span_name,
+                        activity_type=schema.ACTIVITY_TOOL_CALL,
+                        session_id=_sid,
+                    )
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     try:
@@ -212,6 +246,7 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                 _open_spans[_span_key] = span
                 try:
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_TOOL_CALL)
+                    span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_TOOL)
                     for k, v in _get_config_attrs().items():
                         span.set_attribute(k, v)
                     _sid = current_session_id()
@@ -220,6 +255,12 @@ def _make_tool_wrapper(fn: Callable, name: str, captures_input: bool, captures_o
                         span.set_attribute(schema.PROV_SESSION_ID, _sid)
                     else:
                         warn_missing_session_id_once()
+                    _set_langfuse_trace_attrs(
+                        span,
+                        trace_name=_sid or span_name,
+                        activity_type=schema.ACTIVITY_TOOL_CALL,
+                        session_id=_sid,
+                    )
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     try:
@@ -311,6 +352,7 @@ def _make_agent_wrapper(
                 _open_spans[_span_key] = span
                 try:
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
+                    span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_AGENT)
                     # OTel gen_ai.* dual-emit
                     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
                     for k, v in _get_config_attrs().items():
@@ -324,6 +366,14 @@ def _make_agent_wrapper(
                     else:
                         warn_missing_session_id_once()
                     _set_subagent_attrs(span)
+                    _set_langfuse_trace_attrs(
+                        span,
+                        trace_name=_sid or span_name,
+                        activity_type=schema.ACTIVITY_AGENT_TURN,
+                        session_id=_sid,
+                        parent_session_id=_parent_session_id,
+                        agent_type=_agent_type,
+                    )
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     if _sid:
@@ -350,6 +400,7 @@ def _make_agent_wrapper(
                 _open_spans[_span_key] = span
                 try:
                     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_AGENT_TURN)
+                    span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_AGENT)
                     # OTel gen_ai.* dual-emit
                     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_INVOKE_AGENT)
                     for k, v in _get_config_attrs().items():
@@ -363,6 +414,14 @@ def _make_agent_wrapper(
                     else:
                         warn_missing_session_id_once()
                     _set_subagent_attrs(span)
+                    _set_langfuse_trace_attrs(
+                        span,
+                        trace_name=_sid or span_name,
+                        activity_type=schema.ACTIVITY_AGENT_TURN,
+                        session_id=_sid,
+                        parent_session_id=_parent_session_id,
+                        agent_type=_agent_type,
+                    )
                     if captures_input:
                         span.set_attribute(schema.PROV_USED, str(args[0]) if args else str(kwargs))
                     if _sid:
@@ -543,14 +602,23 @@ def trace_llm(
                     _open_spans[_span_key] = span
                     try:
                         span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
+                        span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_GENERATION)
                         span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
                         span.set_attribute(schema.PROV_LLM_MODEL, model)
+                        span.set_attribute(schema.LANGFUSE_OBSERVATION_MODEL_NAME, model)
                         # OTel gen_ai.* dual-emit
                         span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
                         span.set_attribute(schema.GEN_AI_PROVIDER_NAME, provider)
                         span.set_attribute(schema.GEN_AI_SYSTEM, provider)
                         for k, v in _get_config_attrs().items():
                             span.set_attribute(k, v)
+                        _sid = current_session_id()
+                        _set_langfuse_trace_attrs(
+                            span,
+                            trace_name=_sid or span_name,
+                            activity_type=schema.ACTIVITY_LLM_CALL,
+                            session_id=_sid,
+                        )
                         # Set after config attrs so explicit model param wins over cfg.agent_model
                         span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
                         # Increment per-session turn counter and record on span
@@ -574,14 +642,23 @@ def trace_llm(
                     _open_spans[_span_key] = span
                     try:
                         span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
+                        span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_GENERATION)
                         span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
                         span.set_attribute(schema.PROV_LLM_MODEL, model)
+                        span.set_attribute(schema.LANGFUSE_OBSERVATION_MODEL_NAME, model)
                         # OTel gen_ai.* dual-emit
                         span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
                         span.set_attribute(schema.GEN_AI_PROVIDER_NAME, provider)
                         span.set_attribute(schema.GEN_AI_SYSTEM, provider)
                         for k, v in _get_config_attrs().items():
                             span.set_attribute(k, v)
+                        _sid = current_session_id()
+                        _set_langfuse_trace_attrs(
+                            span,
+                            trace_name=_sid or span_name,
+                            activity_type=schema.ACTIVITY_LLM_CALL,
+                            session_id=_sid,
+                        )
                         # Set after config attrs so explicit model param wins over cfg.agent_model
                         span.set_attribute(schema.GEN_AI_REQUEST_MODEL, model)
                         # Increment per-session turn counter and record on span

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -1602,6 +1602,25 @@ def _extract_and_set_response(
         _set_anthropic_response_attrs(span, data, elapsed_ms, model=model)
 
 
+def _set_langfuse_generation_details(
+    span: Any,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: float | None = None,
+) -> None:
+    """Attach Langfuse-native generation usage/cost details as JSON strings."""
+    span.set_attribute(
+        schema.LANGFUSE_OBSERVATION_USAGE_DETAILS,
+        json.dumps({"input": input_tokens, "output": output_tokens}),
+    )
+    if cost_usd is not None:
+        span.set_attribute(
+            schema.LANGFUSE_OBSERVATION_COST_DETAILS,
+            json.dumps({"total": cost_usd}),
+        )
+
+
 def _set_anthropic_response_attrs(span: Any, data: dict, elapsed_ms: int, model: str = "") -> None:
     usage = data.get("usage", {})
     raw_input = usage.get("input_tokens", 0)
@@ -1628,18 +1647,21 @@ def _set_anthropic_response_attrs(span: Any, data: dict, elapsed_ms: int, model:
 
     # Cost tracking — pass cache breakdown so each bucket is priced correctly
     # (cache_read ~10x cheaper, cache_write slightly above regular input rate).
+    cost_usd = None
     if model and (pt > 0 or ct > 0):
-        span.set_attribute(schema.COST_USD, compute_cost(
+        cost_usd = compute_cost(
             model, pt, ct,
             cache_read_tokens=cache_read,
             cache_write_tokens=cache_write,
-        ))
+        )
+        span.set_attribute(schema.COST_USD, cost_usd)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
     span.set_attribute(schema.GEN_AI_USAGE_OUTPUT_TOKENS, ct)
     if stop:
         span.set_attribute(schema.GEN_AI_RESPONSE_FINISH_REASONS, [stop])
+    _set_langfuse_generation_details(span, input_tokens=pt, output_tokens=ct, cost_usd=cost_usd)
 
 
 def _set_google_response_attrs(span: Any, data: dict, elapsed_ms: int, model: str = "") -> None:
@@ -1664,14 +1686,17 @@ def _set_google_response_attrs(span: Any, data: dict, elapsed_ms: int, model: st
     span.set_attribute(schema.CACHE_HIT_RATE, 0.0)
 
     # Cost tracking
+    cost_usd = None
     if model and (pt > 0 or ct > 0):
-        span.set_attribute(schema.COST_USD, compute_cost(model, pt, ct))
+        cost_usd = compute_cost(model, pt, ct)
+        span.set_attribute(schema.COST_USD, cost_usd)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
     span.set_attribute(schema.GEN_AI_USAGE_OUTPUT_TOKENS, ct)
     if stop:
         span.set_attribute(schema.GEN_AI_RESPONSE_FINISH_REASONS, [stop])
+    _set_langfuse_generation_details(span, input_tokens=pt, output_tokens=ct, cost_usd=cost_usd)
 
 
 def _anthropic_response_text(data: dict) -> str:
@@ -1706,14 +1731,17 @@ def _set_openai_response_attrs(span: Any, data: dict, elapsed_ms: int, model: st
     span.set_attribute(schema.CACHE_HIT_RATE, 0.0)
 
     # Cost tracking
+    cost_usd = None
     if model and (pt > 0 or ct > 0):
-        span.set_attribute(schema.COST_USD, compute_cost(model, pt, ct))
+        cost_usd = compute_cost(model, pt, ct)
+        span.set_attribute(schema.COST_USD, cost_usd)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
     span.set_attribute(schema.GEN_AI_USAGE_OUTPUT_TOKENS, ct)
     if stop:
         span.set_attribute(schema.GEN_AI_RESPONSE_FINISH_REASONS, [stop])
+    _set_langfuse_generation_details(span, input_tokens=pt, output_tokens=ct, cost_usd=cost_usd)
 
 
 def _google_response_text(data: dict) -> str:
@@ -1769,7 +1797,9 @@ def _maybe_set_response_preview(span: Any, text: str) -> None:
     # body has no text (tool-use only, empty response). Without this the field
     # is NULL in Tempo and downstream lineage queries can't distinguish
     # "no text" from "preview never attempted" (issue #176).
-    span.set_attribute(schema.PROV_LLM_RESPONSE_PREVIEW, preview[:512] if preview else "")
+    preview_value = preview[:512] if preview else ""
+    span.set_attribute(schema.PROV_LLM_RESPONSE_PREVIEW, preview_value)
+    span.set_attribute(schema.LANGFUSE_OBSERVATION_OUTPUT, json.dumps(preview_value))
 
 
 # ---------------------------------------------------------------------------
@@ -1807,12 +1837,21 @@ def _set_request_attrs(
     span.set_attribute(schema.PROV_AGENT_MODEL, agent_model)
     span.set_attribute(schema.PROV_WAS_ASSOCIATED_WITH, agent_id)
     span.set_attribute("http.route", f"/{path}")
+    span.set_attribute(schema.LANGFUSE_OBSERVATION_TYPE, schema.LANGFUSE_OBS_TYPE_GENERATION)
+    span.set_attribute(schema.LANGFUSE_OBSERVATION_MODEL_NAME, model)
+    span.set_attribute(schema.LANGFUSE_TRACE_METADATA_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
+    span.set_attribute(schema.LANGFUSE_TRACE_METADATA_AGENT_ID, agent_id)
 
     if session_id is not None:
         span.set_attribute(schema.SESSION_ID, session_id)
         span.set_attribute(schema.PROV_SESSION_ID, session_id)
+        span.set_attribute(schema.LANGFUSE_SESSION_ID, session_id)
+        span.set_attribute(schema.LANGFUSE_TRACE_NAME, task_label or session_id)
+    else:
+        span.set_attribute(schema.LANGFUSE_TRACE_NAME, task_label or f"{agent_id}:{model}")
     if project is not None:
         span.set_attribute(schema.PROV_PROJECT, project)
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_PROJECT, project)
     if turn is not None:
         span.set_attribute(schema.PROV_SESSION_TURN, turn)
     if det_trace_id_raw is not None:
@@ -1825,12 +1864,15 @@ def _set_request_attrs(
         repository = _detect_repository_name(cwd)
         if repository:
             span.set_attribute(schema.PROV_REPOSITORY, repository)
+            span.set_attribute(schema.LANGFUSE_TRACE_METADATA_REPOSITORY, repository)
 
     # Sub-agent attribution (issue #15)
     if parent_session_id is not None:
         span.set_attribute(schema.PROV_PARENT_SESSION_ID, parent_session_id)
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_PARENT_SESSION_ID, parent_session_id)
     if agent_type is not None:
         span.set_attribute(schema.PROV_AGENT_TYPE, agent_type)
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_AGENT_TYPE, agent_type)
     if turn_depth is not None:
         span.set_attribute(schema.PROV_SESSION_TURN, turn_depth)
 
@@ -1839,6 +1881,7 @@ def _set_request_attrs(
         span.set_attribute(schema.PROV_TRACE_PARENT, traceparent)
     if task_label is not None:
         span.set_attribute(schema.PROV_TASK_LABEL, task_label)
+        span.set_attribute(schema.LANGFUSE_TRACE_METADATA_TASK_LABEL, task_label)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_OPERATION_NAME, schema.GEN_AI_OP_CHAT)
@@ -1899,6 +1942,7 @@ def _set_request_attrs(
 
         if _capture_prompts and preview:
             span.set_attribute(schema.PROV_LLM_PROMPT_PREVIEW, preview)
+            span.set_attribute(schema.LANGFUSE_OBSERVATION_INPUT, json.dumps(preview))
     except PIIBlockedError:
         raise  # propagate so the route handler can return 400
     except Exception:

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -148,6 +148,38 @@ GEN_AI_OP_CHAT = "chat"
 GEN_AI_OP_INVOKE_AGENT = "invoke_agent"
 
 # ---------------------------------------------------------------------------
+# Langfuse OpenTelemetry attributes
+# ---------------------------------------------------------------------------
+
+LANGFUSE_TRACE_NAME = "langfuse.trace.name"
+LANGFUSE_SESSION_ID = "langfuse.session.id"
+LANGFUSE_TRACE_TAGS = "langfuse.trace.tags"
+LANGFUSE_OBSERVATION_TYPE = "langfuse.observation.type"
+LANGFUSE_OBSERVATION_MODEL_NAME = "langfuse.observation.model.name"
+LANGFUSE_OBSERVATION_USAGE_DETAILS = "langfuse.observation.usage_details"
+LANGFUSE_OBSERVATION_COST_DETAILS = "langfuse.observation.cost_details"
+LANGFUSE_OBSERVATION_INPUT = "langfuse.observation.input"
+LANGFUSE_OBSERVATION_OUTPUT = "langfuse.observation.output"
+
+# Filterable Langfuse trace metadata. These mirror backend-neutral prov.*
+# fields without making Langfuse the AgentWeave source of truth.
+LANGFUSE_TRACE_METADATA_PROJECT = "langfuse.trace.metadata.project"
+LANGFUSE_TRACE_METADATA_AGENT_ID = "langfuse.trace.metadata.agent_id"
+LANGFUSE_TRACE_METADATA_AGENT_TYPE = "langfuse.trace.metadata.agent_type"
+LANGFUSE_TRACE_METADATA_PARENT_SESSION_ID = "langfuse.trace.metadata.parent_session_id"
+LANGFUSE_TRACE_METADATA_REPOSITORY = "langfuse.trace.metadata.repository"
+LANGFUSE_TRACE_METADATA_TASK_LABEL = "langfuse.trace.metadata.task_label"
+LANGFUSE_TRACE_METADATA_ACTIVITY_TYPE = "langfuse.trace.metadata.activity_type"
+
+# Observation type values supported by Langfuse's OTEL ingestion.
+LANGFUSE_OBS_TYPE_SPAN = "span"
+LANGFUSE_OBS_TYPE_GENERATION = "generation"
+LANGFUSE_OBS_TYPE_EVENT = "event"
+LANGFUSE_OBS_TYPE_AGENT = "agent"
+LANGFUSE_OBS_TYPE_TOOL = "tool"
+LANGFUSE_OBS_TYPE_EVALUATOR = "evaluator"
+
+# ---------------------------------------------------------------------------
 # Cache token tracking (Anthropic prompt caching)
 # ---------------------------------------------------------------------------
 

--- a/sdk/python/tests/test_decorators.py
+++ b/sdk/python/tests/test_decorators.py
@@ -411,6 +411,10 @@ class TestTraceLlm:
         assert attrs[schema.GEN_AI_USAGE_INPUT_TOKENS] == 150
         assert attrs[schema.GEN_AI_USAGE_OUTPUT_TOKENS] == 42
         assert list(attrs[schema.GEN_AI_RESPONSE_FINISH_REASONS]) == ["end_turn"]
+        assert attrs[schema.LANGFUSE_OBSERVATION_TYPE] == schema.LANGFUSE_OBS_TYPE_GENERATION
+        assert attrs[schema.LANGFUSE_OBSERVATION_MODEL_NAME] == "claude-sonnet-4-6"
+        assert attrs[schema.LANGFUSE_TRACE_METADATA_ACTIVITY_TYPE] == schema.ACTIVITY_LLM_CALL
+        assert attrs[schema.LANGFUSE_TRACE_METADATA_AGENT_ID] == "test-agent"
 
     def test_openai_token_convention(self, _setup_test_tracer):
         exporter, _ = _setup_test_tracer

--- a/sdk/python/tests/test_schema.py
+++ b/sdk/python/tests/test_schema.py
@@ -51,6 +51,17 @@ class TestProvAttributes:
         assert schema.PROV_CWD == "prov.cwd"
         assert schema.PROV_REPOSITORY == "prov.repository"
 
+    def test_langfuse_attributes(self):
+        assert schema.LANGFUSE_TRACE_NAME == "langfuse.trace.name"
+        assert schema.LANGFUSE_SESSION_ID == "langfuse.session.id"
+        assert schema.LANGFUSE_OBSERVATION_TYPE == "langfuse.observation.type"
+        assert schema.LANGFUSE_OBSERVATION_MODEL_NAME == "langfuse.observation.model.name"
+        assert schema.LANGFUSE_TRACE_METADATA_AGENT_ID == "langfuse.trace.metadata.agent_id"
+        assert schema.LANGFUSE_TRACE_METADATA_PROJECT == "langfuse.trace.metadata.project"
+        assert schema.LANGFUSE_OBS_TYPE_GENERATION == "generation"
+        assert schema.LANGFUSE_OBS_TYPE_AGENT == "agent"
+        assert schema.LANGFUSE_OBS_TYPE_TOOL == "tool"
+
     def test_all_prov_attributes_start_with_prov(self):
         """All PROV_ constants should have values starting with 'prov.'."""
         for attr_name in dir(schema):


### PR DESCRIPTION
## Summary
- point the collector fanout manifest at the side-by-side Langfuse v3 service
- add Langfuse-native OTEL attributes for trace/session metadata, observation types, generation model, usage, cost, and previews
- document the Langfuse eval mapping and current dual-export rollout state

## Validation
- python3 -m py_compile sdk/python/agentweave/schema.py sdk/python/agentweave/decorators.py sdk/python/agentweave/proxy.py
- pytest -q sdk/python/tests/test_schema.py sdk/python/tests/test_decorators.py
- git diff --check