### PR TITLE
fix(pricing): add the Claude 5 family and reprice Haiku 4.5

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.4
+          image: localhost:5000/agentweave-proxy:0.3.5
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/pricing.py
+++ b/sdk/python/agentweave/pricing.py
@@ -42,6 +42,20 @@ _PriceEntry = Union[Tuple[float, float], Tuple[float, float, float, float]]
 
 _DEFAULT_PRICING: dict[str, _PriceEntry] = {
     # ── Anthropic Claude (input, output, cache_read, cache_write) ─────────────
+    # Cache columns follow the published multipliers: read = 0.1x input,
+    # write = 1.25x input (the 5-minute TTL; a 1h-TTL write is 2x and is not
+    # modelled here).
+    #
+    # Claude 5 generation. These were missing entirely, so every claude-opus-5
+    # span — the primary model on the NAS — was written with cost.usd = -1.
+    "claude-opus-5":              (5.00, 25.00, 0.50, 6.25),
+    # Sonnet 5 carries an introductory $2.00/$10.00 rate through 2026-08-31.
+    # Standard rates are used here: the table has no date handling, and
+    # over-reporting spend during the intro window is the safer error for a
+    # budget tool than under-reporting it indefinitely afterwards.
+    "claude-sonnet-5":            (3.00, 15.00, 0.30, 3.75),
+    "claude-fable-5":             (10.00, 50.00, 1.00, 12.50),
+    "claude-mythos-5":            (10.00, 50.00, 1.00, 12.50),
     # claude-opus-4 / claude-3-opus-*
     "claude-opus-4":              (15.00, 75.00, 1.50, 18.75),
     "claude-opus-4-5":            (15.00, 75.00, 1.50, 18.75),
@@ -52,8 +66,9 @@ _DEFAULT_PRICING: dict[str, _PriceEntry] = {
     "claude-3-5-sonnet":          (3.00, 15.00, 0.30, 3.75),
     # claude-3-haiku (legacy)
     "claude-3-haiku":             (0.25,  1.25, 0.03, 0.30),
-    # claude-haiku-4-5 / claude-3-5-haiku-*
-    "claude-haiku-4-5":           (0.80,  4.00, 0.08, 1.00),
+    # claude-haiku-4-5 is $1.00/$5.00; the table carried pre-repricing values.
+    "claude-haiku-4-5":           (1.00,  5.00, 0.10, 1.25),
+    # claude-3-5-haiku-* keeps its own (lower) legacy rate.
     "claude-haiku-3-5":           (0.80,  4.00, 0.08, 1.00),
     "claude-3-5-haiku":           (0.80,  4.00, 0.08, 1.00),
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -301,7 +301,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.4",
+    version="0.3.5",
 )
 
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.4"
+version = "0.3.5"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/tests/test_pricing.py
+++ b/sdk/python/tests/test_pricing.py
@@ -9,6 +9,71 @@ import pytest
 # pricing.compute_cost unit tests
 # ---------------------------------------------------------------------------
 
+class TestClaude5FamilyPricing:
+    """The Claude 5 generation must be priced, not fall through to UNKNOWN_COST.
+
+    The table shipped only the Claude 4 family, so every Claude 5 span was
+    written with cost.usd = -1 — including claude-opus-5, the primary model on
+    the NAS. Cost is the dashboard's headline metric, so this silently broke it
+    for the whole generation.
+    """
+
+    @pytest.mark.parametrize(
+        "model,expected_input,expected_output",
+        [
+            ("claude-opus-5", 5.00, 25.00),
+            ("claude-sonnet-5", 3.00, 15.00),
+            ("claude-fable-5", 10.00, 50.00),
+        ],
+    )
+    def test_claude_5_models_are_priced(self, model, expected_input, expected_output):
+        from agentweave.pricing import compute_cost, UNKNOWN_COST
+
+        in_cost = compute_cost(model, input_tokens=1_000_000, output_tokens=0)
+        out_cost = compute_cost(model, input_tokens=0, output_tokens=1_000_000)
+
+        assert in_cost != UNKNOWN_COST, f"{model} is unpriced"
+        assert abs(in_cost - expected_input) < 1e-9
+        assert abs(out_cost - expected_output) < 1e-9
+
+    def test_haiku_4_5_repriced_to_current_rates(self):
+        """Haiku 4.5 is $1.00/$5.00 — the table had the pre-repricing values."""
+        from agentweave.pricing import compute_cost
+
+        assert abs(compute_cost("claude-haiku-4-5", 1_000_000, 0) - 1.00) < 1e-9
+        assert abs(compute_cost("claude-haiku-4-5", 0, 1_000_000) - 5.00) < 1e-9
+
+    def test_context_suffixed_model_id_resolves(self):
+        """The proxy sees ids like `claude-opus-5[1m]` from Claude Code."""
+        from agentweave.pricing import compute_cost, UNKNOWN_COST
+
+        cost = compute_cost("claude-opus-5[1m]", input_tokens=1_000_000, output_tokens=0)
+
+        assert cost != UNKNOWN_COST
+        assert abs(cost - 5.00) < 1e-9
+
+    def test_opus_5_does_not_collide_with_opus_4_entries(self):
+        """Partial matching must not resolve Opus 4.x to the Opus 5 entry."""
+        from agentweave.pricing import compute_cost
+
+        # Opus 4.1 is $15/$75; if it fell through to the opus-5 entry it'd be $5.
+        assert abs(compute_cost("claude-opus-4-1", 1_000_000, 0) - 15.00) < 1e-9
+
+    def test_claude_5_cache_rates(self):
+        """Cache read is 0.1x input; 5-minute cache write is 1.25x input."""
+        from agentweave.pricing import compute_cost
+
+        read = compute_cost(
+            "claude-opus-5", input_tokens=0, output_tokens=0, cache_read_tokens=1_000_000
+        )
+        write = compute_cost(
+            "claude-opus-5", input_tokens=0, output_tokens=0, cache_write_tokens=1_000_000
+        )
+
+        assert abs(read - 0.50) < 1e-9
+        assert abs(write - 6.25) < 1e-9
+
+
 class TestComputeCost:
     """Unit tests for the compute_cost function."""
 
@@ -37,7 +102,7 @@ class TestComputeCost:
         cost_prefixed = compute_cost("anthropic/claude-haiku-4-5", input_tokens=1_000_000, output_tokens=0)
         cost_bare = compute_cost("claude-haiku-4-5", input_tokens=1_000_000, output_tokens=0)
         assert abs(cost_prefixed - cost_bare) < 1e-9
-        assert abs(cost_prefixed - 0.80) < 1e-9
+        assert abs(cost_prefixed - 1.00) < 1e-9
 
     def test_case_insensitive(self):
         from agentweave.pricing import compute_cost
@@ -332,7 +397,7 @@ class TestProxyCostAttrs:
         span = _FakeSpan()
         data = {"usage": {"input_tokens": 1_000_000, "output_tokens": 0}}
         _set_anthropic_response_attrs(span, data, elapsed_ms=10, model="anthropic/claude-haiku-4-5")
-        assert abs(span.attrs["cost.usd"] - 0.80) < 1e-9
+        assert abs(span.attrs["cost.usd"] - 1.00) < 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found while exploring #249: the pricing table stopped at the Claude 4 generation.

## Impact

`compute_cost` returns `UNKNOWN_COST` (`-1.0`) for any model not in the table, so **every Claude 5 span was written with `cost.usd = -1`** — including `claude-opus-5`, the primary model on the NAS. Cost is the dashboard's headline metric (`tempoSearchQuery` selects `span.cost.usd` and the Overview aggregates it), so it has been silently broken for the whole current generation.

Observed on a live production span:

```
prov.llm.model       = claude-opus-5
prov.llm.prompt_tokens = 53675
cost.usd             = -1
```

## Changes

| Model | Input | Output | Cache read | Cache write |
|---|---|---|---|---|
| `claude-opus-5` | $5.00 | $25.00 | $0.50 | $6.25 |
| `claude-sonnet-5` | $3.00 | $15.00 | $0.30 | $3.75 |
| `claude-fable-5` / `claude-mythos-5` | $10.00 | $50.00 | $1.00 | $12.50 |
| `claude-haiku-4-5` (repriced) | $1.00 | $5.00 | $0.10 | $1.25 |

Cache columns follow the published multipliers — read 0.1× input, write 1.25× input at the 5-minute TTL — matching the existing rows' convention.

**Haiku 4.5** carried pre-repricing values ($0.80/$4.00). `claude-3-5-haiku` keeps its own lower legacy rate.

## One judgment call worth your review

**Sonnet 5 has an introductory $2/$10 rate through 2026-08-31** — active for another few weeks. The table has no date handling, so I used the **standard** $3/$15: over-reporting spend during the remaining intro window is a safer error for a budget tool than under-reporting it indefinitely from September. Say the word if you'd rather have it exact now and flip it later.

## Verification

Tests written first, watched fail:

```
6 failed → 43 passed
```

Coverage includes `claude-opus-5[1m]` (the context-suffixed id Claude Code actually sends, which resolves via the partial-match path) and a guard that partial matching doesn't resolve Opus 4.x to the Opus 5 entry.

Two existing tests hardcoded Haiku at `0.80` while actually testing provider-prefix stripping — I updated the expected values and left the assertions intact rather than deleting them.

Full suite: `538 passed, 2 failed` — the two are the pre-existing `test_prompts.py` network 404s.

## Not in scope

`claude-opus-4-5` is listed at $15/$75 alongside Opus 4/4.1. I believe Opus 4.5 shipped at $5/$25, but I couldn't confirm it from the current pricing reference (it lists current models only), so I left it alone rather than guess. Worth a separate check.