### PR TITLE
chore(deploy): pin proxy image to the SDK version instead of :latest

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -21,7 +21,10 @@ spec:
         runAsGroup: 1000
       containers:
         - name: proxy
-          image: localhost:5000/agentweave-proxy:latest
+          # Pinned so the running build is identifiable from the cluster alone.
+          # scripts/deploy.sh cross-checks this against the SDK version and
+          # refuses to deploy on mismatch. Bump both together.
+          image: localhost:5000/agentweave-proxy:0.3.2
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 # --- Configuration (override via env) ---
 REGISTRY="${AGENTWEAVE_REGISTRY:-localhost:5000}"
-IMAGE="${REGISTRY}/agentweave-proxy:latest"
 NAMESPACE="${AGENTWEAVE_NAMESPACE:-agentweave}"
 MONITORING_NAMESPACE="${AGENTWEAVE_MONITORING_NAMESPACE:-monitoring}"
 NODE_IP="${AGENTWEAVE_NODE_IP:-192.168.1.70}"
@@ -17,16 +16,46 @@ ts() { printf "[%s] %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
 
 fail() { ts "ERROR: $*" >&2; exit 1; }
 
+# --- Step 0: Resolve and verify the version being deployed ---
+# The proxy ran as :latest for months, so the running build was not
+# identifiable from the cluster and a rollout could not be correlated to a
+# commit. The SDK version is the single source of truth; the manifest pins it
+# and this check refuses to deploy if the two have drifted.
+MANIFEST="${REPO_ROOT}/deploy/k8s/deployment.yaml"
+VERSION="$(grep -E '^version *= *"' "${REPO_ROOT}/sdk/python/pyproject.toml" \
+  | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
+[ -n "${VERSION}" ] || fail "Could not read version from sdk/python/pyproject.toml"
+
+IMAGE="${REGISTRY}/agentweave-proxy:${VERSION}"
+MANIFEST_IMAGE="$(grep -E 'image: .*agentweave-proxy:' "${MANIFEST}" \
+  | head -1 | sed -E 's/.*image: *//')"
+
+if [ "${MANIFEST_IMAGE}" != "${IMAGE}" ]; then
+  fail "Version drift: pyproject.toml is ${VERSION} (image ${IMAGE}) but
+${MANIFEST} pins ${MANIFEST_IMAGE}.
+Bump both together, or set AGENTWEAVE_REGISTRY to match."
+fi
+ts "Deploying version ${VERSION}"
+
+# Captured before any apply — afterwards the spec already holds the new tag.
+RUNNING_IMAGE="$(kubectl get deployment/agentweave-proxy -n "${NAMESPACE}" \
+  -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)"
+
 # --- Step 1: Build Docker image ---
 ts "Building Docker image: ${IMAGE}"
-docker build -t "${IMAGE}" -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" \
+docker build -t "${IMAGE}" -t "${REGISTRY}/agentweave-proxy:latest" \
+  -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" \
   || fail "Docker build failed"
 ts "Build complete"
 
 # --- Step 2: Push to local registry ---
+# :latest is still pushed so anything pinned to it keeps resolving, but the
+# deployment tracks the versioned tag.
 ts "Pushing image to ${REGISTRY}"
 docker push "${IMAGE}" \
   || fail "Docker push failed — is the registry at ${REGISTRY} running?"
+docker push "${REGISTRY}/agentweave-proxy:latest" \
+  || fail "Docker push of :latest failed"
 ts "Push complete"
 
 # --- Step 3: Deploy to k8s ---
@@ -66,9 +95,17 @@ ts "Validating secret fields"
 AGENTWEAVE_NAMESPACE="${NAMESPACE}" bash "${REPO_ROOT}/deploy/validate-secrets.sh" \
   || fail "Secret validation failed — refusing to continue deploy"
 
-# Restart deployment to pick up :latest image
-kubectl rollout restart deployment/agentweave-proxy -n "${NAMESPACE}"
-ts "Manifests applied, rollout restarting"
+# A changed image tag makes `kubectl apply` roll the deployment on its own.
+# Only force a restart when the tag is unchanged — redeploying the same
+# version after a rebuild — so we don't trigger two rollouts back to back.
+# RUNNING_IMAGE was captured before the apply above.
+if [ "${RUNNING_IMAGE}" = "${IMAGE}" ]; then
+  ts "Image tag unchanged (${IMAGE}) — forcing restart to pick up rebuild"
+  kubectl rollout restart deployment/agentweave-proxy -n "${NAMESPACE}"
+else
+  ts "Image tag changed (${RUNNING_IMAGE:-none} -> ${IMAGE}) — apply will roll"
+fi
+ts "Manifests applied"
 
 # --- Step 4: Wait for rollout ---
 ts "Waiting for rollout to complete (timeout: ${ROLLOUT_TIMEOUT})"

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -268,7 +268,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.1",
+    version="0.3.2",
 )
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.1"
+version = "0.3.2"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Follow-up to #250. Came out of the 2026-08-06 audit: the live proxy pod reported version `0.3.1` and there was no way to tell which commit that was, because the deployment tracked `agentweave-proxy:latest`.

## Changes

- `pyproject.toml` version is the single source of truth; the manifest pins `agentweave-proxy:<version>`.
- `deploy.sh` cross-checks the two and **fails the deploy on drift**, so a version bump can't silently ship under a stale tag.
- `:latest` is still built and pushed, so anything pinned to it keeps resolving.
- The unconditional `rollout restart` is now conditional — a changed tag makes `kubectl apply` roll the deployment by itself, so the restart only fires when redeploying the same version after a rebuild. The pre-apply image is read *before* the manifests are applied, since afterwards the spec already holds the new tag.
- Bumps `0.3.1` → `0.3.2` for the #250 hook span fixes.

`sdk/js` stays at `0.3.1` — it's unchanged and the two SDKs version independently (no parity check in the preflights).

## Verification

Exercised the drift check both ways rather than assuming:

```
VERSION=[0.3.2]
MANIFEST_IMAGE=[localhost:5000/agentweave-proxy:0.3.2]
MATCH -> deploy proceeds
PASS: drift detected (…:0.3.1 != …:0.3.2)
```

`bash -n` clean; `520 passed, 2 failed` (both pre-existing `test_prompts.py` network 404s).

## Deploy impact

Merging this alone changes nothing on the cluster — someone still has to run `scripts/deploy.sh` on the NAS. When that happens it ships the #250 fixes, and hook spans will begin nesting under bridge traceparents for the first time, which is a visible change in the dashboard.

## Not in scope

`dashboard-deployment.yaml` still uses `:latest` and wants the same treatment.