### PR TITLE
fix(deploy): assert the deployed version in the health check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,16 +114,29 @@ kubectl rollout status deployment/agentweave-proxy -n "${NAMESPACE}" --timeout="
 ts "Rollout complete"
 
 # --- Step 5: Health check ---
-ts "Checking proxy health at ${HEALTH_URL}"
+# The NodePort still resolves to the old pod while it drains, so a bare 200
+# here can report the *previous* build as a successful deploy — observed on
+# the 0.3.2 rollout, where this printed version 0.3.1 and exited 0. Require
+# the reported version to match what we just built.
+ts "Checking proxy health at ${HEALTH_URL} (expecting version ${VERSION})"
 for i in $(seq 1 10); do
-  if curl -sf --max-time 5 "${HEALTH_URL}" >/dev/null 2>&1; then
-    HEALTH_RESP=$(curl -sf --max-time 5 "${HEALTH_URL}")
-    ts "Health check passed: ${HEALTH_RESP}"
-    ts "Deploy successful"
-    exit 0
+  if HEALTH_RESP=$(curl -sf --max-time 5 "${HEALTH_URL}" 2>/dev/null); then
+    LIVE_VERSION="$(printf '%s' "${HEALTH_RESP}" \
+      | sed -nE 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p')"
+    if [ "${LIVE_VERSION}" = "${VERSION}" ]; then
+      ts "Health check passed: ${HEALTH_RESP}"
+      ts "Deploy successful"
+      exit 0
+    fi
+    ts "Health check attempt ${i}/10 — serving ${LIVE_VERSION:-unknown}, waiting for ${VERSION}"
+    sleep 3
+    continue
   fi
   ts "Health check attempt ${i}/10 — retrying in 3s"
   sleep 3
 done
 
-fail "Health check failed after 10 attempts at ${HEALTH_URL}"
+fail "Health check failed after 10 attempts at ${HEALTH_URL}
+Last response: ${HEALTH_RESP:-<none>}
+Expected version ${VERSION}. A healthy endpoint serving an older version means
+the rollout did not fully replace the previous pods."


### PR DESCRIPTION
Found while deploying #250/#251 to the NAS.

## The problem

`deploy.sh` treated any HTTP 200 from `/health` as success. During a rollout the NodePort still resolves to the draining pod, so the check can read the **previous** build and declare the deploy successful.

This happened on the 0.3.2 rollout:

```
[21:34:13] Rollout complete
[21:34:14] Health check passed: {"status":"ok","version":"0.3.1",...}
[21:34:14] Deploy successful
```

The new pod was actually fine — I confirmed `agentweave-proxy:0.3.2` running with `agentweave.__version__ == 0.3.2` inside the container, and `/health` has reported `0.3.2` consistently since. The check had simply raced the terminating pod.

But that's the defect: **a deploy that shipped nothing and a deploy that worked print the same thing.** I had to exec into the pod to tell which one I'd got.

## The fix

Parse `version` from the health response and require it to match the version being deployed, retrying until it does. A genuinely stuck rollout now fails loudly, and the failure names the last response and what was expected.

## Verification

Exercised the parse both ways rather than assuming:

```
live response: {"status":"ok","version":"0.3.2",...}
PASS: match accepted
PASS: stale rejected (parsed 0.3.1)
PASS: unparseable rejected
```

`bash -n` clean.