### PR TITLE
fix(proxy): parent LLM spans off the inbound traceparent (#245)

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.2
+          image: localhost:5000/agentweave-proxy:0.3.3
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/deploy/k8s/monitoring/otel-collector.yaml
+++ b/deploy/k8s/monitoring/otel-collector.yaml
@@ -44,6 +44,26 @@ data:
         limit_mib: 384
         spike_limit_mib: 128
 
+      # Claude Code's native OTel spans carry account PII by default —
+      # user.email, user.id, user.account_uuid, user.account_id and
+      # organization.id appear on claude_code.interaction with no content
+      # flags enabled. Enabling native tracing is not optional for us: it is
+      # the only way Claude Code emits the traceparent that lets proxy spans
+      # join the interaction trace (#245). So the PII is stripped here, at the
+      # ingest boundary, before anything reaches Tempo.
+      attributes/strip_pii:
+        actions:
+          - key: user.email
+            action: delete
+          - key: user.id
+            action: delete
+          - key: user.account_uuid
+            action: delete
+          - key: user.account_id
+            action: delete
+          - key: organization.id
+            action: delete
+
     exporters:
       otlphttp/tempo:
         endpoint: http://tempo.monitoring.svc.cluster.local:4318
@@ -55,7 +75,7 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, attributes/strip_pii, batch]
           exporters: [otlphttp/tempo, debug]
 
 ---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -80,6 +80,17 @@ kubectl apply -f "${REPO_ROOT}/deploy/k8s/namespace.yaml"
 # Langfuse fanout overlay is applied manually after Langfuse v3 migration and a
 # real project API key are ready.
 kubectl apply -f "${REPO_ROOT}/deploy/k8s/monitoring/otel-collector.yaml"
+
+# A ConfigMap edit doesn't restart the pods that mount it, so collector config
+# changes silently didn't take effect — the PII-strip processor applied cleanly
+# and the collector kept running a config from ten weeks earlier. Stamp the pod
+# template with the config hash so apply rolls the deployment exactly when the
+# config actually changed.
+COLLECTOR_HASH="$(sha256sum "${REPO_ROOT}/deploy/k8s/monitoring/otel-collector.yaml" | cut -c1-16)"
+kubectl patch deployment/agentweave-otel-collector -n "${MONITORING_NAMESPACE}" \
+  -p "{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"agentweave.dev/config-hash\":\"${COLLECTOR_HASH}\"}}}}}" \
+  >/dev/null || fail "Could not stamp collector config hash"
+
 kubectl rollout status deployment/agentweave-otel-collector \
   -n "${MONITORING_NAMESPACE}" --timeout="${ROLLOUT_TIMEOUT}" \
   || fail "OTel collector rollout did not complete within ${ROLLOUT_TIMEOUT}"

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -142,6 +142,25 @@ def _context_for_trace_id(trace_id_int: int):
     return _trace.set_span_in_context(NonRecordingSpan(span_ctx))
 
 
+def _llm_parent_context(det_trace_id_int: int | None, traceparent: str | None):
+    """Resolve the parent context for an LLM span.
+
+    Precedence:
+
+    1. ``x-agentweave-trace-id`` — an explicit override callers use to pin
+       retries to a trace; the openclaw bridge relies on it, so it stays
+       ahead of everything else.
+    2. An inbound W3C ``traceparent`` — what Claude Code sends when
+       ``CLAUDE_CODE_PROPAGATE_TRACEPARENT`` is set. Parenting off it puts the
+       proxy's LLM span in the same trace as the native
+       ``claude_code.interaction`` span instead of a disconnected root (#245).
+    3. Neither — a root span, as before.
+    """
+    if det_trace_id_int is not None:
+        return _context_for_trace_id(det_trace_id_int)
+    return _extract_parent_context(traceparent)
+
+
 _SPAN_ID_RE = re.compile(r'^[0-9a-fA-F]{16}$')
 
 
@@ -268,7 +287,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.2",
+    version="0.3.3",
 )
 
 
@@ -1344,7 +1363,7 @@ async def _request_and_trace(
     task_label: str | None = None,
 ) -> Response:
     tracer = get_tracer()
-    _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
+    _span_ctx = _llm_parent_context(det_trace_id_int, traceparent)
     _links = _build_parent_links(parent_trace_id_raw, parent_span_id_raw)
     with tracer.start_as_current_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx, links=_links) as span:
         _set_request_attrs(span, model=model, provider=provider,
@@ -1453,7 +1472,7 @@ async def _stream_and_trace(
     task_label: str | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
-    _span_ctx = _context_for_trace_id(det_trace_id_int) if det_trace_id_int is not None else None
+    _span_ctx = _llm_parent_context(det_trace_id_int, traceparent)
     _links = _build_parent_links(parent_trace_id_raw, parent_span_id_raw)
     span = tracer.start_span(f"{schema.SPAN_PREFIX_LLM}.{model}", context=_span_ctx, links=_links)
     _set_request_attrs(span, model=model, provider=provider,

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.2"
+version = "0.3.3"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -918,6 +918,73 @@ class TestSubAgentAttributionHeaders:
         assert "x-agentweave-turn-depth" in _SKIP_HEADERS_ALWAYS
 
 
+class TestLLMSpanParentContext:
+    """LLM spans parent off an inbound traceparent (#245).
+
+    Claude Code sends a traceparent when CLAUDE_CODE_PROPAGATE_TRACEPARENT is
+    set, but the proxy only recorded it as an attribute and started a fresh
+    root trace, so the native claude_code.interaction trace and the proxy's
+    llm span were two disconnected traces for the same request.
+    """
+
+    TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    TP_TRACE_ID = 0x4BF92F3577B34DA6A3CE929D0E0E4736
+    TP_SPAN_ID = 0x00F067AA0BA902B7
+
+    def _ctx_ids(self, ctx):
+        from opentelemetry import trace as otel_trace
+
+        sc = otel_trace.get_current_span(ctx).get_span_context()
+        return sc.trace_id, sc.span_id
+
+    def test_traceparent_becomes_the_parent_context(self):
+        """With no deterministic trace id, the inbound traceparent parents."""
+        from agentweave.proxy import _llm_parent_context
+
+        ctx = _llm_parent_context(None, self.TP)
+
+        assert ctx is not None
+        trace_id, span_id = self._ctx_ids(ctx)
+        assert trace_id == self.TP_TRACE_ID
+        assert span_id == self.TP_SPAN_ID
+
+    def test_deterministic_trace_id_still_wins(self):
+        """An explicit x-agentweave-trace-id overrides traceparent.
+
+        The openclaw bridge pins retries to a trace this way; traceparent must
+        not silently take that over.
+        """
+        from agentweave.proxy import _llm_parent_context
+
+        det = 0x11111111111111111111111111111111
+        ctx = _llm_parent_context(det, self.TP)
+
+        trace_id, _ = self._ctx_ids(ctx)
+        assert trace_id == det
+
+    def test_deterministic_trace_id_alone_unchanged(self):
+        """Existing behaviour with no traceparent is preserved."""
+        from agentweave.proxy import _llm_parent_context
+
+        det = 0x22222222222222222222222222222222
+        ctx = _llm_parent_context(det, None)
+
+        trace_id, _ = self._ctx_ids(ctx)
+        assert trace_id == det
+
+    def test_no_signals_yields_root(self):
+        """Neither signal present means a root span, as before."""
+        from agentweave.proxy import _llm_parent_context
+
+        assert _llm_parent_context(None, None) is None
+
+    def test_malformed_traceparent_yields_root(self):
+        """A malformed traceparent must not produce a bogus parent."""
+        from agentweave.proxy import _llm_parent_context
+
+        assert _llm_parent_context(None, "not-a-traceparent") is None
+
+
 class TestTraceparentPassthrough:
     """Verify W3C traceparent header is read, set on spans, and forwarded downstream (issue #44)."""
 


### PR DESCRIPTION
Closes #245. Deployed and validated on the NAS as `0.3.3`.

## The problem

Claude Code sends a W3C `traceparent` when `CLAUDE_CODE_PROPAGATE_TRACEPARENT` is set, and the proxy already read it — but only to record it as the `prov.trace.parent` attribute. The span still started a fresh root trace, so one request produced two disconnected traces:

```
native   6c4c24bc31f944f2e7643a93371e7077   interaction -> llm_request
proxy    11b8f9d322cee53b478a7b98a16040cb   llm.claude-opus-5 (root)
```

## The fix

`_llm_parent_context` with explicit precedence:

1. `x-agentweave-trace-id` still wins — the openclaw bridge uses it to pin retries to a trace, and traceparent must not silently take that over.
2. Otherwise an inbound `traceparent` becomes the parent.
3. Otherwise root, as before.

Wired into both the streaming and non-streaming span sites.

## The finding that forced a second change

**You cannot get the traceparent without exporting native spans**, and native spans carry account PII. I tested this rather than assuming:

| Config | traceparent |
|---|---|
| `ENABLE_TELEMETRY` + `PROPAGATE_TRACEPARENT` | **absent** |
| `+ ENHANCED_TELEMETRY_BETA`, `OTEL_TRACES_EXPORTER=none` | **absent** |
| `+ OTEL_TRACES_EXPORTER=otlp` | present |

Actual export is required. And `claude_code.interaction` ships `user.email`, `user.id`, `user.account_uuid`, `user.account_id`, `organization.id` with no content flags enabled. Since enabling the join means accepting native export, those attributes are now deleted at the collector, before anything reaches Tempo.

## Also fixed: collector config changes never applied

`kubectl apply` updates a ConfigMap but doesn't restart the pods mounting it. Deploying the PII strip exposed this — the ConfigMap applied, the script printed "successfully rolled out", and the collector kept serving a config from ten weeks earlier (running pod dated 2026-05-30). The pod template is now stamped with the manifest hash so apply rolls it exactly when config changed.

## Verification — live, on the NAS

One trace after a fresh `claude -p`, trace `870cdfb37ad19ca71d951644c53d2905`:

```
SPAN claude_code.llm_request  | svc: claude-code       | parented: True
SPAN claude_code.interaction  | svc: claude-code       | parented: False
SPAN llm.claude-opus-5        | svc: agentweave-proxy  | parented: True

TOTAL SPANS: 3
SERVICES: {agentweave-proxy, claude-code}
PII PRESENT: NONE - stripped
session.id = 690e383c-19b3-4441-b7f1-a91c268f3661
prov.agent.id = claude-code-nas
```

First time proxy and native spans have shared a trace. The session id is now a real per-session UUID instead of the static `claude-code-nas-main`.

Deploy idempotency checked both ways: first run rolls the collector (new annotation), second run with unchanged hash leaves the pod in place.

`525 passed, 2 failed` — both pre-existing `test_prompts.py` network 404s.

## Live config changed on the NAS

`~/.claude/settings.json` (backed up to `settings.json.bak-20260806-230223`):

- **Removed** `X-AgentWeave-Session-Id: claude-code-nas-main`. `X-AgentWeave-Agent-Id` and `-Project` stay — those are genuinely per-machine.
- **Added** native tracing: `CLAUDE_CODE_ENABLE_TELEMETRY`, `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA`, `CLAUDE_CODE_PROPAGATE_TRACEPARENT`, `OTEL_TRACES_EXPORTER=otlp` (metrics and logs exporters set to `none`), pointed at the collector ClusterIP so the PII strip applies.
- **Added** `OTEL_RESOURCE_ATTRIBUTES=prov.agent.id=claude-code-nas,prov.project=claude-code`, since native spans carry no agent identity of their own.

## Notes

- The collector endpoint is the hardcoded ClusterIP `10.43.221.47:4318`, matching what the openclaw bridge already does. Fragile if the service is recreated; a NodePort would be sturdier.
- This does **not** normalize `claude_code.*` into the `prov.*` schema — that's still #249. Both span families now coexist in one trace under their own names.