### PR TITLE
feat(proxy,dashboard): tag span provenance and surface native spans (#249)

### DIFF
--- a/dashboard/src/lib/queries.ts
+++ b/dashboard/src/lib/queries.ts
@@ -46,9 +46,26 @@ export const TEMPO_SERVICE = 'agentweave-proxy'
 // be matched alongside agentweave-proxy for Overview/session queries to count
 // them.
 export const TEMPO_SERVICES = ['agentweave-proxy', 'mux-router'] as const
-export const TEMPO_SERVICE_FILTER = `(${TEMPO_SERVICES.map(
+
+// Services whose spans are queryable in Tempo. claude-code is included so
+// Claude Code's native spans — normalized into prov.* by the normalizer
+// service (#249) — are visible for tool-level and session detail.
+//
+// Safe against double counting: native llm_request spans deliberately do NOT
+// carry prov.activity.type = "llm_call", so the Overview's cost and token
+// aggregation still sees each model call exactly once, from the proxy.
+export const TEMPO_QUERYABLE_SERVICES = [
+  ...TEMPO_SERVICES,
+  'claude-code',
+] as const
+export const TEMPO_SERVICE_FILTER = `(${TEMPO_QUERYABLE_SERVICES.map(
   (s) => `resource.service.name = "${s}"`,
 ).join(' || ')})`
+
+// Prometheus span-metrics deliberately stay on the proxy services only. Tempo's
+// metrics-generator emits a series per service, so adding claude-code here
+// would count the same model call twice — once from the proxy span and once
+// from the native one.
 export const PROM_SERVICE_REGEX = TEMPO_SERVICES.join('|')
 const PROM_LLM_SPAN_FILTER = `service=~"${PROM_SERVICE_REGEX}",prov_llm_model=~".+"`
 

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.5
+          image: localhost:5000/agentweave-proxy:0.3.6
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/deploy/k8s/normalizer.yaml
+++ b/deploy/k8s/normalizer.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: normalizer
           # Pinned to the SDK version, same convention as the proxy.
-          image: localhost:5000/agentweave-normalizer:0.3.5
+          image: localhost:5000/agentweave-normalizer:0.3.6
           imagePullPolicy: Always
           ports:
             - containerPort: 4318

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/normalizer.py
+++ b/sdk/python/agentweave/normalizer.py
@@ -29,11 +29,6 @@ from typing import Any, Optional
 
 from agentweave import pricing, schema
 
-# Marks which collector produced a span, so the later migration to
-# native-as-primary (#249 phase C) is a switch rather than a re-mapping.
-PROV_SOURCE = "prov.source"
-SOURCE_NATIVE = "native"
-
 _HARNESS = "claude-code"
 
 # claude_code.* span name -> prov.activity.type
@@ -149,7 +144,7 @@ def _normalize_span(span: dict) -> None:
     attrs = _decode_attrs(span)
 
     _set(span, schema.PROV_HARNESS, _HARNESS)
-    _set(span, PROV_SOURCE, SOURCE_NATIVE)
+    _set(span, schema.PROV_SOURCE, schema.SOURCE_NATIVE)
 
     activity = _ACTIVITY_BY_SPAN.get(name)
     if activity:

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -32,7 +32,7 @@ from fastapi.responses import JSONResponse
 
 from agentweave.normalizer import normalize_payload
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 logger = logging.getLogger("agentweave.normalizer")
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -301,7 +301,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.5",
+    version="0.3.6",
 )
 
 
@@ -2093,6 +2093,11 @@ def _set_request_attrs(
     span.set_attribute(schema.GEN_AI_SYSTEM, provider)
     span.set_attribute(schema.GEN_AI_REQUEST_MODEL, agent_model)
     span.set_attribute(schema.GEN_AI_AGENT_NAME, agent_id)
+
+    # Records that this span came from the proxy rather than Claude Code's
+    # native exporter, so the two can be told apart without inferring from
+    # service.name (#249).
+    span.set_attribute(schema.PROV_SOURCE, schema.SOURCE_PROXY)
 
     # Apply global session context (env-var defaults) — but don't overwrite
     # per-request values that were already set explicitly above.

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -62,6 +62,13 @@ PROV_REPOSITORY = "prov.repository"                 # enclosing git repository n
 PROV_HARNESS = "prov.harness"                       # "claude-code" | "openclaw"
 PROV_TOOL_NAME = "prov.tool.name"                   # tool invoked by an agent
 
+# Which collector produced a span (issue #249). Both the proxy and the
+# normalizer tag their output, so migrating to native-as-primary is a switch on
+# this value rather than an inference from service.name.
+PROV_SOURCE = "prov.source"
+SOURCE_PROXY = "proxy"
+SOURCE_NATIVE = "native"
+
 # Agent type constants
 AGENT_TYPE_MAIN = "main"
 AGENT_TYPE_SUBAGENT = "subagent"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.5"
+version = "0.3.6"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -918,6 +918,37 @@ class TestSubAgentAttributionHeaders:
         assert "x-agentweave-turn-depth" in _SKIP_HEADERS_ALWAYS
 
 
+class TestProvSourceTagging:
+    """Every span records which collector produced it (#249).
+
+    The migration to native-as-primary switches on prov.source. If only the
+    normalizer tagged its output, the switch would be asymmetric — proxy spans
+    inferred from service.name, native spans tagged explicitly. Both are
+    tagged so the flip is symmetric.
+    """
+
+    def test_proxy_llm_spans_are_tagged_as_proxy(self, monkeypatch):
+        from agentweave.config import AgentWeaveConfig
+        from agentweave.proxy import _set_request_attrs
+        from agentweave import schema
+
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        span = _FakeSpan()
+
+        _set_request_attrs(
+            span, model="claude-opus-5", provider="anthropic",
+            agent_id="claude-code-nas", agent_model="claude-opus-5",
+            path="v1/messages", body={},
+        )
+
+        assert span.attrs[schema.PROV_SOURCE] == schema.SOURCE_PROXY
+
+    def test_source_constants_are_distinct(self):
+        from agentweave import schema
+
+        assert schema.SOURCE_PROXY != schema.SOURCE_NATIVE
+
+
 class TestGlobalSessionContextLeak:
     """The process-global session context must not leak across callers.
 


### PR DESCRIPTION
Rollout step 4 of the design (#257). Small, but one part is genuinely non-obvious.

## `prov.source` on both producers

The proxy now tags its LLM spans `prov.source = "proxy"`. Previously only the normalizer tagged its output, so the migration to native-as-primary would have been asymmetric — native tagged explicitly, proxy inferred from `service.name`. Both are tagged, so the flip is a symmetric switch.

`PROV_SOURCE` and the source constants move from `normalizer.py` into `schema.py`, which is where shared vocabulary belongs now that two producers use them.

## The dashboard change, and the trap in it

`TEMPO_SERVICES` fed **two** consumers — the Tempo service filter *and* `PROM_SERVICE_REGEX`. Appending `claude-code` to the shared list would have surfaced native spans in Tempo (intended) **and** pulled them into Prometheus span-metrics panels (not intended).

Tempo's metrics-generator emits a series per service, so the same model call would then be counted twice — once from the proxy span, once from the native one. The two lists are now separate, with the reasoning in comments so the next person doesn't re-merge them.

Tempo-side is safe by construction: native `llm_request` spans deliberately carry no `prov.activity.type = "llm_call"`, so the Overview's cost and token aggregation still sees each model call exactly once.

## Verification

```
571 passed, 2 failed      (python; the two are pre-existing test_prompts 404s)
tsc --noEmit              clean
```

New tests assert the proxy tags `prov.source = "proxy"` and that the two source constants are distinct.

## Deploy impact

Bumps `0.3.5` → `0.3.6`. Merging changes nothing on the cluster — the proxy, normalizer, and dashboard all need deploying. That's step 5, along with the cutover that finally puts the normalizer in the path.