### PR TITLE
fix(proxy): warn on legacy forced sessions

### DIFF
--- a/docs/attribution-runbook.md
+++ b/docs/attribution-runbook.md
@@ -23,7 +23,9 @@ order — first non-empty value wins:
    globally (legacy callers that POST `/session` without `session_key`),
    the stored value is used as a low-priority fallback. This intentionally
    ranks BELOW explicit headers so unrelated callers are not hijacked
-   (issue #189).
+   (issue #189). This path is deprecated: `force:true` without
+   `session_key` logs a "legacy global force" warning so callers can be
+   found before the fallback is removed.
 5. **Proxy process env** — `AGENTWEAVE_<ATTR>` without subagent mode.
 6. **Static config** — `agentweave.yaml`.
 7. **Sentinel** — `"unattributed"` for `agent_id`; `None` for the rest.

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -493,6 +493,12 @@ async def set_session_context(body: dict):
     else:
         # Legacy path (no session_key): update global context and force flag.
         # Not concurrent-safe — callers should migrate to session_key.
+        if force:
+            logger.warning(
+                "deprecated legacy global force session context used: "
+                "POST /session with force=true and no session_key; "
+                "migrate caller to session_key before this path is removed"
+            )
         _session_context = ctx
         _session_context_force = force
 

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1445,20 +1445,24 @@ class TestForcedSessionContextRace:
         assert captured[0]["agent_id"] == "legacy-fallback-agent"
         assert captured[0]["session_id"] == "legacy-fallback-sess"
 
-    def test_legacy_force_without_key_still_works(self, monkeypatch):
-        """Backward compat: POST /session with force:true and no session_key sets global flag."""
+    def test_legacy_force_without_key_warns_and_still_works(self, monkeypatch, caplog):
+        """Backward compat: warn on legacy force while keeping the global flag path."""
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
         monkeypatch.setattr(proxy_module, "_session_context_force", False)
 
         client = TestClient(app)
-        resp = client.post("/session", json={
-            "session_id": "legacy-sess",
-            "force": True,
-            # no session_key
-        })
+        with caplog.at_level(logging.WARNING, logger="agentweave.proxy"):
+            resp = client.post("/session", json={
+                "session_id": "legacy-sess",
+                "force": True,
+                # no session_key
+            })
         assert resp.status_code == 200
+        warning_messages = [record.message for record in caplog.records]
+        assert any("legacy global force" in msg for msg in warning_messages)
+        assert any("session_key" in msg for msg in warning_messages)
         # Legacy path: global flag should be set
         assert proxy_module._session_context_force is True
         assert len(proxy_module._forced_session_contexts) == 0


### PR DESCRIPTION
Summary
- Add a proxy warning when POST /session uses force:true without session_key, marking the legacy global force path as deprecated.
- Keep the existing legacy fallback behavior intact for stage 1.
- Update the attribution runbook with the staged deprecation warning behavior.

Verification
- cd sdk/python && uv pip install --python .venv/bin/python -e ".[dev]"
- cd sdk/python && .venv/bin/python -m pytest

Refs arniesaha/agentweave#191
