### PR TITLE
fix(deploy): pin to the registry node and avoid a k8s env-var collision

### DIFF
--- a/deploy/docker/Dockerfile.normalizer
+++ b/deploy/docker/Dockerfile.normalizer
@@ -21,12 +21,19 @@ EXPOSE 4318
 
 # Configuration via environment variables:
 #   AGENTWEAVE_COLLECTOR_ENDPOINT  — OTLP HTTP base URL of the collector
-#   AGENTWEAVE_NORMALIZER_PORT     — listen port (default 4318)
+#   AGENTWEAVE_LISTEN_PORT         — listen port (default 4318)
+#
+# NOTE: use AGENTWEAVE_LISTEN_PORT, never AGENTWEAVE_NORMALIZER_PORT. Kubernetes
+# injects service-discovery variables named after each Service, so a Service
+# called agentweave-normalizer sets AGENTWEAVE_NORMALIZER_PORT to
+# "tcp://<clusterIP>:4318" in every pod in the namespace — which uvicorn then
+# rejects as a non-integer port. The proxy hit the same trap with
+# AGENTWEAVE_PROXY_PORT.
 #
 # Run uvicorn directly rather than through the `agentweave` CLI: the CLI has no
 # normalizer subcommand yet, and adding one is not needed to deploy this.
 ENTRYPOINT ["sh", "-c", "\
   exec uvicorn agentweave.normalizer_service:app \
     --host 0.0.0.0 \
-    --port ${AGENTWEAVE_NORMALIZER_PORT:-4318} \
+    --port ${AGENTWEAVE_LISTEN_PORT:-4318} \
 "]

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -15,6 +15,12 @@ spec:
       labels:
         app: agentweave-proxy
     spec:
+      # The image registry (localhost:5000) runs only on arnabsnas, so a pod
+      # scheduled onto any other node ImagePullBackOffs. This pin existed only
+      # in the live cluster until now — the manifest lacked it, so a reschedule
+      # would have broken the deployment with no way to see why from git.
+      nodeSelector:
+        kubernetes.io/hostname: arnabsnas
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/deploy/k8s/normalizer.yaml
+++ b/deploy/k8s/normalizer.yaml
@@ -25,6 +25,12 @@ spec:
       labels:
         app: agentweave-normalizer
     spec:
+      # The image registry (localhost:5000) runs only on arnabsnas, so a pod
+      # scheduled onto any other node ImagePullBackOffs. This pin existed only
+      # in the live cluster until now — the manifest lacked it, so a reschedule
+      # would have broken the deployment with no way to see why from git.
+      nodeSelector:
+        kubernetes.io/hostname: arnabsnas
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/docs/superpowers/specs/2026-08-07-native-otel-normalization-design.md
+++ b/docs/superpowers/specs/2026-08-07-native-otel-normalization-design.md
@@ -137,7 +137,14 @@ Assert on emitted spans, never on HTTP status — the defect class that produced
 2. Build the normalizer with the mapping and tests; no deployment.
 3. Deploy the normalizer with **no traffic pointed at it**. Validate by replaying a captured native payload through the running service and diffing its output against the unit-test expectations — this checks packaging, config, and connectivity to the collector without putting live spans at risk.
 4. Add `prov.source = "proxy"` to the proxy; widen the dashboard filter to include `"claude-code"`.
-5. Point `OTEL_EXPORTER_OTLP_ENDPOINT` on the NAS at the normalizer. Native spans now arrive normalized instead of raw.
+5. Point `OTEL_EXPORTER_OTLP_ENDPOINT` on the NAS at the normalizer **and set
+   `OTEL_EXPORTER_OTLP_PROTOCOL=http/json`**. Native spans now arrive
+   normalized instead of raw.
+
+   Both variables, not just the endpoint. The NAS was on `http/protobuf` from
+   #253, and repointing the endpoint alone produced a 415 from the normalizer
+   — spans rejected rather than normalized. The 415 named the cause
+   immediately, but the step should not have needed it.
 
 Rollback is repointing that one env var back at the collector — native spans revert to raw-but-stored, which is today's behaviour.
 

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -13,7 +13,11 @@ Configuration (environment):
 
     AGENTWEAVE_COLLECTOR_ENDPOINT  OTLP HTTP base URL of the collector
                                    (default http://10.43.221.47:4318)
-    AGENTWEAVE_NORMALIZER_PORT     listen port (default 4318)
+    AGENTWEAVE_LISTEN_PORT         listen port (default 4318)
+
+Do not name the port variable after the Service: Kubernetes injects
+AGENTWEAVE_NORMALIZER_PORT as "tcp://<clusterIP>:4318" for a Service called
+agentweave-normalizer, which uvicorn rejects as a non-integer port.
 
 The collector keeps doing PII stripping downstream, so this service does not
 duplicate that responsibility.


### PR DESCRIPTION
Three defects surfaced by deploying the normalizer for real (rollout step 5 of #257). All three were invisible until something actually ran in the cluster.

## 1. Node pinning existed only in the cluster, not in git

The normalizer scheduled onto the `ubuntu` node and `ImagePullBackOff`'d — `localhost:5000` runs only on `arnabsnas`.

Investigating that turned up a **latent bug in the proxy**: the live deployment carries `nodeSelector: kubernetes.io/hostname=arnabsnas`, but `deploy/k8s/deployment.yaml` does not. That pin was added out-of-band and never committed. **If the proxy pod ever rescheduled to `ubuntu`, it would have failed exactly the same way**, with nothing in git to explain it. Both manifests now carry the pin with the reason.

## 2. A Kubernetes env-var collision crash-looped the container

```
Error: Invalid value for '--port': 'tcp://10.43.187.169:4318' is not a valid integer
```

Kubernetes injects service-discovery variables named after each Service. A Service called `agentweave-normalizer` sets `AGENTWEAVE_NORMALIZER_PORT=tcp://<clusterIP>:4318` in every pod in the namespace, clobbering my config var.

The proxy's own Dockerfile documents this trap verbatim — *"use AGENTWEAVE_LISTEN_PORT, not AGENTWEAVE_PROXY_PORT (k8s injects AGENTWEAVE_PROXY_PORT as a service discovery var)"* — and I picked a colliding name anyway. Renamed to `AGENTWEAVE_LISTEN_PORT`, matching the proxy, with the reasoning recorded so the next service doesn't repeat it.

## 3. The design's cutover step was incomplete

Rollout step 5 said "point `OTEL_EXPORTER_OTLP_ENDPOINT` at the normalizer". The NAS was on `http/protobuf` from #253, so that alone produced a **415** and the batch was rejected rather than normalized. The step must set `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` too. Doc corrected.

Worth noting the 415 did its job — it named the misconfiguration in one line instead of failing to parse binary as JSON. That was a deliberate design choice in #260 and it paid for itself on the first real cutover.

## Cutover is live and verified

```
llm.claude-opus-5           svc=agentweave-proxy  act=llm_call        src=proxy   cost=0.0301985
claude_code.llm_request     svc=claude-code       act=-               src=native  cost=0.0301985
claude_code.tool            svc=claude-code       act=tool_call       src=native
claude_code.tool.execution  svc=claude-code       act=tool_execution  src=native
claude_code.tool.blocked_on_user  svc=claude-code act=permission_wait src=native
claude_code.interaction     svc=claude-code       act=agent_turn      src=native

llm_call spans: 2 for 2 model calls — no double counting
```

The cost figures are an unplanned cross-check: the normalizer computed `0.0301985` from native's *split* token counts while the proxy independently computed the same value from its *summed* counts. Two code paths agreeing to seven decimals is strong evidence the token arithmetic is right.