### PR TITLE
fix(proxy): remove legacy forced session fallback (#191)

### DIFF
--- a/docs/attribution-runbook.md
+++ b/docs/attribution-runbook.md
@@ -19,16 +19,12 @@ order — first non-empty value wins:
    `X-AgentWeave-Session-Id`, `X-AgentWeave-Task-Label`,
    `X-AgentWeave-Parent-Session-Id`, `X-AgentWeave-Agent-Type`,
    `X-AgentWeave-Project`.
-4. **Legacy global forced context** — if `_session_context_force` is set
-   globally (legacy callers that POST `/session` without `session_key`),
-   the stored value is used as a low-priority fallback. This intentionally
-   ranks BELOW explicit headers so unrelated callers are not hijacked
-   (issue #189). This path is deprecated: `force:true` without
-   `session_key` logs a "legacy global force" warning so callers can be
-   found before the fallback is removed.
-5. **Proxy process env** — `AGENTWEAVE_<ATTR>` without subagent mode.
-6. **Static config** — `agentweave.yaml`.
-7. **Sentinel** — `"unattributed"` for `agent_id`; `None` for the rest.
+4. **Proxy process env** — `AGENTWEAVE_<ATTR>` without subagent mode.
+5. **Static config** — `agentweave.yaml`.
+6. **Sentinel** — `"unattributed"` for `agent_id`; `None` for the rest.
+
+`POST /session` with `force:true` must include `session_key`; unkeyed forced
+session context is rejected with HTTP 400.
 
 ## `unattributed` vs `unknown` on the dashboard
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -61,7 +61,7 @@ import time
 from typing import Any, AsyncIterator
 
 import httpx
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from opentelemetry.trace import Link, NonRecordingSpan, SpanContext, StatusCode, TraceFlags
 
@@ -410,13 +410,8 @@ async def provider_base_health() -> dict:
     return await health()
 
 
-# When True, _session_context overrides request headers (used during sub-agent windows).
-# Kept for backward compatibility with callers that don't supply a session_key.
-_session_context_force: bool = False
-
 # Per-session-key forced context map (issue #149).
-# Replaces the single global _session_context_force for concurrent-safe attribution:
-# each sub-agent window stores its override under a unique key so concurrent
+# Each sub-agent window stores its override under a unique key so concurrent
 # requests from other channels (e.g. Telegram) are not misattributed.
 # Key: session_key string, Value: dict of forced session context attrs
 # LRU-bounded: orphaned entries (e.g. from bridge plugin crashes mid sub-agent)
@@ -433,17 +428,16 @@ def _set_forced_context(session_key: str, ctx: dict[str, str]) -> None:
 
 @app.post("/session", include_in_schema=True)
 async def set_session_context(body: dict):
-    """Override the global session context for all subsequent spans.
+    """Set global session context or per-key forced session context.
 
-    When ``force: true`` is included, the session context takes precedence
-    over per-request headers.  This allows the bridge plugin to temporarily
-    switch attribution during a sub-agent window.
+    When ``force: true`` is included, ``session_key`` is required.  The keyed
+    session context takes precedence over per-request headers for requests that
+    carry the matching ``X-AgentWeave-Session-Key`` header.  This allows the
+    bridge plugin to temporarily switch attribution during a sub-agent window.
 
-    When ``session_key`` is also provided, the override is stored per-key in
-    ``_forced_session_contexts`` so concurrent requests on different channels
-    are not misattributed (issue #149).  Requests that carry the matching
-    ``X-AgentWeave-Session-Key`` header will use this override; all other
-    requests continue to see the global ``_session_context``.
+    The override is stored per-key in ``_forced_session_contexts`` so
+    concurrent requests on different channels are not misattributed
+    (issue #149).
 
     To clear a per-key override, POST with ``force: false`` and the same
     ``session_key``.
@@ -453,7 +447,7 @@ async def set_session_context(body: dict):
     build OTel links[] on llm_call spans (issue #178).  Sending either field
     as an explicit empty string clears the entry for that session.
     """
-    global _session_context, _session_context_force, _forced_session_contexts
+    global _session_context, _forced_session_contexts
     ctx = {k: v for k, v in {
         "prov.session.id": body.get("session_id", ""),
         "prov.parent.session.id": body.get("parent_session_id", ""),
@@ -462,6 +456,15 @@ async def set_session_context(body: dict):
         "prov.agent.id": body.get("agent_id", ""),
         "prov.project": body.get("project", ""),
     }.items() if v}
+
+    force = bool(body.get("force", False))
+    session_key = body.get("session_key", "")
+
+    if force and not session_key:
+        raise HTTPException(
+            status_code=400,
+            detail="force:true requires session_key",
+        )
 
     # Issue #178: bridge pushes the active agent_turn's trace/span IDs so the
     # proxy can build links[] on llm_call spans.  Keyed by session_id so
@@ -476,9 +479,6 @@ async def set_session_context(body: dict):
             # Explicit empty string in either field clears the entry.
             _clear_session_parent_span(_sid_for_parent)
 
-    force = bool(body.get("force", False))
-    session_key = body.get("session_key", "")
-
     if session_key:
         if force:
             # Store per-key forced context — isolates concurrent request streams
@@ -489,18 +489,9 @@ async def set_session_context(body: dict):
         # Update global context so GET /session reflects the latest state;
         # but do NOT set the global force flag — that would affect all requests.
         _session_context = ctx
-        _session_context_force = False
     else:
-        # Legacy path (no session_key): update global context and force flag.
-        # Not concurrent-safe — callers should migrate to session_key.
-        if force:
-            logger.warning(
-                "deprecated legacy global force session context used: "
-                "POST /session with force=true and no session_key; "
-                "migrate caller to session_key before this path is removed"
-            )
+        # Non-forced global context update for GET /session and default attrs.
         _session_context = ctx
-        _session_context_force = force
 
     return {"ok": True, "context": ctx, "force": force, "session_key": session_key}
 
@@ -995,8 +986,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     # Resolve the active forced session context for this request (issue #149).
     # Per-key lookup (concurrent-safe): if the request carries X-AgentWeave-Session-Key
     # and a matching entry exists in _forced_session_contexts, use that entry.
-    # Fall back to the legacy global _session_context_force flag for callers
-    # that haven't migrated to session_key yet.
     _incoming_session_key = request.headers.get("x-agentweave-session-key", "")
     _forced_ctx: dict[str, str] | None = (
         _forced_session_contexts.get(_incoming_session_key)
@@ -1004,19 +993,10 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         else None
     )
     _is_subagent_env = os.getenv("AGENTWEAVE_AGENT_TYPE", "").lower() == "subagent"
-    # Issue #189: split per-key force from legacy global force.
-    # _force_per_key: request carries a session_key matching a stored forced
-    #   context — caller explicitly opted in, so this wins over per-request
-    #   headers (preserves bridge-driven subagent attribution).
-    # _force_legacy: legacy global _session_context_force flag is set, but the
-    #   request did NOT match a per-key context. Treat as a low-priority
-    #   FALLBACK only: explicit per-request headers must win, otherwise
-    #   unrelated callers get hijacked by whichever subagent the bridge
-    #   most recently forced (the original #189 symptom).
+    # Request carries a session_key matching a stored forced context — caller
+    # explicitly opted in, so this wins over per-request headers.
     _force_per_key = _forced_ctx is not None
-    _force_legacy = _session_context_force and not _force_per_key
-    # _active_ctx is the context dict to read forced attributes from.
-    _active_ctx: dict[str, str] = _forced_ctx if _force_per_key else _session_context
+    _active_ctx: dict[str, str] = _forced_ctx if _forced_ctx is not None else {}
 
     # The literal "unattributed" sentinel is treated as a no-op so it can't
     # short-circuit the project-qualified fallback below — defends against
@@ -1028,7 +1008,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         (_real(_active_ctx.get("prov.agent.id")) if _force_per_key else None)
         or (_real(os.getenv("AGENTWEAVE_AGENT_ID")) if _is_subagent_env else None)
         or _real(request.headers.get("x-agentweave-agent-id"))
-        or (_real(_active_ctx.get("prov.agent.id")) if _force_legacy else None)
         or _real(os.getenv("AGENTWEAVE_AGENT_ID"))
         or _real(_config_value("agent_id"))
     )
@@ -1042,7 +1021,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         (_active_ctx.get("prov.session.id") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-session-id")
-        or (_active_ctx.get("prov.session.id") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_SESSION_ID")
     )
     # Only use explicitly set project — do NOT infer from agent_id prefix.
@@ -1051,7 +1029,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         request.headers.get("x-agentweave-project")
         or (_active_ctx.get("prov.project") if _force_per_key else None)
         or os.getenv("AGENTWEAVE_PROJECT")
-        or (_active_ctx.get("prov.project") if _force_legacy else None)
         or None
     )
     # When attribution is missing but we still know the project, qualify the
@@ -1063,7 +1040,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     task_label: str | None = (
         (_active_ctx.get("prov.task.label") if _force_per_key else None)
         or request.headers.get("x-agentweave-task-label")
-        or (_active_ctx.get("prov.task.label") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_TASK_LABEL")
         or None
     )
@@ -1101,7 +1077,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         (_active_ctx.get("prov.parent.session.id") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_PARENT_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-parent-session-id")
-        or (_active_ctx.get("prov.parent.session.id") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_PARENT_SESSION_ID")
         or None
     )
@@ -1109,7 +1084,6 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         (_active_ctx.get("prov.agent.type") if _force_per_key else None)
         or (os.getenv("AGENTWEAVE_AGENT_TYPE") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-type")
-        or (_active_ctx.get("prov.agent.type") if _force_legacy else None)
         or os.getenv("AGENTWEAVE_AGENT_TYPE")
         or None
     )

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -994,8 +994,8 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     )
     _is_subagent_env = os.getenv("AGENTWEAVE_AGENT_TYPE", "").lower() == "subagent"
     # Request carries a session_key matching a stored forced context — caller
-    # explicitly opted in, so this wins over per-request headers.
-    _force_per_key = _forced_ctx is not None
+    # explicitly opted in, so this wins over per-request headers. When there is
+    # no match, _active_ctx is empty and contributes nothing to resolution.
     _active_ctx: dict[str, str] = _forced_ctx if _forced_ctx is not None else {}
 
     # The literal "unattributed" sentinel is treated as a no-op so it can't
@@ -1005,7 +1005,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         return v if v and v != "unattributed" else None
 
     _agent_id_resolved = (
-        (_real(_active_ctx.get("prov.agent.id")) if _force_per_key else None)
+        _real(_active_ctx.get("prov.agent.id"))
         or (_real(os.getenv("AGENTWEAVE_AGENT_ID")) if _is_subagent_env else None)
         or _real(request.headers.get("x-agentweave-agent-id"))
         or _real(os.getenv("AGENTWEAVE_AGENT_ID"))
@@ -1018,7 +1018,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     )
 
     session_id = (
-        (_active_ctx.get("prov.session.id") if _force_per_key else None)
+        _active_ctx.get("prov.session.id")
         or (os.getenv("AGENTWEAVE_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-session-id")
         or os.getenv("AGENTWEAVE_SESSION_ID")
@@ -1027,7 +1027,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
     # Use AGENTWEAVE_PROJECT env var or X-AgentWeave-Project header.
     project = (
         request.headers.get("x-agentweave-project")
-        or (_active_ctx.get("prov.project") if _force_per_key else None)
+        or _active_ctx.get("prov.project")
         or os.getenv("AGENTWEAVE_PROJECT")
         or None
     )
@@ -1038,7 +1038,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         f"unattributed:{project}" if project else "unattributed"
     )
     task_label: str | None = (
-        (_active_ctx.get("prov.task.label") if _force_per_key else None)
+        _active_ctx.get("prov.task.label")
         or request.headers.get("x-agentweave-task-label")
         or os.getenv("AGENTWEAVE_TASK_LABEL")
         or None
@@ -1074,14 +1074,14 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
 
     # Sub-agent attribution headers (issue #15)
     parent_session_id: str | None = (
-        (_active_ctx.get("prov.parent.session.id") if _force_per_key else None)
+        _active_ctx.get("prov.parent.session.id")
         or (os.getenv("AGENTWEAVE_PARENT_SESSION_ID") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-parent-session-id")
         or os.getenv("AGENTWEAVE_PARENT_SESSION_ID")
         or None
     )
     agent_type: str | None = (
-        (_active_ctx.get("prov.agent.type") if _force_per_key else None)
+        _active_ctx.get("prov.agent.type")
         or (os.getenv("AGENTWEAVE_AGENT_TYPE") if _is_subagent_env else None)
         or request.headers.get("x-agentweave-agent-type")
         or os.getenv("AGENTWEAVE_AGENT_TYPE")

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -1130,7 +1130,6 @@ class TestForcedSessionContextRace:
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
-        monkeypatch.setattr(proxy_module, "_session_context_force", False)
 
         client = TestClient(app)
         resp = client.post("/session", json={
@@ -1149,8 +1148,6 @@ class TestForcedSessionContextRace:
             "prov.session.id": "subagent-sess-001",
             "prov.parent.session.id": "parent-001",
         }
-        # Global force flag must NOT be set — that's the whole fix
-        assert proxy_module._session_context_force is False
 
     def test_session_key_clear_removes_from_map(self, monkeypatch):
         """POST /session with force:false + session_key removes the key from the map."""
@@ -1179,7 +1176,6 @@ class TestForcedSessionContextRace:
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict({
             "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
         }))
-        monkeypatch.setattr(proxy_module, "_session_context_force", False)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
 
@@ -1237,7 +1233,6 @@ class TestForcedSessionContextRace:
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict({
             "key-subagent": {"prov.session.id": "forced-sess", "prov.agent.id": "forced-agent"},
         }))
-        monkeypatch.setattr(proxy_module, "_session_context_force", False)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
 
@@ -1297,20 +1292,14 @@ class TestForcedSessionContextRace:
         """x-agentweave-task-label must not be forwarded upstream."""
         assert "x-agentweave-task-label" in _SKIP_HEADERS_ALWAYS
 
-    def test_legacy_global_force_does_not_override_explicit_header(self, monkeypatch):
-        """Issue #189: when ONLY the legacy global force flag is set (no per-key
-        match) and the request carries an explicit X-AgentWeave-Agent-Id, the
-        explicit header MUST win — otherwise unrelated callers (e.g. a Claude
-        Code Mac dryrun) get hijacked into whatever subagent the bridge most
-        recently forced (e.g. nix-v1).
-        """
+    def test_global_session_context_does_not_override_explicit_header(self, monkeypatch):
+        """Global session context is never a forced override without a matching key."""
         from unittest.mock import AsyncMock, MagicMock, patch
         import httpx
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
         from agentweave.config import AgentWeaveConfig
 
-        # Legacy global force is on, with a global ctx pinning agent_id=nix-v1
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
         monkeypatch.setattr(proxy_module, "_session_context", {
             "prov.session.id": "claude-code-main",
@@ -1320,9 +1309,11 @@ class TestForcedSessionContextRace:
             "prov.parent.session.id": "nix-main",
             "prov.agent.type": "subagent",
         })
-        monkeypatch.setattr(proxy_module, "_session_context_force", True)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        monkeypatch.delenv("AGENTWEAVE_AGENT_ID", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_SESSION_ID", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_AGENT_TYPE", raising=False)
 
         captured: list[dict] = []
         original_set_request_attrs = proxy_module._set_request_attrs
@@ -1376,7 +1367,7 @@ class TestForcedSessionContextRace:
         assert len(captured) >= 1
         c = captured[0]
         assert c["agent_id"] == "claude-code-mac-subagent", (
-            f"Explicit header must beat legacy global force, got: {c['agent_id']!r}"
+            f"Explicit header must beat global session context, got: {c['agent_id']!r}"
         )
         assert c["session_id"] == "claude-code-nexus-dryrun-20260510"
         assert c["task_label"] == "nexus dryrun"
@@ -1384,11 +1375,8 @@ class TestForcedSessionContextRace:
         assert c["parent_session_id"] == "nix-main"
         assert c["agent_type"] == "subagent"
 
-    def test_legacy_global_force_fills_attrs_when_header_missing(self, monkeypatch):
-        """Issue #189: legacy global force still acts as a fallback for
-        attributes the request does NOT supply — preserves backward compat
-        for the few legacy callers that have not migrated to session_key.
-        """
+    def test_global_session_context_does_not_fill_attrs_when_header_missing(self, monkeypatch):
+        """Global session context is not used as a request attribution fallback."""
         from unittest.mock import AsyncMock, MagicMock, patch
         import httpx
         from fastapi.testclient import TestClient
@@ -1400,9 +1388,11 @@ class TestForcedSessionContextRace:
             "prov.session.id": "legacy-fallback-sess",
             "prov.agent.id": "legacy-fallback-agent",
         })
-        monkeypatch.setattr(proxy_module, "_session_context_force", True)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        monkeypatch.delenv("AGENTWEAVE_AGENT_ID", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_SESSION_ID", raising=False)
+        monkeypatch.delenv("AGENTWEAVE_AGENT_TYPE", raising=False)
 
         captured: list[dict] = []
         original_set_request_attrs = proxy_module._set_request_attrs
@@ -1433,7 +1423,7 @@ class TestForcedSessionContextRace:
         with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm), \
              patch.object(proxy_module, "_set_request_attrs", side_effect=_capturing):
             client = TestClient(app)
-            # No attribution headers — fallback chain should fill from legacy ctx
+            # No attribution headers — request resolution should not fill from global ctx
             client.post(
                 "/v1/messages",
                 json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
@@ -1442,30 +1432,26 @@ class TestForcedSessionContextRace:
             )
 
         assert len(captured) >= 1
-        assert captured[0]["agent_id"] == "legacy-fallback-agent"
-        assert captured[0]["session_id"] == "legacy-fallback-sess"
+        assert captured[0]["agent_id"] == "unattributed"
+        assert captured[0]["session_id"] is None
 
-    def test_legacy_force_without_key_warns_and_still_works(self, monkeypatch, caplog):
-        """Backward compat: warn on legacy force while keeping the global flag path."""
+    def test_force_without_key_is_rejected(self, monkeypatch):
+        """force:true without session_key is no longer accepted."""
         from fastapi.testclient import TestClient
         from agentweave.proxy import app
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
-        monkeypatch.setattr(proxy_module, "_session_context_force", False)
+        monkeypatch.setattr(proxy_module, "_session_context", {})
 
         client = TestClient(app)
-        with caplog.at_level(logging.WARNING, logger="agentweave.proxy"):
-            resp = client.post("/session", json={
-                "session_id": "legacy-sess",
-                "force": True,
-                # no session_key
-            })
-        assert resp.status_code == 200
-        warning_messages = [record.message for record in caplog.records]
-        assert any("legacy global force" in msg for msg in warning_messages)
-        assert any("session_key" in msg for msg in warning_messages)
-        # Legacy path: global flag should be set
-        assert proxy_module._session_context_force is True
+        resp = client.post("/session", json={
+            "session_id": "legacy-sess",
+            "force": True,
+            # no session_key
+        })
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "force:true requires session_key"
         assert len(proxy_module._forced_session_contexts) == 0
+        assert proxy_module._session_context == {}
 
     def test_forced_contexts_map_is_lru_bounded(self, monkeypatch):
         """Orphaned entries (bridge plugin crashes mid sub-agent) must not leak.
@@ -1888,7 +1874,6 @@ class TestAttributeResolution:
 
         monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
         monkeypatch.setattr(proxy_module, "_session_context", {})
-        monkeypatch.setattr(proxy_module, "_session_context_force", False)
         monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
         if agent_id_env is not None:


### PR DESCRIPTION
Summary:
- Reject POST /session force:true requests that omit session_key with HTTP 400.
- Remove the legacy _session_context_force fallback from proxy request attribution resolution.
- Replace legacy forced-session acceptance tests with rejection/no-fallback coverage and update the attribution runbook.

Production guard:
- Checked agentweave-proxy logs with KUBECONFIG=/home/Arnab/.kube/config.
- Last 24h and 48h: zero deprecated legacy global force warning hits.
- Last 72h: one hit at 2026-06-05T21:21:22-07:00, matching the documented stage-1 validation probe, not a real caller.

Verification:
- cd sdk/python && .venv/bin/python -m pytest tests/test_proxy.py::TestForcedSessionContextRace -q
- cd sdk/python && .venv/bin/python -m pytest tests/test_proxy.py -q
- cd sdk/python && .venv/bin/python -m pytest -q

Fixes arniesaha/agentweave#191