### PR TITLE
feat(normalizer): OTLP-JSON receiver, image, and k8s manifests (#249)

### DIFF
--- a/deploy/docker/Dockerfile.normalizer
+++ b/deploy/docker/Dockerfile.normalizer
@@ -1,0 +1,32 @@
+FROM python:3.11-slim
+
+LABEL org.opencontainers.image.title="AgentWeave Normalizer"
+LABEL org.opencontainers.image.description="Normalizes Claude Code native OTel spans into the prov.* schema"
+LABEL org.opencontainers.image.source="https://github.com/arniesaha/agentweave"
+LABEL org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+
+# Same dependency set as the proxy — FastAPI, uvicorn, httpx all come from the
+# proxy extra, and pricing.py is needed for cost computation.
+COPY sdk/python/pyproject.toml ./
+COPY README.md ./
+COPY sdk/python/agentweave/ ./agentweave/
+RUN pip install --no-cache-dir ".[proxy]"
+
+RUN useradd -m -u 1000 agentweave
+USER agentweave
+
+EXPOSE 4318
+
+# Configuration via environment variables:
+#   AGENTWEAVE_COLLECTOR_ENDPOINT  — OTLP HTTP base URL of the collector
+#   AGENTWEAVE_NORMALIZER_PORT     — listen port (default 4318)
+#
+# Run uvicorn directly rather than through the `agentweave` CLI: the CLI has no
+# normalizer subcommand yet, and adding one is not needed to deploy this.
+ENTRYPOINT ["sh", "-c", "\
+  exec uvicorn agentweave.normalizer_service:app \
+    --host 0.0.0.0 \
+    --port ${AGENTWEAVE_NORMALIZER_PORT:-4318} \
+"]

--- a/deploy/k8s/normalizer.yaml
+++ b/deploy/k8s/normalizer.yaml
@@ -1,0 +1,101 @@
+---
+# AgentWeave Normalizer — receives Claude Code's native OTLP-JSON spans,
+# normalizes them into the prov.* schema, and forwards to the OTel collector.
+#
+#   Claude Code --OTLP/JSON--> normalizer --OTLP--> collector --> Tempo
+#
+# Deployed with NO traffic pointed at it initially (rollout step 3 of
+# docs/superpowers/specs/2026-08-07-native-otel-normalization-design.md).
+# Traffic is cut over by repointing OTEL_EXPORTER_OTLP_ENDPOINT on the client;
+# rollback is repointing that one variable back at the collector.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentweave-normalizer
+  namespace: agentweave
+  labels:
+    app: agentweave-normalizer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentweave-normalizer
+  template:
+    metadata:
+      labels:
+        app: agentweave-normalizer
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: normalizer
+          # Pinned to the SDK version, same convention as the proxy.
+          image: localhost:5000/agentweave-normalizer:0.3.5
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 4318
+              name: otlp-http
+          env:
+            # In-cluster DNS rather than the hardcoded ClusterIP the bridge and
+            # Claude Code currently use — this pod is inside the cluster, so it
+            # does not need the host-reachable address.
+            - name: AGENTWEAVE_COLLECTOR_ENDPOINT
+              value: "http://agentweave-otel-collector.monitoring.svc.cluster.local:4318"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 4318
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 4318
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              memory: 256Mi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentweave-normalizer
+  namespace: agentweave
+  labels:
+    app: agentweave-normalizer
+spec:
+  type: ClusterIP
+  selector:
+    app: agentweave-normalizer
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+
+---
+# NodePort so Claude Code on the NAS host reaches the normalizer directly.
+# Host-to-ClusterIP routing on this cluster has been observed taking ~5s on a
+# cold path, which is not acceptable in a telemetry hot path.
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentweave-normalizer-nodeport
+  namespace: agentweave
+  labels:
+    app: agentweave-normalizer
+spec:
+  type: NodePort
+  selector:
+    app: agentweave-normalizer
+  ports:
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      nodePort: 30419

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -120,4 +120,7 @@ async def ingest_traces(request: Request) -> JSONResponse:
             {"error": f"collector returned {status}"}, status_code=502
         )
 
-    return JSONResponse({"ok": True}, status_code=200)
+    # OTLP/HTTP expects an ExportTraceServiceResponse. An empty object is the
+    # valid "everything accepted" form; a bespoke body risks an exporter
+    # warning or rejecting, which would be silent in a telemetry path.
+    return JSONResponse({}, status_code=200)

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -1,0 +1,123 @@
+"""OTLP-JSON receiver that normalizes Claude Code spans and forwards them on.
+
+Sits between Claude Code and the OTel collector:
+
+    Claude Code --OTLP/JSON--> normalizer --OTLP--> collector --> Tempo
+
+Deliberately a separate service rather than an endpoint on the proxy: the proxy
+is on the request hot path, restarts frequently, and a normalization bug there
+would present as a proxy bug. See the design doc for the full rationale —
+docs/superpowers/specs/2026-08-07-native-otel-normalization-design.md
+
+Configuration (environment):
+
+    AGENTWEAVE_COLLECTOR_ENDPOINT  OTLP HTTP base URL of the collector
+                                   (default http://10.43.221.47:4318)
+    AGENTWEAVE_NORMALIZER_PORT     listen port (default 4318)
+
+The collector keeps doing PII stripping downstream, so this service does not
+duplicate that responsibility.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import httpx
+from fastapi import Request
+from fastapi.applications import FastAPI
+from fastapi.responses import JSONResponse
+
+from agentweave.normalizer import normalize_payload
+
+__version__ = "0.3.5"
+
+logger = logging.getLogger("agentweave.normalizer")
+
+COLLECTOR_ENDPOINT = os.getenv(
+    "AGENTWEAVE_COLLECTOR_ENDPOINT", "http://10.43.221.47:4318"
+).rstrip("/")
+
+_FORWARD_TIMEOUT_SECONDS = 30
+
+app = FastAPI(
+    title="AgentWeave Normalizer",
+    description="Normalizes Claude Code native OTel spans into the prov.* schema",
+    version=__version__,
+)
+
+
+async def _forward(url: str, document: dict) -> int:
+    """POST a normalized payload to the collector. Returns its status code."""
+    async with httpx.AsyncClient(timeout=_FORWARD_TIMEOUT_SECONDS) as client:
+        response = await client.post(
+            url, json=document, headers={"content-type": "application/json"}
+        )
+        return response.status_code
+
+
+@app.get("/health", include_in_schema=True)
+async def health() -> dict:
+    """Liveness probe. Reports the collector it forwards to, so a misconfigured
+    endpoint is visible without exec'ing into the pod."""
+    return {
+        "status": "ok",
+        "version": __version__,
+        "collector_endpoint": COLLECTOR_ENDPOINT,
+    }
+
+
+@app.post("/v1/traces", include_in_schema=True, response_model=None)
+async def ingest_traces(request: Request) -> JSONResponse:
+    """Receive an OTLP-JSON trace export, normalize it, forward it on.
+
+    Status codes matter here: the OTel exporter retries on 5xx and drops on
+    2xx. Anything that means "the batch did not land" must be a 5xx, or spans
+    are lost silently.
+    """
+    content_type = request.headers.get("content-type", "")
+    if "protobuf" in content_type:
+        # Configured for the wrong protocol — say so rather than failing to
+        # parse binary as JSON and returning a confusing 400.
+        return JSONResponse(
+            {
+                "error": "this endpoint accepts OTLP-JSON only; set "
+                "OTEL_EXPORTER_OTLP_PROTOCOL=http/json"
+            },
+            status_code=415,
+        )
+
+    raw = await request.body()
+    try:
+        document = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        # Malformed input is the client's bug; a retry won't fix it, so 4xx.
+        logger.warning("rejecting unparseable OTLP-JSON payload: %s", exc)
+        return JSONResponse({"error": f"invalid JSON: {exc}"}, status_code=400)
+
+    try:
+        normalized = normalize_payload(document)
+    except Exception:
+        # Never drop a batch because normalization tripped: forward it
+        # unchanged so the spans still reach Tempo, and make the bug loud.
+        logger.exception("normalization failed; forwarding payload unchanged")
+        normalized = document
+
+    url = f"{COLLECTOR_ENDPOINT}/v1/traces"
+    try:
+        status = await _forward(url, normalized)
+    except Exception as exc:
+        logger.error("forward to %s failed: %s", url, exc)
+        return JSONResponse(
+            {"error": f"upstream collector unreachable: {exc}"}, status_code=502
+        )
+
+    if status >= 400:
+        logger.error("collector rejected batch with %s", status)
+        return JSONResponse(
+            {"error": f"collector returned {status}"}, status_code=502
+        )
+
+    return JSONResponse({"ok": True}, status_code=200)

--- a/sdk/python/tests/test_normalizer_service.py
+++ b/sdk/python/tests/test_normalizer_service.py
@@ -123,6 +123,26 @@ class TestTraceIngest:
         assert len(sink.calls) == 1
 
 
+class TestOTLPResponseContract:
+    """OTLP/HTTP specifies an ExportTraceServiceResponse body on success.
+
+    An empty object is the valid "everything accepted" form. A bespoke body
+    like {"ok": true} risks an exporter rejecting or warning on the response,
+    and this service sits in the telemetry path where that would be silent.
+    """
+
+    def test_success_body_is_an_empty_export_response(
+        self, client, payload, monkeypatch
+    ):
+        _Forwarded().install(monkeypatch)
+
+        response = client.post("/v1/traces", json=payload)
+
+        assert response.status_code == 200
+        assert response.json() == {}
+        assert response.headers["content-type"].startswith("application/json")
+
+
 class TestHealth:
     def test_health_reports_version_and_collector(self, client):
         response = client.get("/health")

--- a/sdk/python/tests/test_normalizer_service.py
+++ b/sdk/python/tests/test_normalizer_service.py
@@ -1,0 +1,134 @@
+"""Tests for the normalizer OTLP receiver (issue #249).
+
+The service sits in the telemetry path between Claude Code and the collector.
+Its failure modes matter more than its happy path: a silent drop loses spans
+with no signal, and a 2xx on a failed forward tells the OTel exporter not to
+retry. Both are asserted here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="proxy deps not installed")
+
+FIXTURE = Path(__file__).parent / "fixtures" / "claude_code_otlp_json.json"
+
+
+@pytest.fixture
+def payload() -> dict:
+    return json.loads(FIXTURE.read_text())
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from agentweave.normalizer_service import app
+
+    return TestClient(app)
+
+
+class _Forwarded:
+    """Records what the service forwarded upstream."""
+
+    def __init__(self, status: int = 200, raise_exc: Exception | None = None):
+        self.status = status
+        self.raise_exc = raise_exc
+        self.calls: list[tuple[str, dict]] = []
+
+    def install(self, monkeypatch):
+        import agentweave.normalizer_service as svc
+
+        async def _fake_forward(url: str, document: dict) -> int:
+            self.calls.append((url, document))
+            if self.raise_exc is not None:
+                raise self.raise_exc
+            return self.status
+
+        monkeypatch.setattr(svc, "_forward", _fake_forward)
+        return self
+
+
+class TestTraceIngest:
+    def test_forwards_normalized_spans(self, client, payload, monkeypatch):
+        sink = _Forwarded().install(monkeypatch)
+
+        response = client.post("/v1/traces", json=payload)
+
+        assert response.status_code == 200
+        assert len(sink.calls) == 1
+        _, forwarded = sink.calls[0]
+        attrs = {
+            a["key"]
+            for rs in forwarded["resourceSpans"]
+            for ss in rs["scopeSpans"]
+            for s in ss["spans"]
+            for a in s["attributes"]
+        }
+        assert "prov.activity.type" in attrs
+        assert "prov.source" in attrs
+
+    def test_upstream_failure_returns_5xx_so_the_exporter_retries(
+        self, client, payload, monkeypatch
+    ):
+        """A 2xx here would tell the OTel exporter the batch landed. It didn't."""
+        _Forwarded(raise_exc=RuntimeError("collector unreachable")).install(monkeypatch)
+
+        response = client.post("/v1/traces", json=payload)
+
+        assert response.status_code >= 500
+
+    def test_upstream_error_status_is_propagated(self, client, payload, monkeypatch):
+        _Forwarded(status=503).install(monkeypatch)
+
+        response = client.post("/v1/traces", json=payload)
+
+        assert response.status_code >= 500
+
+    def test_malformed_json_is_rejected_not_forwarded(self, client, monkeypatch):
+        sink = _Forwarded().install(monkeypatch)
+
+        response = client.post(
+            "/v1/traces",
+            content=b"{not json",
+            headers={"content-type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert sink.calls == []
+
+    def test_protobuf_payload_is_rejected_with_a_clear_status(self, client, monkeypatch):
+        """The service only speaks OTLP-JSON. A client configured for protobuf
+        should get an actionable status, not a parse crash."""
+        sink = _Forwarded().install(monkeypatch)
+
+        response = client.post(
+            "/v1/traces",
+            content=b"\x0a\x0b\x08\x01",
+            headers={"content-type": "application/x-protobuf"},
+        )
+
+        assert response.status_code == 415
+        assert sink.calls == []
+
+    def test_empty_payload_is_accepted(self, client, monkeypatch):
+        sink = _Forwarded().install(monkeypatch)
+
+        response = client.post("/v1/traces", json={"resourceSpans": []})
+
+        assert response.status_code == 200
+        assert len(sink.calls) == 1
+
+
+class TestHealth:
+    def test_health_reports_version_and_collector(self, client):
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["version"]
+        assert body["collector_endpoint"]


### PR DESCRIPTION
Stacked on #258 — review that first; this PR targets that branch, not `main`.

Wraps the normalizer library in the service the design calls for, plus the image and manifests. **Not deployed** — that's rollout step 3, after merge.

## Status codes are the load-bearing part

The OTel exporter retries on 5xx and **drops on 2xx**. So anything meaning "this batch did not land" has to be a 5xx, or spans vanish with no signal anywhere:

| Condition | Status | Why |
|---|---|---|
| Collector unreachable or rejecting | `502` | Exporter retries; batch isn't lost |
| Malformed JSON | `400` | Client bug — a retry won't fix it |
| `content-type: application/x-protobuf` | `415` | Names the misconfiguration instead of failing to parse binary as JSON |

**Normalization failure is deliberately non-fatal.** If the mapping throws, the payload is forwarded *unchanged* and the exception logged loudly. A mapping bug then degrades to today's behaviour (raw spans in Tempo) rather than losing telemetry — the normalizer sits in the path, so it must not be able to black-hole data.

## Verified against the built image, not just the test client

```
HEALTH: {"status":"ok","version":"0.3.5","collector_endpoint":"http://127.0.0.1:9"}
protobuf content-type      -> 415
malformed json             -> 400
unreachable collector      -> 502   (not a silent 200)
```

Manifests validated with `kubectl apply --dry-run=client`; nodePort 30419 confirmed unused; the collector's in-cluster DNS name checked against the live service.

## Two deployment details worth a look

- **NodePort included.** Host-to-ClusterIP routing on this cluster was observed taking ~5.6s on a cold path while debugging #253. That's fine for a one-off curl and not fine in a telemetry hot path, so Claude Code on the NAS gets a NodePort. In-cluster the pod uses DNS rather than the hardcoded `10.43.221.47` that Claude Code and the bridge currently carry.
- **Deploys with no traffic.** Cutover is repointing `OTEL_EXPORTER_OTLP_ENDPOINT`; rollback is repointing it back. One variable, both directions.

## Verification

```
7 passed    (service)
566 passed, 2 failed   (full suite)
```

Two failures are the pre-existing `test_prompts.py` network 404s.

## Not in scope

Dashboard filter widening and `prov.source = "proxy"` on the proxy (rollout step 4), and the cutover itself (step 5). `deploy.sh` is untouched — its version-drift check is proxy-specific, and adding a second image to it is its own change.