### PR TITLE
fix(proxy): normalize telemetry model labels

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -374,11 +374,30 @@ def _upstream_url(provider: str, path: str, query_string: str) -> str:
     return url
 
 
+_MODEL_RANGE_SUFFIX_RE = re.compile(r"\[[0-9]+[smhd]\]$")
+
+
+def _normalize_model_label(model: Any) -> str:
+    """Return the model label used for telemetry.
+
+    Some callers have leaked Prometheus range selectors into the request model
+    string, e.g. ``claude-opus-4-8[1m]``. Keep the upstream request body intact,
+    but normalize the telemetry label so span names and prov.llm.model stay
+    stable for dashboards and quality gates.
+    """
+    if not isinstance(model, str):
+        return "unknown"
+    model = model.strip()
+    if not model:
+        return "unknown"
+    return _MODEL_RANGE_SUFFIX_RE.sub("", model)
+
+
 def _extract_model(provider: str, path: str, body: dict) -> str:
     if provider == "google":
         m = _GEMINI_MODEL_RE.search(path)
-        return m.group(1) if m else "gemini"
-    return body.get("model", "unknown")
+        return _normalize_model_label(m.group(1) if m else "gemini")
+    return _normalize_model_label(body.get("model", "unknown"))
 
 
 def _is_streaming(provider: str, path: str, body: dict) -> bool:

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -17,6 +17,7 @@ from agentweave.proxy import (
     _detect_provider,
     _is_chatgpt_mode_bearer,
     _maybe_reroute_openai_to_codex,
+    _extract_model,
     _extract_anthropic_cache_tokens,
     _inject_anthropic_key,
     _openai_response_text,
@@ -78,6 +79,28 @@ class TestDetectProvider:
 
     def test_anthropic_fallback(self):
         assert _detect_provider("v1/unknown/path") == "anthropic"
+
+
+class TestExtractModel:
+    def test_strips_prometheus_range_suffix_from_body_model(self):
+        assert (
+            _extract_model("anthropic", "v1/messages", {"model": "claude-opus-4-8[1m]"})
+            == "claude-opus-4-8"
+        )
+
+    def test_strips_prometheus_range_suffix_from_google_path_model(self):
+        assert (
+            _extract_model(
+                "google",
+                "v1beta/models/gemini-2.5-pro[5m]:generateContent",
+                {},
+            )
+            == "gemini-2.5-pro"
+        )
+
+    @pytest.mark.parametrize("model", ["", None, 42])
+    def test_falls_back_to_unknown_for_unusable_body_model(self, model):
+        assert _extract_model("openai", "v1/responses", {"model": model}) == "unknown"
 
 
 class TestChatGPTModeBearerDetection:

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -102,6 +102,13 @@ class TestExtractModel:
     def test_falls_back_to_unknown_for_unusable_body_model(self, model):
         assert _extract_model("openai", "v1/responses", {"model": model}) == "unknown"
 
+    def test_does_not_mutate_request_body(self):
+        # Normalization is telemetry-only: the upstream request body must be
+        # forwarded unchanged, range selector and all.
+        body = {"model": "claude-opus-4-8[1m]"}
+        _extract_model("anthropic", "v1/messages", body)
+        assert body == {"model": "claude-opus-4-8[1m]"}
+
 
 class TestChatGPTModeBearerDetection:
     """ChatGPT-mode JWTs (eyJ…) versus OpenAI sk-* keys versus empty/anthropic."""


### PR DESCRIPTION
## Summary

- normalize proxy telemetry model labels by stripping accidental trailing Prometheus range selectors like `[1m]`
- keep the upstream request body unchanged; only span names and `prov.llm.model` labels are normalized
- add regression coverage for Anthropic/OpenAI body models, Google path models, and unusable model values

## Validation

- `python3 -m pytest sdk/python/tests/test_proxy.py::TestExtractModel tests/test_trace_quality_gate.py -q`
- `python3 -m py_compile scripts/trace_quality_gate.py sdk/python/agentweave/proxy.py`

Fixes #239.
