### PR TITLE
fix(bridge): export private model inputs to Langfuse

### DIFF
--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -75,6 +75,28 @@ function makeCtx(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function makeCtxWithInternalDiagnostics(overrides: Record<string, unknown> = {}) {
+  const listeners = new Set<(evt: unknown, metadata: unknown, privateData: object) => void>()
+  return {
+    ctx: {
+      ...makeCtx(overrides),
+      internalDiagnostics: {
+        onEvent(listener: (evt: unknown, metadata: unknown, privateData: object) => void) {
+          listeners.add(listener)
+          return () => {
+            listeners.delete(listener)
+          }
+        },
+      },
+    },
+    fireInternal(evt: object, privateData: unknown = {}) {
+      for (const listener of listeners) {
+        listener(evt, { trusted: true }, privateData as object)
+      }
+    },
+  }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 describe("createAgentWeaveBridgeService", () => {
   let service: ReturnType<typeof createAgentWeaveBridgeService>
@@ -147,6 +169,55 @@ describe("createAgentWeaveBridgeService", () => {
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.session.id", "018f-openclaw-preview-0001")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("langfuse.observation.input", "summarize the deployment status")
     expect(mockSpan.setAttribute).toHaveBeenCalledWith("prov.input.preview", "summarize the deployment status")
+  })
+
+  it("sets Langfuse input from private model-call content without public lifecycle previews", async () => {
+    await service.stop()
+    const harness = makeCtxWithInternalDiagnostics()
+    service = createAgentWeaveBridgeService()
+    await service.start(harness.ctx)
+
+    harness.fireInternal({
+      type: "message.queued",
+      sessionKey: "agent:main:private-input-session",
+      sessionId: "018f-openclaw-private-input-0001",
+      channel: "telegram",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+    harness.fireInternal(
+      {
+        type: "model.call.completed",
+        sessionKey: "agent:main:private-input-session",
+        sessionId: "018f-openclaw-private-input-0001",
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        durationMs: 12,
+        ts: Date.now(),
+        seq: 2,
+      },
+      {
+        modelContent: {
+          inputMessages: [
+            { role: "system", content: "system instructions stay out" },
+            {
+              role: "user",
+              content: "Please summarize deployment status Authorization: Bearer sk-live-secret-token",
+            },
+          ],
+        },
+      },
+    )
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "langfuse.observation.input",
+      "Please summarize deployment status Authorization: Bearer [REDACTED]",
+    )
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      "prov.input.preview",
+      "Please summarize deployment status Authorization: Bearer [REDACTED]",
+    )
   })
 
   it("uses task labels as a safe input fallback for lifecycle spans", () => {

--- a/plugins/openclaw-agentweave-bridge/src/service.test.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.test.ts
@@ -220,6 +220,49 @@ describe("createAgentWeaveBridgeService", () => {
     )
   })
 
+  it("does not capture private input preview when captureInputPreviews is false", async () => {
+    await service.stop()
+    const harness = makeCtxWithInternalDiagnostics({ captureInputPreviews: false })
+    service = createAgentWeaveBridgeService()
+    await service.start(harness.ctx)
+
+    harness.fireInternal({
+      type: "message.queued",
+      sessionKey: "agent:main:no-capture-session",
+      sessionId: "018f-openclaw-no-capture-0001",
+      channel: "telegram",
+      source: "user",
+      ts: Date.now(),
+      seq: 1,
+    })
+    harness.fireInternal(
+      {
+        type: "model.call.completed",
+        sessionKey: "agent:main:no-capture-session",
+        sessionId: "018f-openclaw-no-capture-0001",
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        durationMs: 12,
+        ts: Date.now(),
+        seq: 2,
+      },
+      {
+        modelContent: {
+          inputMessages: [
+            { role: "system", content: "system instructions stay out" },
+            {
+              role: "user",
+              content: "Please summarize deployment status",
+            },
+          ],
+        },
+      },
+    )
+
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("langfuse.observation.input", expect.anything())
+    expect(mockSpan.setAttribute).not.toHaveBeenCalledWith("prov.input.preview", expect.anything())
+  })
+
   it("uses task labels as a safe input fallback for lifecycle spans", () => {
     fire({
       type: "message.queued",

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -41,6 +41,7 @@ export interface BridgeConfig {
   project?: string
   enabled?: boolean
   proxyUrl?: string
+  captureInputPreviews?: boolean
 }
 
 /** Sources that indicate a spawned sub-agent (not a user-initiated message). */
@@ -345,6 +346,7 @@ export function createAgentWeaveBridgeService() {
         proxyUrl: fileConfig.proxyUrl
           ?? process.env.AGENTWEAVE_PROXY_URL
           ?? undefined,
+        captureInputPreviews: fileConfig.captureInputPreviews ?? true,
       }
 
       if (config.enabled === false) return
@@ -703,7 +705,9 @@ export function createAgentWeaveBridgeService() {
               if (!provider && !model) break
               if (provider) match.turn.span.setAttribute("prov.llm.provider", provider)
               if (model) match.turn.span.setAttribute("prov.llm.model", model)
-              const privateInputPreview = resolvePrivateInputPreview(privateData)
+              const privateInputPreview = config.captureInputPreviews
+                ? resolvePrivateInputPreview(privateData)
+                : undefined
               if (privateInputPreview) {
                 match.turn.span.setAttribute("prov.input.preview", privateInputPreview)
                 match.turn.span.setAttribute("langfuse.observation.input", privateInputPreview)

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -12,6 +12,28 @@ interface ActiveTurn {
   ctx: Context
 }
 
+interface DiagnosticPrivateData {
+  modelContent?: {
+    inputMessages?: unknown
+    outputMessages?: unknown
+    systemPrompt?: string
+    toolDefinitions?: unknown
+  }
+}
+
+interface BridgeServiceContext {
+  config: Record<string, unknown>
+  internalDiagnostics?: {
+    onEvent?: (
+      listener: (
+        event: unknown,
+        metadata: unknown,
+        privateData: DiagnosticPrivateData,
+      ) => void,
+    ) => () => void
+  }
+}
+
 export interface BridgeConfig {
   otlpEndpoint: string
   agentId?: string
@@ -97,7 +119,18 @@ function initSdk(config: BridgeConfig): void {
   console.log("[agentweave-bridge] OTel SDK started, exporting to:", `${config.otlpEndpoint}/v1/traces`)
 }
 
-function subscribeToDiagnosticEvents(listener: (evt: unknown) => void): () => void {
+function subscribeToDiagnosticEvents(
+  ctx: BridgeServiceContext,
+  listener: (evt: unknown, privateData?: DiagnosticPrivateData) => void,
+): () => void {
+  if (ctx.internalDiagnostics?.onEvent) {
+    const unsubInternal = ctx.internalDiagnostics.onEvent((evt, _metadata, privateData) => {
+      listener(evt, privateData)
+    })
+    console.log("[agentweave-bridge] subscribed to internal diagnostic events")
+    return unsubInternal
+  }
+
   // Two openclaw plugin-sdk subscriptions:
   //
   // 1. `onDiagnosticEvent` covers the public (untrusted) event stream —
@@ -112,11 +145,11 @@ function subscribeToDiagnosticEvents(listener: (evt: unknown) => void): () => vo
   // `onModelDiagnosticEvent` was added to the plugin-sdk in a separate
   // openclaw PR; older runtimes export only `onDiagnosticEvent`, so we
   // guard the call to keep the bridge compatible.
-  const unsubMain = (onDiagnosticEvent as (l: (evt: unknown) => void) => () => void)(listener)
+  const unsubMain = (onDiagnosticEvent as (l: (evt: unknown) => void) => () => void)((evt) => listener(evt))
   console.log("[agentweave-bridge] subscribed to diagnostic events via plugin-sdk")
   let unsubModel: (() => void) | undefined
   if (typeof onModelDiagnosticEvent === "function") {
-    unsubModel = (onModelDiagnosticEvent as (l: (evt: unknown) => void) => () => void)(listener)
+    unsubModel = (onModelDiagnosticEvent as (l: (evt: unknown) => void) => () => void)((evt) => listener(evt))
     console.log("[agentweave-bridge] subscribed to model.* trusted events via plugin-sdk")
   } else {
     console.warn(
@@ -156,6 +189,46 @@ function truncatePreview(value: string, maxChars = 1000): string {
   const normalized = value.replace(/\s+/g, " ").trim()
   if (normalized.length <= maxChars) return normalized
   return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`
+}
+
+function redactPreview(value: string): string {
+  return value
+    .replace(/\b(Authorization\s*:\s*Bearer\s+)[^\s,;]+/giu, "$1[REDACTED]")
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{16,}/gu, "$1[REDACTED]")
+    .replace(/\b([A-Z][A-Z0-9_]{2,}(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*=\s*)[^\s,;]+/gu, "$1[REDACTED]")
+    .replace(/\b(api[_-]?key|token|secret|password|credential)(["']?\s*[:=]\s*["']?)[^"'\s,;]+/giu, "$1$2[REDACTED]")
+}
+
+function textFromMessagePart(part: unknown): string | undefined {
+  if (typeof part === "string") return part
+  if (!part || typeof part !== "object") return undefined
+  const record = part as Record<string, unknown>
+  return firstString(record.text, record.content, record.value)
+}
+
+function textFromMessageContent(content: unknown): string | undefined {
+  if (typeof content === "string") return content
+  if (Array.isArray(content)) {
+    return content.map(textFromMessagePart).filter(Boolean).join(" ")
+  }
+  return textFromMessagePart(content)
+}
+
+function resolvePrivateInputPreview(privateData?: DiagnosticPrivateData): string | undefined {
+  const messages = privateData?.modelContent?.inputMessages
+  if (!Array.isArray(messages)) return undefined
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index]
+    if (!message || typeof message !== "object") continue
+    const record = message as Record<string, unknown>
+    const role = typeof record.role === "string" ? record.role.toLowerCase() : ""
+    if (role && role !== "user") continue
+    const text = textFromMessageContent(record.content ?? record.text ?? record.message)
+    if (text?.trim()) return truncatePreview(redactPreview(text))
+  }
+
+  return undefined
 }
 
 function resolveInputPreview(evt: Record<string, unknown>, fallback?: string): string | undefined {
@@ -254,7 +327,7 @@ export function createAgentWeaveBridgeService() {
   return {
     id: "agentweave-bridge",
 
-    async start(ctx: { config: Record<string, unknown> }) {
+    async start(ctx: BridgeServiceContext) {
       const pluginEntry = (ctx.config as Record<string, unknown>)?.plugins as Record<string, unknown> | undefined
       const pluginConfig = (pluginEntry?.entries as Record<string, unknown>)?.["agentweave-bridge"] as Record<string, unknown> | undefined
       const fileConfig = pluginConfig?.config as Partial<BridgeConfig> ?? {}
@@ -277,7 +350,7 @@ export function createAgentWeaveBridgeService() {
       if (config.enabled === false) return
       initSdk(config)
 
-      unsubscribe = subscribeToDiagnosticEvents((evt: unknown) => {
+      unsubscribe = subscribeToDiagnosticEvents(ctx, (evt: unknown, privateData?: DiagnosticPrivateData) => {
         const e = evt as { type?: string; sessionKey?: string; sessionId?: string; channel?: string; source?: string; outcome?: string; error?: string; durationMs?: number; provider?: string; model?: string; costUsd?: number; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }; toolName?: string; level?: string; detector?: string; count?: number; queueDepth?: number; taskLabel?: string; inputPreview?: string; inputSummary?: string; promptPreview?: string; cwd?: string; repository?: string; raw_data?: { cwd?: string; repository?: string; inputPreview?: string; inputSummary?: string; promptPreview?: string }; rawData?: { cwd?: string; repository?: string; inputPreview?: string; inputSummary?: string; promptPreview?: string } }
         console.log("[agentweave-bridge] event:", e.type, "sessionKey:", e.sessionKey, "source:", e.source)
         try {
@@ -630,6 +703,11 @@ export function createAgentWeaveBridgeService() {
               if (!provider && !model) break
               if (provider) match.turn.span.setAttribute("prov.llm.provider", provider)
               if (model) match.turn.span.setAttribute("prov.llm.model", model)
+              const privateInputPreview = resolvePrivateInputPreview(privateData)
+              if (privateInputPreview) {
+                match.turn.span.setAttribute("prov.input.preview", privateInputPreview)
+                match.turn.span.setAttribute("langfuse.observation.input", privateInputPreview)
+              }
               break
             }
 

--- a/plugins/openclaw-agentweave-bridge/test/stubs/openclaw-plugin-sdk-diagnostic-runtime.ts
+++ b/plugins/openclaw-agentweave-bridge/test/stubs/openclaw-plugin-sdk-diagnostic-runtime.ts
@@ -30,3 +30,7 @@ export function onDiagnosticEvent(listener: (evt: unknown) => void): () => void 
     state.listeners.delete(listener)
   }
 }
+
+export function onModelDiagnosticEvent(listener: (evt: unknown) => void): () => void {
+  return onDiagnosticEvent(listener)
+}


### PR DESCRIPTION
## Summary
- Subscribe the OpenClaw bridge to internal diagnostic events when the runtime exposes them, preserving compatibility with the public plugin SDK fallback.
- Extract the latest user input from private model-call payloads and export it as `prov.input.preview` plus `langfuse.observation.input`.
- Redact bearer/API-token-style secrets before writing private input previews to spans.

## Verification
- `git diff --check`
- `npm ci`
- `npm test -- --run` — 34 tests passed
- `npm run build`
