### PR TITLE
fix(sdk-py): detect missing OpenClaw bridge installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ AgentWeave emits standard OTLP HTTP — works with any compatible backend:
 | Topic | Doc |
 |-------|-----|
 | Claude Code proxy setup | [docs/claude-code-proxy.md](./docs/claude-code-proxy.md) |
+| OpenClaw bridge install | [plugins/openclaw-agentweave-bridge/INSTALL.md](./plugins/openclaw-agentweave-bridge/INSTALL.md) |
 | Session grouping | [docs/session-grouping.md](./docs/session-grouping.md) |
 | Proxy setup | [docs/proxy-setup.md](./docs/proxy-setup.md) |
 | Production hardening | [docs/production-hardening.md](./docs/production-hardening.md) |

--- a/plugins/openclaw-agentweave-bridge/INSTALL.md
+++ b/plugins/openclaw-agentweave-bridge/INSTALL.md
@@ -99,6 +99,18 @@ Repeat these steps on every OpenClaw machine:
 5. Restart OpenClaw.
 6. Run `agentweave doctor` and confirm `openclaw.bridge` passes.
 
+Developer-preview fleet guidance:
+
+- Keep the plugin path local to each OpenClaw install; `agentweave doctor`
+  warns if `plugins.entries.agentweave-bridge.path` points at a missing
+  directory.
+- Treat this as a per-machine rollout checklist, not full automation. Hosts
+  with AgentWeave proxy or OTLP settings but no registered bridge will report
+  an `openclaw.bridge` warning so they can be fixed before comparing Tempo
+  coverage against the lakehouse session count.
+- After updating a host, send one OpenClaw message and confirm a fresh
+  `openclaw.turn` span appears before moving to the next machine.
+
 ## How it works
 
 ```

--- a/sdk/python/agentweave/doctor.py
+++ b/sdk/python/agentweave/doctor.py
@@ -316,6 +316,19 @@ def _check_openclaw_bridge(env: Mapping[str, str]) -> DoctorCheck:
             details={"config_path": str(config_path)},
         )
 
+    bridge_path = _bridge_entry_path(bridge_entry, config_path)
+    if bridge_path and not bridge_path.exists():
+        return DoctorCheck(
+            name="openclaw.bridge",
+            status=WARN,
+            message="OpenClaw agentweave-bridge plugin is configured, but the plugin path does not exist.",
+            suggestion=(
+                "Copy or install plugins/openclaw-agentweave-bridge on this machine, "
+                "then update plugins.entries.agentweave-bridge.path and restart OpenClaw."
+            ),
+            details={"config_path": str(config_path), "plugin_path": str(bridge_path)},
+        )
+
     return DoctorCheck(
         name="openclaw.bridge",
         status=PASS,
@@ -473,6 +486,18 @@ def _bridge_entry_disabled(entry: object) -> bool:
         return True
     config = entry.get("config")
     return isinstance(config, dict) and config.get("enabled") is False
+
+
+def _bridge_entry_path(entry: object, config_path: Path) -> Path | None:
+    if not isinstance(entry, dict):
+        return None
+    raw_path = str(entry.get("path", "")).strip()
+    if not raw_path:
+        return None
+    path = Path(raw_path).expanduser()
+    if path.is_absolute():
+        return path
+    return (config_path.parent / path).resolve()
 
 
 def _proxy_root_url(value: str) -> str:

--- a/sdk/python/tests/test_doctor.py
+++ b/sdk/python/tests/test_doctor.py
@@ -170,6 +170,8 @@ def test_doctor_warns_when_openclaw_bridge_missing_with_agentweave_hints(monkeyp
 def test_doctor_passes_when_openclaw_bridge_is_configured(monkeypatch, tmp_path):
     import agentweave.doctor as doctor_module
 
+    bridge_path = tmp_path / "plugins" / "openclaw-agentweave-bridge"
+    bridge_path.mkdir(parents=True)
     config_path = tmp_path / "openclaw.json"
     config_path.write_text(
         json.dumps(
@@ -177,7 +179,7 @@ def test_doctor_passes_when_openclaw_bridge_is_configured(monkeypatch, tmp_path)
                 "plugins": {
                     "entries": {
                         "agentweave-bridge": {
-                            "path": "/opt/openclaw/plugins/openclaw-agentweave-bridge",
+                            "path": str(bridge_path),
                             "config": {"enabled": True},
                         }
                     }
@@ -197,3 +199,38 @@ def test_doctor_passes_when_openclaw_bridge_is_configured(monkeypatch, tmp_path)
     bridge_check = next(check for check in checks if check.name == "openclaw.bridge")
     assert bridge_check.status == "pass"
     assert "is configured" in bridge_check.message
+
+
+def test_doctor_warns_when_openclaw_bridge_path_is_missing(monkeypatch, tmp_path):
+    import agentweave.doctor as doctor_module
+
+    missing_bridge_path = tmp_path / "plugins" / "openclaw-agentweave-bridge"
+    config_path = tmp_path / "openclaw.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "plugins": {
+                    "entries": {
+                        "agentweave-bridge": {
+                            "path": str(missing_bridge_path),
+                            "config": {"enabled": True},
+                        }
+                    }
+                }
+            }
+        )
+    )
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "0.3.0")
+    checks = doctor_module.run_doctor(
+        env={
+            **_healthy_env(),
+            "OPENCLAW_CONFIG_PATH": str(config_path),
+        }
+    )
+
+    bridge_check = next(check for check in checks if check.name == "openclaw.bridge")
+    assert bridge_check.status == "warn"
+    assert "plugin path does not exist" in bridge_check.message
+    assert bridge_check.details["plugin_path"] == str(missing_bridge_path)
+    assert not doctor_module.has_failures(checks)


### PR DESCRIPTION
## Summary
- Adds an `agentweave doctor` warning when OpenClaw has an `agentweave-bridge` entry but the configured plugin path is missing on that machine.
- Keeps the existing bridge-installed pass path covered by creating a real plugin directory in the doctor test fixture.
- Links the OpenClaw bridge install guide from the main README and expands the fleet rollout checklist with developer-preview verification guidance.

## Verification
- `uv venv .venv && . .venv/bin/activate && cd sdk/python && uv pip install -e ".[dev]" && pytest tests/test_doctor.py -q`
- `. .venv/bin/activate && cd sdk/python && pytest`

Refs arniesaha/agentweave#186
