### PR TITLE
fix(proxy): repair traceparent parsing, hook attribution, and span timing

### DIFF
--- a/sdk/python/agentweave/hooks/claude-code/stop.sh
+++ b/sdk/python/agentweave/hooks/claude-code/stop.sh
@@ -15,9 +15,14 @@ if [ -f "$BUFFER" ]; then
   if [ -n "$EVENTS" ]; then
     # Read traceparent from env if the agentweave-bridge plugin set it
     TP="${AGENTWEAVE_TRACEPARENT:-}"
+    # Agent identity so hook spans are attributable and joinable (#247).
+    # Empty values are dropped proxy-side rather than written as empty attrs.
+    AID="${AGENTWEAVE_AGENT_ID:-}"
+    ATYPE="${AGENTWEAVE_AGENT_TYPE:-}"
+    PROJ="${AGENTWEAVE_PROJECT:-}"
     curl -s -X POST "$PROXY/hooks/batch" \
       -H "Content-Type: application/json" \
-      -d "{\"session_id\":\"${SID}\",\"traceparent\":\"${TP}\",\"events\":$(echo "$EVENTS" | jq -s .)}"
+      -d "{\"session_id\":\"${SID}\",\"traceparent\":\"${TP}\",\"agent_id\":\"${AID}\",\"agent_type\":\"${ATYPE}\",\"project\":\"${PROJ}\",\"cwd\":\"${PWD}\",\"events\":$(echo "$EVENTS" | jq -s .)}"
   fi
   rm -f "$EXPORT_FILE"
 fi

--- a/sdk/python/agentweave/hooks/claude-code/stop.sh
+++ b/sdk/python/agentweave/hooks/claude-code/stop.sh
@@ -13,16 +13,22 @@ if [ -f "$BUFFER" ]; then
   mv "$BUFFER" "$EXPORT_FILE" 2>/dev/null || exit 0
   EVENTS=$(cat "$EXPORT_FILE")
   if [ -n "$EVENTS" ]; then
-    # Read traceparent from env if the agentweave-bridge plugin set it
-    TP="${AGENTWEAVE_TRACEPARENT:-}"
-    # Agent identity so hook spans are attributable and joinable (#247).
-    # Empty values are dropped proxy-side rather than written as empty attrs.
-    AID="${AGENTWEAVE_AGENT_ID:-}"
-    ATYPE="${AGENTWEAVE_AGENT_TYPE:-}"
-    PROJ="${AGENTWEAVE_PROJECT:-}"
+    # Build the payload with jq so quotes or backslashes in a path, project
+    # name, or agent id can't corrupt the JSON body. jq is already required
+    # here for `jq -s`, so this adds no new dependency.
+    # Agent identity so hook spans are attributable and joinable (#247);
+    # empty values are dropped proxy-side rather than written as empty attrs.
+    PAYLOAD=$(echo "$EVENTS" | jq -s \
+      --arg sid "$SID" \
+      --arg tp "${AGENTWEAVE_TRACEPARENT:-}" \
+      --arg aid "${AGENTWEAVE_AGENT_ID:-}" \
+      --arg atype "${AGENTWEAVE_AGENT_TYPE:-}" \
+      --arg proj "${AGENTWEAVE_PROJECT:-}" \
+      --arg cwd "$PWD" \
+      '{session_id:$sid, traceparent:$tp, agent_id:$aid, agent_type:$atype, project:$proj, cwd:$cwd, events:.}')
     curl -s -X POST "$PROXY/hooks/batch" \
       -H "Content-Type: application/json" \
-      -d "{\"session_id\":\"${SID}\",\"traceparent\":\"${TP}\",\"agent_id\":\"${AID}\",\"agent_type\":\"${ATYPE}\",\"project\":\"${PROJ}\",\"cwd\":\"${PWD}\",\"events\":$(echo "$EVENTS" | jq -s .)}"
+      -d "$PAYLOAD"
   fi
   rm -f "$EXPORT_FILE"
 fi

--- a/sdk/python/agentweave/hooks/claude-code/subagent_stop.sh
+++ b/sdk/python/agentweave/hooks/claude-code/subagent_stop.sh
@@ -8,14 +8,19 @@ SID="${CLAUDE_SESSION_ID:-}"
 INPUT=$(cat)
 
 # Use jq for safe JSON composition; fall back to raw curl if unavailable.
+# Agent identity so subagent spans are attributable and joinable (#247).
+AID="${AGENTWEAVE_AGENT_ID:-}"
+PROJ="${AGENTWEAVE_PROJECT:-}"
+
 if command -v jq >/dev/null 2>&1; then
   PAYLOAD=$(echo "$INPUT" | jq -c --arg sid "$SID" --arg psid "${CLAUDE_PARENT_SESSION_ID:-}" \
-    '{span_name:"subagent.stop", session_id:$sid, attributes:{"prov.parent.session.id":$psid, "prov.agent.type":"subagent", hook_data:.}}')
+    --arg aid "$AID" --arg proj "$PROJ" --arg cwd "$PWD" \
+    '{span_name:"subagent.stop", session_id:$sid, agent_id:$aid, project:$proj, cwd:$cwd, attributes:{"prov.parent.session.id":$psid, "prov.agent.type":"subagent", hook_data:.}}')
   curl -s -X POST "$PROXY/hooks/span" \
     -H "Content-Type: application/json" \
     -d "$PAYLOAD" &
 else
   curl -s -X POST "$PROXY/hooks/span" \
     -H "Content-Type: application/json" \
-    -d "{\"span_name\":\"subagent.stop\",\"session_id\":\"${SID}\",\"attributes\":{\"prov.parent.session.id\":\"${CLAUDE_PARENT_SESSION_ID:-}\",\"prov.agent.type\":\"subagent\",\"hook_data\":$INPUT}}" &
+    -d "{\"span_name\":\"subagent.stop\",\"session_id\":\"${SID}\",\"agent_id\":\"${AID}\",\"project\":\"${PROJ}\",\"cwd\":\"${PWD}\",\"attributes\":{\"prov.parent.session.id\":\"${CLAUDE_PARENT_SESSION_ID:-}\",\"prov.agent.type\":\"subagent\",\"hook_data\":$INPUT}}" &
 fi

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -838,6 +838,18 @@ async def delete_prompt(name: str):
     return {"ok": True, "deleted": deleted, "name": name}
 
 
+def _event_start_time_ns(ts) -> int:
+    """Convert a buffered hook event's ms timestamp to epoch nanoseconds.
+
+    Falls back to wall clock when the timestamp is missing or unparseable, so
+    one corrupt line in the buffer can't fail the whole batch.
+    """
+    try:
+        return int(ts) * 1_000_000
+    except (TypeError, ValueError):
+        return time.time_ns()
+
+
 def _hook_attribution(body: dict) -> dict[str, str]:
     """Build the ``prov.*`` agent-attribution attributes for a hook span.
 
@@ -903,34 +915,45 @@ async def hooks_batch(body: dict):
     for event in events:
         event_type = event.get("event", "unknown")
         ts = event.get("ts")
-        data = event.get("data", {})
+        data = event.get("data")
+        if not isinstance(data, dict):
+            # A corrupt buffer line shouldn't cost us the rest of the batch.
+            data = {}
 
         span_name = f"hook.{event_type}"
         # Stamp at event time, not export time: the Stop hook batches a whole
         # session's buffer, so wall-clock here collapses every tool call in the
-        # session to the same instant (#248).
-        start_time = int(ts) * 1_000_000 if ts else None
+        # session to the same instant (#248).  The buffer records one timestamp
+        # per event, so these are point-in-time spans — end them at start_time
+        # rather than letting them run to the export moment, which would report
+        # the whole buffering delay as tool latency.
+        start_time = _event_start_time_ns(ts)
+        # end_on_exit=False so the span can be pinned to start_time; the
+        # try/finally preserves the context manager's guarantee that it ends.
         with tracer.start_as_current_span(
-            span_name, context=parent_ctx, start_time=start_time
+            span_name, context=parent_ctx, start_time=start_time, end_on_exit=False
         ) as span:
-            span.set_attribute("prov.session.id", session_id or event.get("session_id", ""))
-            span.set_attribute("prov.hook.source", "claude-code")
-            span.set_attribute("prov.hook.event_type", event_type)
-            for key, value in attribution.items():
-                span.set_attribute(key, value)
-            if ts:
-                span.set_attribute("prov.hook.timestamp_ms", ts)
+            try:
+                span.set_attribute("prov.session.id", session_id or event.get("session_id", ""))
+                span.set_attribute("prov.hook.source", "claude-code")
+                span.set_attribute("prov.hook.event_type", event_type)
+                for key, value in attribution.items():
+                    span.set_attribute(key, value)
+                if ts:
+                    span.set_attribute("prov.hook.timestamp_ms", ts)
 
-            # Extract tool use data if present
-            tool_name = data.get("tool_name") or data.get("toolName")
-            if tool_name:
-                span.set_attribute("prov.tool.name", tool_name)
-            tool_input = data.get("tool_input") or data.get("toolInput")
-            if tool_input and isinstance(tool_input, str):
-                span.set_attribute("prov.tool.input_preview", tool_input[:512])
-            tool_result = data.get("tool_result") or data.get("toolResult")
-            if tool_result and isinstance(tool_result, str):
-                span.set_attribute("prov.tool.result_preview", tool_result[:512])
+                # Extract tool use data if present
+                tool_name = data.get("tool_name") or data.get("toolName")
+                if tool_name:
+                    span.set_attribute("prov.tool.name", tool_name)
+                tool_input = data.get("tool_input") or data.get("toolInput")
+                if tool_input and isinstance(tool_input, str):
+                    span.set_attribute("prov.tool.input_preview", tool_input[:512])
+                tool_result = data.get("tool_result") or data.get("toolResult")
+                if tool_result and isinstance(tool_result, str):
+                    span.set_attribute("prov.tool.result_preview", tool_result[:512])
+            finally:
+                span.end(end_time=start_time)
 
         spans_created += 1
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -712,16 +712,28 @@ async def get_agent_health_config():
 # ---------------------------------------------------------------------------
 
 def _extract_parent_context(traceparent: str | None):
-    """Parse a W3C traceparent header into an OTel context for span linking."""
+    """Parse a W3C traceparent header into an OTel context for span linking.
+
+    Returns ``None`` when no usable parent can be recovered, so callers fall
+    back to emitting a root span.  A malformed header is expected and logged at
+    debug; anything else means the propagator API itself broke and is logged as
+    a warning, since silently rooting every span is how #246 went unnoticed.
+    """
     if not traceparent:
         return None
+    from opentelemetry import propagate, trace as _otel_trace
+
     try:
-        from opentelemetry.propagators.textmap import DictGetter
-        from opentelemetry import propagate
-        ctx = propagate.extract(carrier={"traceparent": traceparent}, getter=DictGetter())
-        return ctx
-    except Exception:
+        ctx = propagate.extract(carrier={"traceparent": traceparent})
+    except Exception:  # pragma: no cover — propagator API breakage
+        logger.warning("traceparent extraction failed", exc_info=True)
         return None
+
+    span_ctx = _otel_trace.get_current_span(ctx).get_span_context()
+    if not span_ctx.is_valid:
+        logger.debug("ignoring malformed traceparent: %r", traceparent)
+        return None
+    return ctx
 
 
 # ---------------------------------------------------------------------------
@@ -826,6 +838,27 @@ async def delete_prompt(name: str):
     return {"ok": True, "deleted": deleted, "name": name}
 
 
+def _hook_attribution(body: dict) -> dict[str, str]:
+    """Build the ``prov.*`` agent-attribution attributes for a hook span.
+
+    Hook spans previously carried only session id and tool name, so they could
+    not be attributed to an agent or joined to LLM spans on any dimension
+    (#247).  Fields absent from the body are omitted rather than written as
+    empty strings, keeping older installed hook scripts working.
+    """
+    attrs: dict[str, str] = {"prov.harness": "claude-code"}
+    for key, field in (
+        ("prov.agent.id", "agent_id"),
+        ("prov.agent.type", "agent_type"),
+        ("prov.project", "project"),
+        ("prov.cwd", "cwd"),
+    ):
+        value = body.get(field)
+        if value:
+            attrs[key] = str(value)
+    return attrs
+
+
 @app.post("/hooks/span", include_in_schema=True)
 async def hooks_span(body: dict):
     """Receive a single span from Claude Code hooks (e.g., SubagentStop).
@@ -842,6 +875,9 @@ async def hooks_span(body: dict):
     with tracer.start_as_current_span(span_name, context=parent_ctx) as span:
         span.set_attribute("prov.session.id", session_id)
         span.set_attribute("prov.hook.source", "claude-code")
+        for key, value in _hook_attribution(body).items():
+            span.set_attribute(key, value)
+        # Explicit attributes are applied last so callers can override.
         for key, value in attributes.items():
             if value is not None:
                 span.set_attribute(key, str(value) if not isinstance(value, (int, float, bool)) else value)
@@ -861,6 +897,7 @@ async def hooks_batch(body: dict):
     session_id = body.get("session_id", "")
     events = body.get("events", [])
     parent_ctx = _extract_parent_context(body.get("traceparent"))
+    attribution = _hook_attribution(body)
 
     spans_created = 0
     for event in events:
@@ -869,10 +906,18 @@ async def hooks_batch(body: dict):
         data = event.get("data", {})
 
         span_name = f"hook.{event_type}"
-        with tracer.start_as_current_span(span_name, context=parent_ctx) as span:
+        # Stamp at event time, not export time: the Stop hook batches a whole
+        # session's buffer, so wall-clock here collapses every tool call in the
+        # session to the same instant (#248).
+        start_time = int(ts) * 1_000_000 if ts else None
+        with tracer.start_as_current_span(
+            span_name, context=parent_ctx, start_time=start_time
+        ) as span:
             span.set_attribute("prov.session.id", session_id or event.get("session_id", ""))
             span.set_attribute("prov.hook.source", "claude-code")
             span.set_attribute("prov.hook.event_type", event_type)
+            for key, value in attribution.items():
+                span.set_attribute(key, value)
             if ts:
                 span.set_attribute("prov.hook.timestamp_ms", ts)
 

--- a/sdk/python/tests/test_hooks.py
+++ b/sdk/python/tests/test_hooks.py
@@ -224,6 +224,196 @@ class TestHooksProxyEndpoints:
         assert data["spans_created"] == 1
 
 
+class TestHooksSpanContent:
+    """Tests asserting on emitted span structure, not just HTTP status.
+
+    Covers #246 (spans emitted as trace roots), #247 (no agent attribution on
+    hook spans), and #248 (spans stamped with export time, not event time).
+    """
+
+    @pytest.fixture
+    def captured_spans(self):
+        """Install an in-memory exporter on the proxy's tracer provider."""
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+            InMemorySpanExporter,
+        )
+        from agentweave import exporter as aw_exporter
+
+        previous = aw_exporter._provider
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        aw_exporter._provider = provider
+        try:
+            yield exporter
+        finally:
+            aw_exporter._provider = previous
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+
+        return TestClient(app)
+
+    # -- #246: parent context ------------------------------------------------
+
+    def test_extract_parent_context_parses_valid_traceparent(self):
+        """A well-formed traceparent yields a context carrying that trace id."""
+        from opentelemetry import trace as otel_trace
+        from agentweave.proxy import _extract_parent_context
+
+        traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+        ctx = _extract_parent_context(traceparent)
+
+        assert ctx is not None
+        span_ctx = otel_trace.get_current_span(ctx).get_span_context()
+        assert span_ctx.trace_id == 0x4BF92F3577B34DA6A3CE929D0E0E4736
+        assert span_ctx.span_id == 0x00F067AA0BA902B7
+
+    def test_extract_parent_context_returns_none_for_malformed(self):
+        """A malformed traceparent degrades to no parent rather than raising."""
+        from agentweave.proxy import _extract_parent_context
+
+        assert _extract_parent_context("not-a-traceparent") is None
+
+    def test_hooks_batch_parents_spans_under_traceparent(self, client, captured_spans):
+        """Events posted with a traceparent become children of that trace."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Read"}},
+                ],
+            },
+        )
+
+        spans = captured_spans.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].parent is not None
+        assert spans[0].parent.span_id == 0x00F067AA0BA902B7
+        assert spans[0].context.trace_id == 0x4BF92F3577B34DA6A3CE929D0E0E4736
+
+    def test_hooks_batch_without_traceparent_emits_root(self, client, captured_spans):
+        """Absent a traceparent, spans remain roots — existing behaviour."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Read"}},
+                ],
+            },
+        )
+
+        spans = captured_spans.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].parent is None
+
+    # -- #247: agent attribution --------------------------------------------
+
+    def test_hooks_batch_sets_agent_attribution(self, client, captured_spans):
+        """Agent identity supplied in the body lands on every emitted span."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "agent_id": "claude-code-nas",
+                "agent_type": "main",
+                "project": "agentweave",
+                "cwd": "/home/arnab/dev/agentweave",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Bash"}},
+                ],
+            },
+        )
+
+        attrs = captured_spans.get_finished_spans()[0].attributes
+        assert attrs["prov.agent.id"] == "claude-code-nas"
+        assert attrs["prov.agent.type"] == "main"
+        assert attrs["prov.project"] == "agentweave"
+        assert attrs["prov.cwd"] == "/home/arnab/dev/agentweave"
+        assert attrs["prov.harness"] == "claude-code"
+
+    def test_hooks_batch_omits_absent_attribution_fields(self, client, captured_spans):
+        """Missing agent identity omits the keys rather than writing empties."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Bash"}},
+                ],
+            },
+        )
+
+        attrs = captured_spans.get_finished_spans()[0].attributes
+        assert "prov.agent.id" not in attrs
+        assert "prov.project" not in attrs
+        # harness is always known on this endpoint
+        assert attrs["prov.harness"] == "claude-code"
+
+    def test_hooks_span_sets_agent_attribution(self, client, captured_spans):
+        """SubagentStop spans are attributable too, not just batched ones."""
+        client.post(
+            "/hooks/span",
+            json={
+                "span_name": "subagent.stop",
+                "session_id": "sess-1",
+                "agent_id": "claude-code-nas",
+                "project": "agentweave",
+                "attributes": {"prov.agent.type": "subagent"},
+            },
+        )
+
+        attrs = captured_spans.get_finished_spans()[0].attributes
+        assert attrs["prov.agent.id"] == "claude-code-nas"
+        assert attrs["prov.project"] == "agentweave"
+        assert attrs["prov.harness"] == "claude-code"
+        # explicit attributes still win for keys they set
+        assert attrs["prov.agent.type"] == "subagent"
+
+    # -- #248: event-time timestamps ----------------------------------------
+
+    def test_hooks_batch_stamps_spans_at_event_time(self, client, captured_spans):
+        """Span start times come from the buffered ts, not the export moment."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Read"}},
+                    {"event": "post_tool_use", "ts": 1711234599999, "data": {"tool_name": "Write"}},
+                ],
+            },
+        )
+
+        spans = captured_spans.get_finished_spans()
+        assert len(spans) == 2
+        starts = sorted(s.start_time for s in spans)
+        assert starts[0] == 1711234567890 * 1_000_000
+        assert starts[1] == 1711234599999 * 1_000_000
+
+    def test_hooks_batch_falls_back_to_wall_clock_without_ts(self, client, captured_spans):
+        """An event with no ts still produces a span with a sane start time."""
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [{"event": "post_tool_use", "data": {"tool_name": "Read"}}],
+            },
+        )
+
+        spans = captured_spans.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].start_time > 0
+
+
 class TestHooksShellScripts:
     """Tests for hook shell script existence and structure."""
 
@@ -258,6 +448,69 @@ class TestHooksShellScripts:
         for script in ["post_tool_use.sh", "subagent_stop.sh", "stop.sh"]:
             script_path = hooks_dir / script
             assert os.access(script_path, os.X_OK), f"{script} should be executable"
+
+    def _run_stop_hook(self, tmp_path, env_extra):
+        """Run stop.sh against a stub curl, returning the JSON body it posted."""
+        import os
+        import subprocess
+
+        session_id = "sess-shell-1"
+        buffer = tmp_path / f"hooks_buffer_{session_id}.jsonl"
+        buffer.write_text(
+            json.dumps(
+                {"event": "post_tool_use", "ts": 1711234567890, "session_id": session_id,
+                 "data": {"tool_name": "Bash"}}
+            )
+            + "\n"
+        )
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        captured = tmp_path / "payload.json"
+        stub = bin_dir / "curl"
+        stub.write_text(
+            '#!/bin/bash\n'
+            'prev=""\n'
+            'for a in "$@"; do\n'
+            '  if [ "$prev" = "-d" ]; then printf "%s" "$a" > ' f'"{captured}"' '; fi\n'
+            '  prev="$a"\n'
+            'done\n'
+        )
+        stub.chmod(0o755)
+
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["CLAUDE_SESSION_ID"] = session_id
+        env["AGENTWEAVE_HOOKS_BUFFER"] = str(buffer)
+        env.update(env_extra)
+
+        subprocess.run(
+            ["bash", str(self._get_hooks_dir() / "stop.sh")],
+            env=env, check=True, capture_output=True,
+        )
+        return json.loads(captured.read_text())
+
+    def test_stop_hook_sends_agent_attribution(self, tmp_path):
+        """stop.sh forwards agent identity from env so spans are attributable."""
+        payload = self._run_stop_hook(
+            tmp_path,
+            {
+                "AGENTWEAVE_AGENT_ID": "claude-code-nas",
+                "AGENTWEAVE_AGENT_TYPE": "main",
+                "AGENTWEAVE_PROJECT": "agentweave",
+            },
+        )
+
+        assert payload["agent_id"] == "claude-code-nas"
+        assert payload["agent_type"] == "main"
+        assert payload["project"] == "agentweave"
+
+    def test_stop_hook_omits_unset_attribution(self, tmp_path):
+        """Unset agent identity yields empty strings the proxy then drops."""
+        payload = self._run_stop_hook(tmp_path, {})
+
+        assert payload["session_id"] == "sess-shell-1"
+        assert not payload.get("agent_id")
 
     def test_settings_template_valid_json(self):
         """Settings template is valid JSON with expected structure."""

--- a/sdk/python/tests/test_hooks.py
+++ b/sdk/python/tests/test_hooks.py
@@ -399,6 +399,64 @@ class TestHooksSpanContent:
         assert starts[0] == 1711234567890 * 1_000_000
         assert starts[1] == 1711234599999 * 1_000_000
 
+    def test_hooks_batch_emits_zero_duration_for_point_events(self, client, captured_spans):
+        """A single ts yields a point-in-time span, not one lasting until export.
+
+        Setting start_time alone makes the span end at wall clock, so an event
+        buffered an hour before the Stop hook reports a one-hour duration and
+        poisons the spanmetrics latency histograms.
+        """
+        import time
+
+        one_hour_ago_ms = int(time.time() * 1000) - 3_600_000
+
+        client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": one_hour_ago_ms, "data": {"tool_name": "Bash"}},
+                ],
+            },
+        )
+
+        span = captured_spans.get_finished_spans()[0]
+        assert span.end_time == span.start_time
+
+    def test_hooks_batch_survives_malformed_ts(self, client, captured_spans):
+        """A non-numeric ts degrades to wall clock instead of 500ing the batch."""
+        response = client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": "not-a-number", "data": {"tool_name": "Bash"}},
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": {"tool_name": "Read"}},
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["spans_created"] == 2
+        assert len(captured_spans.get_finished_spans()) == 2
+
+    def test_hooks_batch_survives_non_dict_event_data(self, client, captured_spans):
+        """A corrupt buffer line can't 500 the batch or leak an unended span."""
+        response = client.post(
+            "/hooks/batch",
+            json={
+                "session_id": "sess-1",
+                "events": [
+                    {"event": "post_tool_use", "ts": 1711234567890, "data": "corrupt-line"},
+                    {"event": "post_tool_use", "ts": 1711234567891, "data": {"tool_name": "Read"}},
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+        spans = captured_spans.get_finished_spans()
+        assert len(spans) == 2, "both spans must be ended and exported"
+
     def test_hooks_batch_falls_back_to_wall_clock_without_ts(self, client, captured_spans):
         """An event with no ts still produces a span with a sane start time."""
         client.post(
@@ -504,6 +562,16 @@ class TestHooksShellScripts:
         assert payload["agent_id"] == "claude-code-nas"
         assert payload["agent_type"] == "main"
         assert payload["project"] == "agentweave"
+
+    def test_stop_hook_payload_survives_quotes_in_values(self, tmp_path):
+        """A cwd or project containing quotes must not corrupt the JSON body."""
+        payload = self._run_stop_hook(
+            tmp_path,
+            {"AGENTWEAVE_PROJECT": 'we"ird\\proj'},
+        )
+
+        assert payload["project"] == 'we"ird\\proj'
+        assert payload["events"][0]["data"]["tool_name"] == "Bash"
 
     def test_stop_hook_omits_unset_attribution(self, tmp_path):
         """Unset agent identity yields empty strings the proxy then drops."""


### PR DESCRIPTION
Fixes #246 (hook path), #247, #248. First slice of the data-quality work from the 2026-08-06 pipeline audit.

## What was broken

**`_extract_parent_context` never worked.** It imported `DictGetter` from `opentelemetry.propagators.textmap`, which doesn't exist in the installed OTel version. The `ImportError` hit a bare `except Exception` and the function returned `None` unconditionally:

```
has DictGetter: False
_extract_parent_context('00-4bf92f35...-00f067aa0ba902b7-01') = None
```

So every hook span was a trace root — including openclaw-bridge sessions where `stop.sh` correctly forwarded `AGENTWEAVE_TRACEPARENT`. The plumbing was wired all along; the swallowed exception made the failure invisible.

**Hook spans had no agent attribution.** Full attribute set of a live `hook.post_tool_use` span was session id, hook source, event type, timestamp, tool name. No `prov.agent.id`, `prov.harness`, `prov.project`, or `prov.cwd` — so they showed up agent-less in every dashboard view and couldn't be joined to LLM spans on any dimension.

**Spans were stamped at export time.** The `Stop` hook batch-posts a whole session's buffer, and spans were created at that moment. Production data showed five consecutive spans spanning 366 **microseconds** — real Bash calls don't happen 70 µs apart. Durations were meaningless and waterfall ordering was wrong.

## What changed

- `_extract_parent_context` uses the current propagator API, validates the extracted span context, and distinguishes a malformed header (debug) from propagator breakage (warning) instead of silently rooting.
- `/hooks/batch` and `/hooks/span` accept `agent_id` / `agent_type` / `project` / `cwd` and set the matching `prov.*` attributes plus `prov.harness=claude-code`. Absent fields are omitted rather than written as empty attributes, so already-installed hook scripts keep working.
- `stop.sh` and `subagent_stop.sh` forward that identity from the environment.
- Span start time comes from the buffered event `ts`.

## Why this shipped undetected

`test_hooks.py` asserted only HTTP status codes and `spans_created` counts — never span structure, attributes, or timing. The new tests use an in-memory span exporter to assert on emitted spans, and drive `stop.sh` against a stub `curl` to check the actual wire payload.

## Verification

```
516 passed, 2 failed
```

The two failures are `test_prompts.py::test_fetch_prompt_local` and `::test_fetch_prompt_not_found_raises`, both pre-existing on a clean `origin/main` tree (confirmed via stash) and unrelated — they 404 against a network fetch.

## Not in scope

- `subagent_stop.sh` still sends no `traceparent`, so subagent spans remain roots. Needs a session root span to parent under — that's #245/#246.
- `openclaw.turn` still emits one flat span per turn with no children — remainder of #246.
- The static `X-AgentWeave-Session-Id` on the NAS is untouched — #245.