### PR TITLE
fix(proxy): scope global session context to the agent that set it

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.3
+          image: localhost:5000/agentweave-proxy:0.3.4
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -273,6 +273,11 @@ def _inject_anthropic_key(forward_headers: dict[str, str], query_string: str) ->
 # Global session context — set at startup from env, overrideable via POST /session
 _session_context: dict[str, str] = {
     k: v for k, v in {
+        # Records who the global belongs to. Session identity from this dict is
+        # only applied to requests from the same agent (see _set_request_attrs),
+        # so an env-configured single-tenant proxy must name its agent here or
+        # its session id will not be applied to anything.
+        "prov.agent.id": os.getenv("AGENTWEAVE_AGENT_ID", ""),
         "prov.session.id": os.getenv("AGENTWEAVE_SESSION_ID", ""),
         "prov.parent.session.id": os.getenv("AGENTWEAVE_PARENT_SESSION_ID", ""),
         "prov.task.label": os.getenv("AGENTWEAVE_TASK_LABEL", ""),
@@ -281,13 +286,22 @@ _session_context: dict[str, str] = {
     }.items() if v
 }
 
+# Attributes in _session_context that identify a specific session rather than
+# acting as a config default. These are only applied to requests from the agent
+# that wrote the global, so one caller's session can't be stamped on another's.
+_GLOBAL_IDENTITY_ATTRS = frozenset({
+    schema.SESSION_ID,
+    schema.PROV_SESSION_ID,
+    schema.PROV_PARENT_SESSION_ID,
+})
+
 # Gemini model name from URL, e.g. /v1beta/models/gemini-2.5-pro:generateContent
 _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.3",
+    version="0.3.4",
 )
 
 
@@ -2097,9 +2111,25 @@ def _set_request_attrs(
         _explicit_session_attrs.add(schema.PROV_PARENT_SESSION_ID)
     if agent_type is not None:
         _explicit_session_attrs.add(schema.PROV_AGENT_TYPE)
+    # Session identity from the process-global is scoped to the agent that set
+    # it. The bridge POSTs /session with force:false on every main-agent turn,
+    # which writes this global; without scoping, any caller that sends no
+    # X-AgentWeave-Session-Id inherits it — Claude Code spans were being
+    # stamped with openclaw cron session ids. Project and similar defaults are
+    # not identity and still apply across agents.
+    _ctx_owner = _session_context.get(schema.PROV_AGENT_ID)
+    _owns_global = bool(_ctx_owner) and _ctx_owner == agent_id
     for k, v in _session_context.items():
-        if k not in _explicit_session_attrs:
-            span.set_attribute(k, v)
+        if k in _explicit_session_attrs:
+            continue
+        if k in _GLOBAL_IDENTITY_ATTRS and not _owns_global:
+            continue
+        span.set_attribute(k, v)
+    # The global stores prov.session.id only; mirror it onto session.id so the
+    # owning agent gets the same pair an explicit session id would produce.
+    if _owns_global and schema.PROV_SESSION_ID in _session_context:
+        if schema.SESSION_ID not in _explicit_session_attrs:
+            span.set_attribute(schema.SESSION_ID, _session_context[schema.PROV_SESSION_ID])
 
     # Only fall back to cfg.agent_id if no per-request agent_id was provided via header
     if not agent_id:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.3"
+version = "0.3.4"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -918,6 +918,107 @@ class TestSubAgentAttributionHeaders:
         assert "x-agentweave-turn-depth" in _SKIP_HEADERS_ALWAYS
 
 
+class TestGlobalSessionContextLeak:
+    """The process-global session context must not leak across callers.
+
+    POST /session with force:false writes a process-global _session_context.
+    _set_request_attrs then stamps every key of that global onto any span that
+    didn't set the key explicitly, so a request from an unrelated agent that
+    sends no X-AgentWeave-Session-Id inherits whoever wrote the global last.
+
+    On the shared NAS proxy the openclaw bridge writes it on every main-agent
+    turn (service.ts: force is false when there's no upstream and the agent
+    isn't a subagent), so Claude Code spans were being stamped with openclaw
+    cron session ids like agent:main:cron:<uuid>:run:<uuid>.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_global(self):
+        from agentweave import proxy as proxy_mod
+
+        saved = dict(proxy_mod._session_context)
+        yield
+        proxy_mod._session_context = saved
+
+    OPENCLAW_SESSION = "agent:main:cron:e2344169:run:4af17ab6"
+
+    def _attrs(self, monkeypatch, global_ctx, **kwargs):
+        from agentweave import proxy as proxy_mod
+        from agentweave.config import AgentWeaveConfig
+
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        proxy_mod._session_context = global_ctx
+        span = _FakeSpan()
+        proxy_mod._set_request_attrs(
+            span, model="claude-opus-5", provider="anthropic",
+            agent_model="claude-opus-5", path="v1/messages", body={},
+            **kwargs,
+        )
+        return span.attrs
+
+    def test_session_id_does_not_leak_to_a_different_agent(self, monkeypatch):
+        """A global written by nix-v1 must not attach to claude-code-nas spans."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
+            agent_id="claude-code-nas", session_id=None,
+        )
+
+        assert attrs.get("prov.session.id") != self.OPENCLAW_SESSION
+        assert attrs.get("session.id") != self.OPENCLAW_SESSION
+
+    def test_session_id_still_applies_to_the_owning_agent(self, monkeypatch):
+        """openclaw's own spans must keep the session id it set (no regression)."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
+            agent_id="nix-v1", session_id=None,
+        )
+
+        assert attrs["prov.session.id"] == self.OPENCLAW_SESSION
+        assert attrs["session.id"] == self.OPENCLAW_SESSION
+
+    def test_parent_session_id_is_scoped_too(self, monkeypatch):
+        """Parent session id is identity as well and must not cross agents."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.parent.session.id": "parent-abc"},
+            agent_id="claude-code-nas",
+        )
+
+        assert attrs.get("prov.parent.session.id") != "parent-abc"
+
+    def test_unowned_global_does_not_supply_session_identity(self, monkeypatch):
+        """With no owner recorded, ownership can't be checked — so don't apply."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.session.id": self.OPENCLAW_SESSION},
+            agent_id="claude-code-nas", session_id=None,
+        )
+
+        assert attrs.get("prov.session.id") != self.OPENCLAW_SESSION
+
+    def test_explicit_session_id_still_wins(self, monkeypatch):
+        """A caller's own session id is unaffected by the global."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
+            agent_id="claude-code-nas", session_id="my-own-session",
+        )
+
+        assert attrs["prov.session.id"] == "my-own-session"
+
+    def test_non_identity_globals_still_apply_across_agents(self, monkeypatch):
+        """Project is a default, not identity — it may still cross agents."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.project": "global-project"},
+            agent_id="claude-code-nas",
+        )
+
+        assert attrs["prov.project"] == "global-project"
+
+
 class TestLLMSpanParentContext:
     """LLM spans parent off an inbound traceparent (#245).
 
@@ -1185,11 +1286,18 @@ class TestSessionEndpoint:
         importlib.reload(proxy_module)
 
     def test_session_context_applied_to_spans(self, monkeypatch):
-        """After POST /session, _set_request_attrs applies context attrs to spans."""
+        """After POST /session, _set_request_attrs applies context attrs to spans.
+
+        The context must name its owning agent for session identity to apply —
+        see TestGlobalSessionContextLeak. Previously this test set no
+        prov.agent.id and still expected the session id on an agent-1 span,
+        which is the cross-caller leak itself.
+        """
         from agentweave.config import AgentWeaveConfig
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
         # Set the global context
         monkeypatch.setattr(proxy_module, "_session_context", {
+            "prov.agent.id": "agent-1",
             "prov.session.id": "ctx-sess-99",
             "prov.task.label": "run tests",
         })


### PR DESCRIPTION
Found while investigating why Claude Code proxy spans carried OpenClaw cron session ids. Deployed as `0.3.4` and verified in production.

## Root cause

A process-global session context on a multi-tenant proxy.

| # | Evidence | Location |
|---|---|---|
| 1 | Bridge POSTs `/session` with `force: Boolean(upstream) \|\| agentType === "subagent"` — **false** on ordinary main-agent turns | `service.ts:673` |
| 2 | On `force:false` the proxy deletes the per-key entry and writes the process-global `_session_context` | `proxy.py:526,532` |
| 3 | `_set_request_attrs` stamped every global key onto any span that hadn't set it explicitly | `proxy.py:2100-2102` |
| 4 | `prov.session.id` was only shielded when `session_id is not None` | `proxy.py:2088-2089` |

The bridge rewrites that global on every main-agent turn, so any caller sending no `X-AgentWeave-Session-Id` inherited it. Observed live: `prov.session.id = agent:main:cron:e2344169-…:run:4af17ab6-…` on spans with `prov.agent.id = claude-code-nas`.

**This is pre-existing, not new.** Claude Code always sent a static session-id header, making `session_id` non-None and shielding the attribute. Removing that header in #253 exposed the leak rather than causing it.

## Why the obvious fix was wrong

Stripping session identity from the global would have fixed Claude Code and **broken OpenClaw**. `x-agentweave-session-key` appears only on the two `/session` POSTs (`service.ts:478,689`) — OpenClaw's model calls never send it, so on `force:false` the global is the only thing carrying its session identity.

## The fix

Scope identity — `session.id`, `prov.session.id`, `prov.parent.session.id` — to the agent named in the global. Non-identity defaults like `prov.project` still apply across agents. An unowned global supplies no identity, since ownership can't be checked; the startup global therefore records `AGENTWEAVE_AGENT_ID` so an env-configured single-tenant proxy still names an owner. When the owning agent picks up the global's session id, `session.id` is mirrored alongside `prov.session.id` to match what an explicit session id produces.

## A test that encoded the bug

`test_session_context_applied_to_spans` set a global with **no** `prov.agent.id` and asserted its session id landed on an `agent-1` span — the cross-caller leak itself. Updated to name the owner rather than deleted.

## Verification

Reproduction test failed with the exact production value shape before the fix, passes after. Full suite: `531 passed, 2 failed` — both pre-existing `test_prompts.py` network 404s.

Live, after deploying `0.3.4`:

```
SPAN claude_code.llm_request | svc: claude-code       session.id = 930a4d08-…
SPAN claude_code.interaction | svc: claude-code       session.id = 930a4d08-…
SPAN llm.claude-opus-5       | svc: agentweave-proxy  prov.session.id = <absent>
```

The OpenClaw session id is gone.

## Known gaps

- **The proxy span now has no session id at all.** Absent is more honest than wrong, and the real id is recoverable from the trace since #253 joins them — but the proxy span itself is session-unattributed. Worth closing as part of #249.
- **OpenClaw preservation is verified by unit test, not yet in production** — no `nix-v1` proxy spans have been emitted since the deploy. It depends on OpenClaw's model calls carrying `x-agentweave-agent-id` so the owner match succeeds. Needs confirming on the next cron run.
- This is still a process-global, so two callers sharing an agent id would still cross-contaminate. Follow-up below.