### PR TITLE
feat(normalizer): map claude_code.* spans into the prov.* schema (#249)

### DIFF
--- a/sdk/python/agentweave/normalizer.py
+++ b/sdk/python/agentweave/normalizer.py
@@ -73,7 +73,13 @@ def _decode_attrs(span: dict) -> dict[str, Any]:
 
 
 def _set(span: dict, key: str, value: Any) -> None:
-    """Append an OTLP-JSON attribute, encoding by Python type."""
+    """Set an OTLP-JSON attribute, encoding by Python type.
+
+    Replaces an existing entry rather than appending a second one. Duplicate
+    attribute keys are undefined behaviour in OTLP, and re-normalization is
+    reachable — a replayed payload, a chained normalizer, or a retry that
+    re-enters the mapping. This keeps the pass idempotent.
+    """
     if value is None:
         return
     if isinstance(value, bool):
@@ -84,7 +90,13 @@ def _set(span: dict, key: str, value: Any) -> None:
         encoded = {"doubleValue": value}
     else:
         encoded = {"stringValue": str(value)}
-    span.setdefault("attributes", []).append({"key": key, "value": encoded})
+
+    attributes = span.setdefault("attributes", [])
+    for attribute in attributes:
+        if attribute["key"] == key:
+            attribute["value"] = encoded
+            return
+    attributes.append({"key": key, "value": encoded})
 
 
 def _normalize_llm_request(span: dict, attrs: dict[str, Any]) -> None:

--- a/sdk/python/agentweave/normalizer.py
+++ b/sdk/python/agentweave/normalizer.py
@@ -1,0 +1,177 @@
+"""Normalize Claude Code's native OTel spans into the AgentWeave prov.* schema.
+
+Claude Code emits its own span hierarchy (``claude_code.interaction`` ->
+``claude_code.llm_request`` / ``claude_code.tool`` / ``claude_code.tool.execution``
+/ ``claude_code.tool.blocked_on_user``) with ``gen_ai.*`` attributes and
+``service.name = "claude-code"``. The dashboard queries ``prov.activity.type``
+and filters on the proxy's service names, so those spans are invisible to it
+despite being stored. This module adds the ``prov.*`` vocabulary so they aren't.
+
+Design: docs/superpowers/specs/2026-08-07-native-otel-normalization-design.md
+Issue:  https://github.com/arniesaha/agentweave/issues/249
+
+Two behaviours here are load-bearing and easy to get wrong:
+
+* ``claude_code.llm_request`` is deliberately **not** given
+  ``prov.activity.type = "llm_call"``. The proxy emits its own span for the
+  same model call, and the dashboard aggregates cost and tokens on that exact
+  attribute value — marking both would double every figure.
+* Native reports the *uncached* input tokens separately from cache reads
+  (``input_tokens: 2``, ``cache_read_tokens: 55627``) while the proxy reports
+  the sum. ``prov.llm.prompt_tokens`` follows the proxy's convention, so the
+  two must be added.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Optional
+
+from agentweave import pricing, schema
+
+# Marks which collector produced a span, so the later migration to
+# native-as-primary (#249 phase C) is a switch rather than a re-mapping.
+PROV_SOURCE = "prov.source"
+SOURCE_NATIVE = "native"
+
+_HARNESS = "claude-code"
+
+# claude_code.* span name -> prov.activity.type
+_ACTIVITY_BY_SPAN = {
+    "claude_code.interaction": "agent_turn",
+    "claude_code.tool": "tool_call",
+    "claude_code.tool.execution": "tool_execution",
+    "claude_code.tool.blocked_on_user": "permission_wait",
+    # claude_code.llm_request is absent on purpose — see the module docstring.
+}
+
+
+def _attr_value(value: dict) -> Any:
+    """Decode a single OTLP-JSON ``AnyValue``.
+
+    Strict protobuf-JSON encodes int64 as a *string*; Claude Code's exporter
+    emits a number. Accept both rather than depending on which one we happen to
+    have observed. Unsupported shapes (bytes, arrays, nested maps) decode to
+    ``None`` so callers can skip them instead of crashing on a payload change.
+    """
+    if "stringValue" in value:
+        return value["stringValue"]
+    if "intValue" in value:
+        try:
+            return int(value["intValue"])
+        except (TypeError, ValueError):
+            return None
+    if "boolValue" in value:
+        return bool(value["boolValue"])
+    if "doubleValue" in value:
+        return float(value["doubleValue"])
+    return None
+
+
+def _decode_attrs(span: dict) -> dict[str, Any]:
+    return {a["key"]: _attr_value(a["value"]) for a in span.get("attributes", [])}
+
+
+def _set(span: dict, key: str, value: Any) -> None:
+    """Append an OTLP-JSON attribute, encoding by Python type."""
+    if value is None:
+        return
+    if isinstance(value, bool):
+        encoded = {"boolValue": value}
+    elif isinstance(value, int):
+        encoded = {"intValue": value}
+    elif isinstance(value, float):
+        encoded = {"doubleValue": value}
+    else:
+        encoded = {"stringValue": str(value)}
+    span.setdefault("attributes", []).append({"key": key, "value": encoded})
+
+
+def _normalize_llm_request(span: dict, attrs: dict[str, Any]) -> None:
+    """Map token counts, model, and cost — but not prov.activity.type."""
+    uncached_in = attrs.get("input_tokens") or 0
+    cache_read = attrs.get("cache_read_tokens") or 0
+    cache_write = attrs.get("cache_creation_tokens") or 0
+    completion = attrs.get("output_tokens") or 0
+
+    # The proxy's prompt_tokens convention includes cache reads; native's
+    # input_tokens does not.
+    _set(span, schema.PROV_LLM_PROMPT_TOKENS, uncached_in + cache_read)
+    _set(span, schema.PROV_LLM_COMPLETION_TOKENS, completion)
+    _set(span, "tokens.cache_read", cache_read)
+    _set(span, "tokens.cache_write", cache_write)
+
+    model = attrs.get("gen_ai.request.model")
+    if model:
+        _set(span, schema.PROV_LLM_MODEL, model)
+    provider = attrs.get("gen_ai.system")
+    if provider:
+        _set(span, schema.PROV_LLM_PROVIDER, provider)
+    if attrs.get("stop_reason"):
+        _set(span, schema.PROV_LLM_STOP_REASON, attrs["stop_reason"])
+
+    if model:
+        # Three different token conventions meet here, so be explicit:
+        #   native      input_tokens = uncached only, cache buckets separate
+        #   prompt_tokens (above)    = uncached + cache_read (proxy convention)
+        #   compute_cost input_tokens = TOTAL; it subtracts both cache buckets
+        #                               to recover the uncached portion
+        # Passing the native or the prompt_tokens value here would floor the
+        # uncached portion at 0 and silently under-charge every cached turn.
+        cost = pricing.compute_cost(
+            model,
+            input_tokens=uncached_in + cache_read + cache_write,
+            output_tokens=completion,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
+        _set(span, "cost.usd", cost)
+
+
+def _normalize_span(span: dict) -> None:
+    """Add prov.* attributes in place. Non-claude_code spans are left alone."""
+    name = span.get("name", "")
+    if not name.startswith("claude_code."):
+        return
+
+    attrs = _decode_attrs(span)
+
+    _set(span, schema.PROV_HARNESS, _HARNESS)
+    _set(span, PROV_SOURCE, SOURCE_NATIVE)
+
+    activity = _ACTIVITY_BY_SPAN.get(name)
+    if activity:
+        _set(span, schema.PROV_ACTIVITY_TYPE, activity)
+
+    session_id = attrs.get("session.id")
+    if session_id:
+        _set(span, schema.PROV_SESSION_ID, session_id)
+
+    turn = attrs.get("interaction.sequence")
+    if turn is not None:
+        _set(span, schema.PROV_SESSION_TURN, turn)
+
+    if name == "claude_code.tool":
+        _set(span, schema.PROV_TOOL_NAME, attrs.get("tool_name"))
+        _set(span, "prov.tool.call_id", attrs.get("tool_use_id"))
+    elif name == "claude_code.tool.execution":
+        # `success` is the native field; `outcome` matches openclaw.turn spans.
+        success = attrs.get("success")
+        if success is not None:
+            _set(span, "outcome", "completed" if success else "failed")
+    elif name == "claude_code.llm_request":
+        _normalize_llm_request(span, attrs)
+
+
+def normalize_payload(document: dict) -> dict:
+    """Return a normalized copy of an OTLP-JSON trace export.
+
+    The input is not mutated — the normalizer sits in the telemetry path and
+    must not surprise a caller that still holds the original payload.
+    """
+    out = copy.deepcopy(document)
+    for resource_spans in out.get("resourceSpans", []):
+        for scope_spans in resource_spans.get("scopeSpans", []):
+            for span in scope_spans.get("spans", []):
+                _normalize_span(span)
+    return out

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -57,6 +57,11 @@ PROV_TASK_LABEL = "prov.task.label"                 # human-readable task label 
 PROV_CWD = "prov.cwd"                               # caller working directory
 PROV_REPOSITORY = "prov.repository"                 # enclosing git repository name
 
+# Emitted by the proxy hook endpoints and the openclaw bridge since before this
+# module tracked them; declared here so every producer shares one spelling.
+PROV_HARNESS = "prov.harness"                       # "claude-code" | "openclaw"
+PROV_TOOL_NAME = "prov.tool.name"                   # tool invoked by an agent
+
 # Agent type constants
 AGENT_TYPE_MAIN = "main"
 AGENT_TYPE_SUBAGENT = "subagent"

--- a/sdk/python/tests/fixtures/claude_code_otlp_json.json
+++ b/sdk/python/tests/fixtures/claude_code_otlp_json.json
@@ -1,0 +1,852 @@
+{
+ "resourceSpans": [
+  {
+   "resource": {
+    "attributes": [
+     {
+      "key": "prov.agent.id",
+      "value": {
+       "stringValue": "claude-code-nas"
+      }
+     },
+     {
+      "key": "prov.project",
+      "value": {
+       "stringValue": "claude-code"
+      }
+     },
+     {
+      "key": "host.arch",
+      "value": {
+       "stringValue": "amd64"
+      }
+     },
+     {
+      "key": "os.type",
+      "value": {
+       "stringValue": "linux"
+      }
+     },
+     {
+      "key": "os.version",
+      "value": {
+       "stringValue": "6.12.30+"
+      }
+     },
+     {
+      "key": "service.name",
+      "value": {
+       "stringValue": "claude-code"
+      }
+     },
+     {
+      "key": "service.version",
+      "value": {
+       "stringValue": "2.1.223"
+      }
+     }
+    ],
+    "droppedAttributesCount": 0
+   },
+   "scopeSpans": [
+    {
+     "scope": {
+      "name": "com.anthropic.claude_code.tracing",
+      "version": "1.0.0"
+     },
+     "spans": [
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "533fc8c19a7e996b",
+       "parentSpanId": "559b452c8d1098af",
+       "name": "claude_code.llm_request",
+       "kind": 1,
+       "startTimeUnixNano": "1786157095295000000",
+       "endTimeUnixNano": "1786157098564879485",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "llm_request"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-opus-5[1m]"
+         }
+        },
+        {
+         "key": "gen_ai.system",
+         "value": {
+          "stringValue": "anthropic"
+         }
+        },
+        {
+         "key": "gen_ai.request.model",
+         "value": {
+          "stringValue": "claude-opus-5[1m]"
+         }
+        },
+        {
+         "key": "llm_request.context",
+         "value": {
+          "stringValue": "interaction"
+         }
+        },
+        {
+         "key": "speed",
+         "value": {
+          "stringValue": "normal"
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 3270
+         }
+        },
+        {
+         "key": "input_tokens",
+         "value": {
+          "intValue": 2
+         }
+        },
+        {
+         "key": "output_tokens",
+         "value": {
+          "intValue": 102
+         }
+        },
+        {
+         "key": "cache_read_tokens",
+         "value": {
+          "intValue": 55627
+         }
+        },
+        {
+         "key": "cache_creation_tokens",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "success",
+         "value": {
+          "boolValue": true
+         }
+        },
+        {
+         "key": "attempt",
+         "value": {
+          "intValue": 1
+         }
+        },
+        {
+         "key": "ttft_ms",
+         "value": {
+          "intValue": 1959
+         }
+        },
+        {
+         "key": "stop_reason",
+         "value": {
+          "stringValue": "tool_use"
+         }
+        },
+        {
+         "key": "gen_ai.response.finish_reasons",
+         "value": {
+          "arrayValue": {
+           "values": [
+            {
+             "stringValue": "tool_use"
+            }
+           ]
+          }
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [
+        {
+         "attributes": [
+          {
+           "key": "attempt",
+           "value": {
+            "intValue": 1
+           }
+          }
+         ],
+         "name": "gen_ai.request.attempt",
+         "timeUnixNano": "1786157095298642125",
+         "droppedAttributesCount": 0
+        }
+       ],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      },
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "c55dce32510949a5",
+       "parentSpanId": "c3c99e267246c1fd",
+       "name": "claude_code.tool.blocked_on_user",
+       "kind": 1,
+       "startTimeUnixNano": "1786157098599000000",
+       "endTimeUnixNano": "1786157098614135039",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "tool.blocked_on_user"
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 15
+         }
+        },
+        {
+         "key": "decision",
+         "value": {
+          "stringValue": "unknown"
+         }
+        },
+        {
+         "key": "source",
+         "value": {
+          "stringValue": "unknown"
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      },
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "b11d86636d1adb73",
+       "parentSpanId": "c3c99e267246c1fd",
+       "name": "claude_code.tool.execution",
+       "kind": 1,
+       "startTimeUnixNano": "1786157098614000000",
+       "endTimeUnixNano": "1786157098685912338",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "tool.execution"
+         }
+        },
+        {
+         "key": "tool_use_id",
+         "value": {
+          "stringValue": "toolu_01RnouwysZmzXrtDHS4KC7ez"
+         }
+        },
+        {
+         "key": "gen_ai.tool.call.id",
+         "value": {
+          "stringValue": "toolu_01RnouwysZmzXrtDHS4KC7ez"
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 72
+         }
+        },
+        {
+         "key": "success",
+         "value": {
+          "boolValue": true
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      },
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "c3c99e267246c1fd",
+       "parentSpanId": "559b452c8d1098af",
+       "name": "claude_code.tool",
+       "kind": 1,
+       "startTimeUnixNano": "1786157098599000000",
+       "endTimeUnixNano": "1786157098686483577",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "tool"
+         }
+        },
+        {
+         "key": "tool_name",
+         "value": {
+          "stringValue": "Bash"
+         }
+        },
+        {
+         "key": "tool_use_id",
+         "value": {
+          "stringValue": "toolu_01RnouwysZmzXrtDHS4KC7ez"
+         }
+        },
+        {
+         "key": "gen_ai.tool.call.id",
+         "value": {
+          "stringValue": "toolu_01RnouwysZmzXrtDHS4KC7ez"
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 87
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      },
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "2caffdfd96edb327",
+       "parentSpanId": "559b452c8d1098af",
+       "name": "claude_code.llm_request",
+       "kind": 1,
+       "startTimeUnixNano": "1786157098693000000",
+       "endTimeUnixNano": "1786157101996254848",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "llm_request"
+         }
+        },
+        {
+         "key": "model",
+         "value": {
+          "stringValue": "claude-opus-5[1m]"
+         }
+        },
+        {
+         "key": "gen_ai.system",
+         "value": {
+          "stringValue": "anthropic"
+         }
+        },
+        {
+         "key": "gen_ai.request.model",
+         "value": {
+          "stringValue": "claude-opus-5[1m]"
+         }
+        },
+        {
+         "key": "llm_request.context",
+         "value": {
+          "stringValue": "interaction"
+         }
+        },
+        {
+         "key": "speed",
+         "value": {
+          "stringValue": "normal"
+         }
+        },
+        {
+         "key": "duration_ms",
+         "value": {
+          "intValue": 3303
+         }
+        },
+        {
+         "key": "input_tokens",
+         "value": {
+          "intValue": 2
+         }
+        },
+        {
+         "key": "output_tokens",
+         "value": {
+          "intValue": 15
+         }
+        },
+        {
+         "key": "cache_read_tokens",
+         "value": {
+          "intValue": 55738
+         }
+        },
+        {
+         "key": "cache_creation_tokens",
+         "value": {
+          "intValue": 0
+         }
+        },
+        {
+         "key": "success",
+         "value": {
+          "boolValue": true
+         }
+        },
+        {
+         "key": "attempt",
+         "value": {
+          "intValue": 1
+         }
+        },
+        {
+         "key": "ttft_ms",
+         "value": {
+          "intValue": 2805
+         }
+        },
+        {
+         "key": "stop_reason",
+         "value": {
+          "stringValue": "end_turn"
+         }
+        },
+        {
+         "key": "gen_ai.response.finish_reasons",
+         "value": {
+          "arrayValue": {
+           "values": [
+            {
+             "stringValue": "end_turn"
+            }
+           ]
+          }
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [
+        {
+         "attributes": [
+          {
+           "key": "attempt",
+           "value": {
+            "intValue": 1
+           }
+          }
+         ],
+         "name": "gen_ai.request.attempt",
+         "timeUnixNano": "1786157098694598248",
+         "droppedAttributesCount": 0
+        }
+       ],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      },
+      {
+       "traceId": "8220d1db9df1fae829d15a9d07dab448",
+       "spanId": "559b452c8d1098af",
+       "name": "claude_code.interaction",
+       "kind": 1,
+       "startTimeUnixNano": "1786157095271000000",
+       "endTimeUnixNano": "1786157101999859350",
+       "attributes": [
+        {
+         "key": "prov.agent.id",
+         "value": {
+          "stringValue": "claude-code-nas"
+         }
+        },
+        {
+         "key": "prov.project",
+         "value": {
+          "stringValue": "claude-code"
+         }
+        },
+        {
+         "key": "user.id",
+         "value": {
+          "stringValue": "REDACTED"
+         }
+        },
+        {
+         "key": "session.id",
+         "value": {
+          "stringValue": "b6d30a27-e8d7-4943-aad3-be952d5688fd"
+         }
+        },
+        {
+         "key": "organization.id",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000001"
+         }
+        },
+        {
+         "key": "user.email",
+         "value": {
+          "stringValue": "redacted@example.com"
+         }
+        },
+        {
+         "key": "user.account_uuid",
+         "value": {
+          "stringValue": "00000000-0000-0000-0000-000000000000"
+         }
+        },
+        {
+         "key": "user.account_id",
+         "value": {
+          "stringValue": "user_REDACTED"
+         }
+        },
+        {
+         "key": "terminal.type",
+         "value": {
+          "stringValue": "non-interactive"
+         }
+        },
+        {
+         "key": "span.type",
+         "value": {
+          "stringValue": "interaction"
+         }
+        },
+        {
+         "key": "user_prompt",
+         "value": {
+          "stringValue": "probe prompt"
+         }
+        },
+        {
+         "key": "user_prompt_length",
+         "value": {
+          "intValue": 71
+         }
+        },
+        {
+         "key": "interaction.sequence",
+         "value": {
+          "intValue": 1
+         }
+        },
+        {
+         "key": "interaction.duration_ms",
+         "value": {
+          "intValue": 6729
+         }
+        }
+       ],
+       "droppedAttributesCount": 0,
+       "events": [],
+       "droppedEventsCount": 0,
+       "status": {
+        "code": 0
+       },
+       "links": [],
+       "droppedLinksCount": 0,
+       "flags": 257
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/sdk/python/tests/test_normalizer.py
+++ b/sdk/python/tests/test_normalizer.py
@@ -224,6 +224,35 @@ class TestNonNativeSpansUntouched:
 
         assert keys == {"prov.activity.type"}, "proxy spans must not be rewritten"
 
+    def test_normalizing_twice_does_not_duplicate_attributes(self, payload):
+        """Duplicate attribute keys are undefined behaviour in OTLP.
+
+        Re-normalization is reachable: a replayed payload, a chained
+        normalizer, or a retry that re-enters the mapping. Each prov.* key must
+        appear exactly once regardless of how many passes ran.
+        """
+        from agentweave.normalizer import normalize_payload
+
+        twice = normalize_payload(normalize_payload(payload))
+
+        for rs in twice["resourceSpans"]:
+            for ss in rs["scopeSpans"]:
+                for span in ss["spans"]:
+                    keys = [a["key"] for a in span["attributes"]]
+                    assert len(keys) == len(set(keys)), (
+                        f"{span['name']} has duplicate keys: "
+                        f"{sorted(k for k in set(keys) if keys.count(k) > 1)}"
+                    )
+
+    def test_second_pass_is_byte_identical_to_the_first(self, payload):
+        """Idempotency in the strong sense — not just de-duplicated."""
+        from agentweave.normalizer import normalize_payload
+
+        once = normalize_payload(payload)
+        twice = normalize_payload(once)
+
+        assert json.dumps(twice, sort_keys=True) == json.dumps(once, sort_keys=True)
+
     def test_input_payload_is_not_mutated(self, payload):
         from agentweave.normalizer import normalize_payload
 

--- a/sdk/python/tests/test_normalizer.py
+++ b/sdk/python/tests/test_normalizer.py
@@ -1,0 +1,233 @@
+"""Tests for claude_code.* -> prov.* normalization (issue #249).
+
+Asserts on the emitted span attributes, never on a status code — the defect
+class behind #246/#247/#248 was tests that checked HTTP responses and never
+looked at what actually landed in a span.
+
+The fixture is a real OTLP-JSON payload captured from a Claude Code session on
+the NAS (2026-08-07), with account PII redacted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "claude_code_otlp_json.json"
+
+
+@pytest.fixture
+def payload() -> dict:
+    return json.loads(FIXTURE.read_text())
+
+
+@pytest.fixture
+def normalized(payload):
+    """Normalized payload keyed by span name for convenient assertions."""
+    from agentweave.normalizer import normalize_payload
+
+    out = normalize_payload(payload)
+    by_name: dict[str, list[dict]] = {}
+    for rs in out["resourceSpans"]:
+        for ss in rs["scopeSpans"]:
+            for span in ss["spans"]:
+                attrs = {
+                    a["key"]: list(a["value"].values())[0] for a in span["attributes"]
+                }
+                by_name.setdefault(span["name"], []).append(attrs)
+    return by_name
+
+
+class TestAttributeDecoding:
+    """OTLP-JSON encodes int64 as a string in strict protobuf-JSON, but Claude
+    Code's exporter emits a number. Both must decode."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ({"stringValue": "hello"}, "hello"),
+            ({"intValue": 42}, 42),
+            ({"intValue": "42"}, 42),
+            ({"boolValue": True}, True),
+            ({"doubleValue": 1.5}, 1.5),
+        ],
+    )
+    def test_decodes_value_shapes(self, raw, expected):
+        from agentweave.normalizer import _attr_value
+
+        assert _attr_value(raw) == expected
+
+    def test_unknown_shape_returns_none(self):
+        from agentweave.normalizer import _attr_value
+
+        assert _attr_value({"bytesValue": "unsupported"}) is None
+
+
+class TestSpanMapping:
+    """One assertion group per row of the design's mapping table."""
+
+    def test_interaction_becomes_agent_turn(self, normalized):
+        attrs = normalized["claude_code.interaction"][0]
+        assert attrs["prov.activity.type"] == "agent_turn"
+        assert attrs["prov.session.id"] == attrs["session.id"]
+
+    def test_tool_becomes_tool_call(self, normalized):
+        attrs = normalized["claude_code.tool"][0]
+        assert attrs["prov.activity.type"] == "tool_call"
+        assert attrs["prov.tool.name"] == attrs["tool_name"]
+        assert attrs["prov.tool.call_id"] == attrs["tool_use_id"]
+
+    def test_tool_execution_becomes_tool_execution(self, normalized):
+        attrs = normalized["claude_code.tool.execution"][0]
+        assert attrs["prov.activity.type"] == "tool_execution"
+        assert attrs["outcome"] == "completed"
+
+    def test_blocked_on_user_becomes_permission_wait(self, normalized):
+        attrs = normalized["claude_code.tool.blocked_on_user"][0]
+        assert attrs["prov.activity.type"] == "permission_wait"
+
+    def test_every_span_carries_harness_and_source(self, normalized):
+        for name, spans in normalized.items():
+            for attrs in spans:
+                assert attrs["prov.harness"] == "claude-code", name
+                assert attrs["prov.source"] == "native", name
+
+
+class TestLLMRequestMapping:
+    def test_llm_request_is_not_marked_as_llm_call(self, normalized):
+        """The proxy owns llm_call. Marking native as llm_call too would double
+        every token and dollar in the dashboard's Overview aggregation."""
+        for attrs in normalized["claude_code.llm_request"]:
+            assert attrs.get("prov.activity.type") != "llm_call"
+
+    def test_prompt_tokens_sums_uncached_input_and_cache_reads(self, normalized):
+        """Native splits input; the proxy reports the sum. Mapping input_tokens
+        straight across under-reports by orders of magnitude on a cached turn."""
+        attrs = normalized["claude_code.llm_request"][0]
+        assert attrs["prov.llm.prompt_tokens"] == (
+            attrs["input_tokens"] + attrs["cache_read_tokens"]
+        )
+        # Guard against the fixture degenerating into a no-cache case, which
+        # would make this test pass without exercising the sum.
+        assert attrs["cache_read_tokens"] > 0
+
+    def test_token_and_model_fields_carried(self, normalized):
+        attrs = normalized["claude_code.llm_request"][0]
+        assert attrs["prov.llm.completion_tokens"] == attrs["output_tokens"]
+        assert attrs["tokens.cache_read"] == attrs["cache_read_tokens"]
+        assert attrs["tokens.cache_write"] == attrs["cache_creation_tokens"]
+        assert attrs["prov.llm.model"] == attrs["gen_ai.request.model"]
+        assert attrs["prov.llm.provider"] == "anthropic"
+
+    def test_cost_is_computed_not_unknown(self, normalized):
+        from agentweave.pricing import UNKNOWN_COST
+
+        attrs = normalized["claude_code.llm_request"][0]
+        assert attrs["cost.usd"] != UNKNOWN_COST
+        assert attrs["cost.usd"] > 0
+
+    def test_cost_prices_cache_reads_at_the_cache_rate(self, normalized):
+        """claude-opus-5: $5.00 input, $25.00 output, $0.50 cache read per 1M.
+
+        Pricing cache reads as full input would inflate a cached turn ~10x.
+        """
+        attrs = normalized["claude_code.llm_request"][0]
+        expected = (
+            attrs["input_tokens"] * 5.00
+            + attrs["cache_read_tokens"] * 0.50
+            + attrs["cache_creation_tokens"] * 6.25
+            + attrs["output_tokens"] * 25.00
+        ) / 1_000_000
+        assert abs(attrs["cost.usd"] - expected) < 1e-9
+
+
+class TestCacheWritePricing:
+    """The captured fixture has cache_creation_tokens == 0, so it cannot
+    discriminate how cache writes are priced. Cover that path explicitly."""
+
+    def _llm_span(self, uncached: int, cache_read: int, cache_write: int, out: int) -> dict:
+        from agentweave.normalizer import normalize_payload
+
+        doc = {
+            "resourceSpans": [{
+                "resource": {"attributes": []},
+                "scopeSpans": [{"spans": [{
+                    "name": "claude_code.llm_request",
+                    "attributes": [
+                        {"key": "gen_ai.request.model", "value": {"stringValue": "claude-opus-5"}},
+                        {"key": "gen_ai.system", "value": {"stringValue": "anthropic"}},
+                        {"key": "input_tokens", "value": {"intValue": uncached}},
+                        {"key": "cache_read_tokens", "value": {"intValue": cache_read}},
+                        {"key": "cache_creation_tokens", "value": {"intValue": cache_write}},
+                        {"key": "output_tokens", "value": {"intValue": out}},
+                    ],
+                }]}],
+            }]
+        }
+        span = normalize_payload(doc)["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        return {a["key"]: list(a["value"].values())[0] for a in span["attributes"]}
+
+    def test_cache_writes_priced_at_the_write_rate(self):
+        """claude-opus-5 cache write is $6.25/M — 1.25x the $5.00 input rate."""
+        attrs = self._llm_span(uncached=1000, cache_read=0, cache_write=1_000_000, out=0)
+
+        expected = (1000 * 5.00 + 1_000_000 * 6.25) / 1_000_000
+        assert abs(attrs["cost.usd"] - expected) < 1e-9
+
+    def test_uncached_input_still_charged_alongside_both_cache_buckets(self):
+        """Regression: passing the uncached portion as compute_cost's
+        input_tokens floors it to 0 and silently drops the input charge."""
+        attrs = self._llm_span(uncached=2, cache_read=50_000, cache_write=1_000, out=10)
+
+        expected = (2 * 5.00 + 50_000 * 0.50 + 1_000 * 6.25 + 10 * 25.00) / 1_000_000
+        assert abs(attrs["cost.usd"] - expected) < 1e-9
+
+    def test_prompt_tokens_excludes_cache_writes(self):
+        """prov.llm.prompt_tokens follows the proxy convention: uncached +
+        cache reads, not cache writes."""
+        attrs = self._llm_span(uncached=2, cache_read=50_000, cache_write=1_000, out=10)
+
+        assert attrs["prov.llm.prompt_tokens"] == 50_002
+        assert attrs["tokens.cache_write"] == 1_000
+
+
+class TestNonNativeSpansUntouched:
+    def test_foreign_spans_pass_through_unchanged(self):
+        from agentweave.normalizer import normalize_payload
+
+        doc = {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": []},
+                    "scopeSpans": [
+                        {
+                            "spans": [
+                                {
+                                    "name": "llm.claude-opus-5",
+                                    "attributes": [
+                                        {"key": "prov.activity.type",
+                                         "value": {"stringValue": "llm_call"}}
+                                    ],
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+
+        out = normalize_payload(doc)
+        attrs = out["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"]
+        keys = {a["key"] for a in attrs}
+
+        assert keys == {"prov.activity.type"}, "proxy spans must not be rewritten"
+
+    def test_input_payload_is_not_mutated(self, payload):
+        from agentweave.normalizer import normalize_payload
+
+        before = json.dumps(payload, sort_keys=True)
+        normalize_payload(payload)
+
+        assert json.dumps(payload, sort_keys=True) == before


### PR DESCRIPTION
First implementation slice for #249, following the design in #257. **Library only — no service, no deployment.** That's rollout step 2; wiring it into the telemetry path is the next PR.

## Spec task 1 is verified: `http/json` works

This gated everything else. Captured a real Claude Code session exporting with `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`:

```
POST /v1/traces content-type=application/json bytes=10418
PARSED AS JSON: yes
SPANS: [claude_code.llm_request, claude_code.tool.blocked_on_user,
        claude_code.tool.execution, claude_code.tool,
        claude_code.llm_request, claude_code.interaction]
```

Full hierarchy, standard-library-parseable. No protobuf dependency needed. That payload — PII-redacted — is now the test fixture.

## The bug my own test caught

Three token conventions meet in the cost path, and they don't agree:

| | `input_tokens` means |
|---|---|
| native span | uncached only; cache buckets separate |
| `prov.llm.prompt_tokens` | uncached + cache_read (proxy convention) |
| `compute_cost(...)` | **total**; it subtracts both cache buckets |

My first implementation passed the *uncached* portion to `compute_cost`, which computed `max(0, 2 − 55627) = 0` and silently dropped the input charge — off by exactly `2 × $5.00/M`. The design called this "the correctness trap" and I walked straight into it; the dedicated test failed before it could ship.

Both the arithmetic and the regression now have explicit coverage, including the **cache-write path the fixture can't exercise** (its `cache_creation_tokens` is 0) — I added synthetic cases for that rather than leaving a changed code path untested.

## Design decisions carried through

- **`claude_code.llm_request` is not marked `llm_call`.** The proxy owns that value and the dashboard aggregates on it; marking both would double every token and dollar. Asserted, not just intended.
- **`prov.source = "native"`** on everything emitted, so the migration to native-primary is a flag flip.
- **Input is never mutated** — the normalizer sits in the telemetry path and must not surprise a caller holding the original payload. Asserted.
- **Non-`claude_code.*` spans pass through untouched.** Asserted.
- **`intValue` decodes from both number and string.** Strict protobuf-JSON says string; Claude Code emits a number. Handling only what I happened to observe would be a latent break.

## Incidental fix

`PROV_HARNESS` and `PROV_TOOL_NAME` were emitted by `proxy.py` and the openclaw bridge as raw string literals but never declared in `schema.py`, so producers could drift on spelling. Added. Existing call sites left alone — out of scope.

## Verification

```
21 passed   (normalizer)
559 passed, 2 failed   (full suite)
```

The two failures are the pre-existing `test_prompts.py` network 404s.

## Not in scope

The normalizer service, its Dockerfile/k8s manifests, the dashboard filter widening, and `prov.source = "proxy"` on the proxy — all rollout steps 3–5.