### PR TITLE
fix(proxy): use OpenClaw session UUID

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -106,11 +106,10 @@ describe("createAgentWeaveBridgeService", () => {
   })
 
   it("creates root span on message.queued and injects traceparent", () => {
-    // service.ts uses sessionKey as the canonical session ID
     fire({
       type: "message.queued",
       sessionKey: "agent:main:test-session",
-      sessionId: "test-session",
+      sessionId: "018f-openclaw-main-test",
       channel: "telegram",
       source: "user",
       queueDepth: 0,
@@ -118,22 +117,25 @@ describe("createAgentWeaveBridgeService", () => {
       seq: 1,
     })
 
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session_id", "agent:main:test-session")
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "agent:main:test-session")
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "agent:main:test-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session_id", "018f-openclaw-main-test")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "018f-openclaw-main-test")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "018f-openclaw-main-test")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:test-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-main-test")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.trace.metadata.session_key", "agent:main:test-session")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.agent.id", "nix-v1")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.agent.type", "main")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.activity.type", "agent_turn")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("channel", "telegram")
     expect(process.env.AGENTWEAVE_TRACEPARENT).toBeTruthy()
-    expect(process.env.AGENTWEAVE_SESSION_ID).toBe("agent:main:test-session")
+    expect(process.env.AGENTWEAVE_SESSION_ID).toBe("018f-openclaw-main-test")
   })
 
   it("sets Langfuse input preview on message.queued when OpenClaw provides one", () => {
     fire({
       type: "message.queued",
       sessionKey: "agent:main:preview-session",
-      sessionId: "preview-session",
+      sessionId: "018f-openclaw-preview-0001",
       channel: "telegram",
       source: "user",
       inputPreview: "  summarize   the deployment\nstatus  ",
@@ -142,7 +144,7 @@ describe("createAgentWeaveBridgeService", () => {
     })
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.observation.type", "agent")
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "agent:main:preview-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-preview-0001")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.observation.input", "summarize the deployment status")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.input.preview", "summarize the deployment status")
   })
@@ -230,11 +232,14 @@ describe("createAgentWeaveBridgeService", () => {
       seq: 1,
     })
 
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "018f-openclaw-main-0009")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "018f-openclaw-main-0009")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.uuid", "018f-openclaw-main-0009")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:uuid-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-main-0009")
   })
 
-  it("omits prov.session.uuid when the event carries no distinct canonical sessionId", () => {
-    // interactive dispatch path: OpenClaw passes only sessionKey, no UUID.
+  it("falls back to sessionKey when the event carries no canonical sessionId", () => {
     fire({
       type: "message.queued",
       sessionKey: "agent:main:no-uuid-session",
@@ -244,7 +249,28 @@ describe("createAgentWeaveBridgeService", () => {
       seq: 1,
     })
 
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "agent:main:no-uuid-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "agent:main:no-uuid-session")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:no-uuid-session")
     expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.session.uuid", expect.anything())
+  })
+
+  it("does not treat a bare route alias sessionId as the canonical UUID", () => {
+    fire({
+      type: "message.queued",
+      sessionKey: "agent:main:main",
+      sessionId: "main",
+      channel: "telegram",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "agent:main:main")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "agent:main:main")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:main")
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.session.uuid", "main")
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("langfuse.session.id", "main")
   })
 
   it("sets cwd and repository on message.queued when provided by the event", () => {
@@ -289,7 +315,11 @@ describe("createAgentWeaveBridgeService", () => {
       seq: 1,
     })
 
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("session.id", "018f-openclaw-sub-0009")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.id", "018f-openclaw-sub-0009")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.uuid", "018f-openclaw-sub-0009")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.session.key", "agent:main:parent:subagent:worker-u")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-sub-0009")
   })
 
   it("sets cwd and repository on session.state subagent roots when provided by the event", () => {
@@ -314,7 +344,7 @@ describe("createAgentWeaveBridgeService", () => {
     fire({
       type: "session.state",
       sessionKey: "agent:main:parent:subagent:worker-preview",
-      sessionId: "worker-preview",
+      sessionId: "018f-openclaw-sub-preview",
       state: "processing",
       taskLabel: "Review pull request #227",
       inputPreview: "Review pull request #227 and patch failures",
@@ -323,7 +353,7 @@ describe("createAgentWeaveBridgeService", () => {
     })
 
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.observation.type", "agent")
-    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "worker-preview")
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-sub-preview")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.trace.name", "Review pull request #227")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.observation.input", "Review pull request #227 and patch failures")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.input.preview", "Review pull request #227 and patch failures")

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -142,6 +142,16 @@ function firstString(...values: unknown[]): string | undefined {
   return undefined
 }
 
+function resolveOpenClawSessionId(sessionKey: string, eventSessionId: unknown): { sessionId: string; canonicalUuid?: string } {
+  const candidate = firstString(eventSessionId)
+  const keyLeaf = sessionKey.split(":").pop()
+  // Some older OpenClaw diagnostic events used the bare route leaf ("main",
+  // "worker-a") as sessionId. That is not the canonical transcript UUID.
+  const isBareRouteAlias = Boolean(candidate && sessionKey && candidate === keyLeaf && candidate !== sessionKey)
+  const canonicalUuid = candidate && !isBareRouteAlias ? candidate : undefined
+  return { sessionId: canonicalUuid ?? sessionKey, canonicalUuid }
+}
+
 function truncatePreview(value: string, maxChars = 1000): string {
   const normalized = value.replace(/\s+/g, " ").trim()
   if (normalized.length <= maxChars) return normalized
@@ -164,6 +174,7 @@ function resolveInputPreview(evt: Record<string, unknown>, fallback?: string): s
 
 function applyLangfuseAgentTurnAttrs(span: Span, params: {
   sessionId?: string
+  sessionKey?: string
   project?: string
   agentId?: string
   agentType?: string
@@ -183,6 +194,7 @@ function applyLangfuseAgentTurnAttrs(span: Span, params: {
   if (params.project) span.setAttribute("langfuse.trace.metadata.project", params.project)
   if (params.agentId) span.setAttribute("langfuse.trace.metadata.agent_id", params.agentId)
   if (params.agentType) span.setAttribute("langfuse.trace.metadata.agent_type", params.agentType)
+  if (params.sessionKey) span.setAttribute("langfuse.trace.metadata.session_key", params.sessionKey)
   if (params.parentSessionId) span.setAttribute("langfuse.trace.metadata.parent_session_id", params.parentSessionId)
   if (params.repository) span.setAttribute("langfuse.trace.metadata.repository", params.repository)
   span.setAttribute("langfuse.trace.metadata.activity_type", "agent_turn")
@@ -272,10 +284,7 @@ export function createAgentWeaveBridgeService() {
           switch (e.type) {
             case "message.queued": {
               const sessionKey = e.sessionKey ?? ""
-              // Use sessionKey (e.g. "agent:main:main") as the session ID, not
-              // sessionId (which is just "main" — the bare agent name).
-              // sessionKey is the fully qualified identifier across OpenClaw.
-              const sessionId = e.sessionKey || e.sessionId || ""
+              const { sessionId, canonicalUuid } = resolveOpenClawSessionId(sessionKey, e.sessionId)
               if (!sessionKey) break
 
               const { agentId, agentType, parentSessionKey } = resolveAgentId(sessionKey, config, activeTurns, e.source)
@@ -285,15 +294,10 @@ export function createAgentWeaveBridgeService() {
               span.setAttribute("session_id", sessionId)
               span.setAttribute("session.id", sessionId)
               span.setAttribute("prov.session.id", sessionId)
-              // Qualified route key kept separate from the (UUID-or-fallback)
-              // session id so Nexus can join native shipper rows by UUID while
-              // still seeing the route key (agentweave#187).
+              // Qualified route key stays available for attribution and
+              // parent/session heuristics after session.id switches to the
+              // OpenClaw UUID used by the native JSONL shipper.
               span.setAttribute("prov.session.key", sessionKey)
-              // Canonical OpenClaw session UUID, when the runtime supplies one
-              // distinct from the route key (cron/isolated path). Lets Nexus
-              // join AgentWeave spans to native-shipper rows by UUID without
-              // disturbing the route-key-based attribution above (agentweave#187).
-              const canonicalUuid = firstString(e.sessionId)
               if (canonicalUuid && canonicalUuid !== sessionKey) {
                 span.setAttribute("prov.session.uuid", canonicalUuid)
               }
@@ -326,6 +330,7 @@ export function createAgentWeaveBridgeService() {
               }
               applyLangfuseAgentTurnAttrs(span, {
                 sessionId,
+                sessionKey,
                 project: config.project,
                 agentId,
                 agentType,
@@ -390,6 +395,7 @@ export function createAgentWeaveBridgeService() {
                 if (config.project) sessionPayload.project = config.project
                 if (parentSid) sessionPayload.parent_session_id = parentSid
                 if (taskLabel) sessionPayload.task_label = taskLabel
+                if (canonicalUuid) sessionPayload.session_uuid = canonicalUuid
                 if (parentTraceIdHex && parentSpanIdHex) {
                   sessionPayload.parent_trace_id = parentTraceIdHex
                   sessionPayload.parent_span_id = parentSpanIdHex
@@ -444,14 +450,13 @@ export function createAgentWeaveBridgeService() {
               if (sessionKey.includes(":subagent:") && !activeTurns.has(sessionKey)) {
                 if (state === "processing") {
                   const subagentId = config.subagentId ?? `${config.agentId ?? "nix"}-subagent-v1`
-                  const sessionId = (e as any).sessionId || sessionKey
+                  const { sessionId, canonicalUuid } = resolveOpenClawSessionId(sessionKey, (e as any).sessionId)
                   const tracer = trace.getTracer("openclaw-agentweave-bridge")
                   const span = tracer.startSpan("openclaw.subagent")
                   span.setAttribute("session_id", sessionId)
                   span.setAttribute("session.id", sessionId)
                   span.setAttribute("prov.session.id", sessionId)
                   span.setAttribute("prov.session.key", sessionKey)
-                  const canonicalUuid = firstString((e as any).sessionId)
                   if (canonicalUuid && canonicalUuid !== sessionKey) {
                     span.setAttribute("prov.session.uuid", canonicalUuid)
                   }
@@ -479,6 +484,7 @@ export function createAgentWeaveBridgeService() {
                   }
                   applyLangfuseAgentTurnAttrs(span, {
                     sessionId,
+                    sessionKey,
                     project: config.project,
                     agentId: subagentId,
                     agentType: "subagent",
@@ -503,6 +509,7 @@ export function createAgentWeaveBridgeService() {
                     body: JSON.stringify({
                       session_key: sessionKey,
                       session_id: sessionId,
+                      ...(canonicalUuid ? { session_uuid: canonicalUuid } : {}),
                       parent_session_id: mainSessionId,
                       agent_id: subagentId,
                       agent_type: "subagent",


### PR DESCRIPTION
## Summary
- use OpenClaw's canonical diagnostic `sessionId` for `session.id`, `prov.session.id`, and `langfuse.session.id` when available
- keep the qualified OpenClaw route key on `prov.session.key` and Langfuse metadata for attribution/parent heuristics
- guard against older diagnostic events that put the bare route alias (for example `main`) in `sessionId`

## Verification
- `/home/Arnab/.nvm/versions/node/v22.22.1/bin/node node_modules/vitest/vitest.mjs run` (plugins/openclaw-agentweave-bridge)
- `/home/Arnab/.nvm/versions/node/v22.22.1/bin/node node_modules/typescript/bin/tsc` (plugins/openclaw-agentweave-bridge)
- `/home/Arnab/.nvm/versions/node/v22.22.1/bin/node node_modules/vitest/vitest.mjs run src/logging/message-lifecycle.test.ts src/auto-reply/reply/dispatch-from-config.test.ts` (/home/Arnab/clawd/projects/openclaw; verifies existing local OpenClaw diagnostic UUID plumb)

Fixes #187
