### PR TITLE
fix(proxy): relay non-JSON upstream bodies instead of 500ing

### DIFF
--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -62,7 +62,7 @@ from typing import Any, AsyncIterator
 
 import httpx
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from opentelemetry.trace import Link, NonRecordingSpan, SpanContext, StatusCode, TraceFlags
 
 from agentweave import schema
@@ -963,7 +963,7 @@ async def list_models(request: Request) -> JSONResponse:
 
 
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"], response_model=None)
-async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse:
+async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse | Response:
     if (denied := _check_auth(request)) is not None:
         return denied
 
@@ -1274,7 +1274,7 @@ async def _request_and_trace(
     parent_span_id_raw: str | None = None,
     parent_trace_id_raw: str | None = None,
     task_label: str | None = None,
-) -> JSONResponse:
+) -> Response:
     tracer = get_tracer()
     _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
     _links = _build_parent_links(parent_trace_id_raw, parent_span_id_raw)
@@ -1297,7 +1297,31 @@ async def _request_and_trace(
                     method, upstream_url, headers=headers, content=body_bytes,
                 )
             elapsed_ms = int((time.perf_counter() - start) * 1000)
-            data = resp.json()
+            try:
+                data = resp.json()
+            except (ValueError, UnicodeDecodeError):
+                data = None
+
+            if data is None:
+                # Upstream returned a non-JSON body (e.g. an HTML error page, or
+                # a non-API path forwarded through the catch-all route). Relay it
+                # transparently instead of crashing on resp.json() and masking the
+                # real upstream response behind a proxy-generated 500.
+                is_error = resp.status_code >= 400
+                span.set_status(StatusCode.ERROR if is_error else StatusCode.OK)
+                _health_record_span(
+                    agent_id=agent_id or "unknown",
+                    session_id=session_id or "",
+                    duration_ms=float(elapsed_ms),
+                    is_error=is_error,
+                    cost_usd=0.0,
+                )
+                return Response(
+                    content=resp.content,
+                    status_code=resp.status_code,
+                    media_type=resp.headers.get("content-type"),
+                )
+
             _extract_and_set_response(span, data=data, provider=provider, elapsed_ms=elapsed_ms, model=model)
             span.set_status(StatusCode.OK)
             # Record span in health tracker

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -2103,6 +2103,67 @@ class TestListModelsEndpoint:
         assert resp.status_code == 401
 
 
+class TestNonJsonUpstreamPassthrough:
+    """The non-streaming handler must relay non-JSON upstream bodies transparently
+    instead of crashing on resp.json() and masking them behind a proxy 500.
+
+    Regression for the follow-up bug found while fixing agentweave#241: forwarding
+    a GET / (or any non-API path) upstream returned an HTML body, and the
+    unconditional resp.json() at proxy._request_and_trace raised JSONDecodeError,
+    which the generic handler re-raised as an opaque HTTP 500.
+    """
+
+    def _mock_non_json_response(self, *, status_code, content, content_type):
+        from unittest.mock import AsyncMock, MagicMock
+        import httpx
+
+        fake_resp = MagicMock(spec=httpx.Response)
+        fake_resp.status_code = status_code
+        fake_resp.content = content
+        fake_resp.headers = {"content-type": content_type}
+        fake_resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+
+        client_instance = AsyncMock()
+        client_instance.request = AsyncMock(return_value=fake_resp)
+
+        cm = MagicMock()
+        cm.__aenter__ = AsyncMock(return_value=client_instance)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    def _post(self, monkeypatch, *, status_code, content, content_type):
+        from unittest.mock import patch
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        cm = self._mock_non_json_response(
+            status_code=status_code, content=content, content_type=content_type,
+        )
+        with patch("agentweave.proxy.httpx.AsyncClient", return_value=cm):
+            return TestClient(app, raise_server_exceptions=False).post(
+                "/v1/messages",
+                json={"model": "claude-3-haiku-20240307", "max_tokens": 1,
+                      "messages": [{"role": "user", "content": "hi"}]},
+                headers={"x-api-key": "sk-ant-test-key"},
+            )
+
+    def test_non_json_error_body_relayed_not_500(self, monkeypatch):
+        """An HTML error page upstream is relayed with its real status and body."""
+        html = b"<html><body>Bad Gateway</body></html>"
+        resp = self._post(monkeypatch, status_code=502, content=html, content_type="text/html")
+        assert resp.status_code == 502  # upstream status preserved, not a proxy 500
+        assert resp.content == html
+        assert resp.headers["content-type"].startswith("text/html")
+
+    def test_non_json_success_body_relayed(self, monkeypatch):
+        """A non-JSON 2xx body is passed through verbatim."""
+        body = b"plain text ok"
+        resp = self._post(monkeypatch, status_code=200, content=body, content_type="text/plain")
+        assert resp.status_code == 200
+        assert resp.content == body
+
+
 # ---------------------------------------------------------------------------
 # Tests for issue #174: env key fallback when AGENTWEAVE_* vars are unset
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The non-streaming proxy handler (`_request_and_trace`) called `resp.json()` unconditionally. Any non-JSON upstream body — an HTML error page, plain text, or a non-API path forwarded through the catch-all route — raised `JSONDecodeError`, which the generic `except` re-raised as an opaque HTTP 500, masking the upstream's real status and body.

Found while reviving the NAS proxy (#241): `GET /` returned 500 with a `json.decoder.JSONDecodeError` traceback.

## Fix

Guard the parse; on a non-JSON body, relay the upstream response transparently — status code, body, and `content-type` preserved — and record the span with `is_error` derived from the upstream status. Mirrors the try/except the `/v1/models` passthrough and `_stream_preflight` already use.

## Validation

- `GET /` on the NAS proxy now returns the upstream's real **404** instead of 500; `/health` (200) and `POST /v1/messages` unaffected; new process log shows zero `JSONDecodeError`.
- Adds `TestNonJsonUpstreamPassthrough` (non-JSON 2xx + error bodies relayed verbatim). Full `test_proxy.py`: **183 passed**.

Fixes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)