### PR TITLE
fix(proxy): stop applying the process-global session context to spans (#255)

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.6
+          image: localhost:5000/agentweave-proxy:0.3.7
           imagePullPolicy: Always
           ports:
             - containerPort: 4000

--- a/deploy/k8s/normalizer.yaml
+++ b/deploy/k8s/normalizer.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         - name: normalizer
           # Pinned to the SDK version, same convention as the proxy.
-          image: localhost:5000/agentweave-normalizer:0.3.6
+          image: localhost:5000/agentweave-normalizer:0.3.7
           imagePullPolicy: Always
           ports:
             - containerPort: 4318

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -32,7 +32,7 @@ from fastapi.responses import JSONResponse
 
 from agentweave.normalizer import normalize_payload
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 logger = logging.getLogger("agentweave.normalizer")
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -286,22 +286,13 @@ _session_context: dict[str, str] = {
     }.items() if v
 }
 
-# Attributes in _session_context that identify a specific session rather than
-# acting as a config default. These are only applied to requests from the agent
-# that wrote the global, so one caller's session can't be stamped on another's.
-_GLOBAL_IDENTITY_ATTRS = frozenset({
-    schema.SESSION_ID,
-    schema.PROV_SESSION_ID,
-    schema.PROV_PARENT_SESSION_ID,
-})
-
 # Gemini model name from URL, e.g. /v1beta/models/gemini-2.5-pro:generateContent
 _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.6",
+    version="0.3.7",
 )
 
 
@@ -536,14 +527,15 @@ async def set_session_context(body: dict):
             # Store per-key forced context — isolates concurrent request streams
             _set_forced_context(session_key, ctx)
         else:
-            # Clear the per-key forced context when force is disabled
+            # Clear the per-key forced context when force is disabled. The
+            # bridge relies on this to restore main-session attribution when a
+            # subagent goes idle (issue #189) — do not repurpose force:false
+            # into a store without changing the bridge in the same step.
             _forced_session_contexts.pop(session_key, None)
-        # Update global context so GET /session reflects the latest state;
-        # but do NOT set the global force flag — that would affect all requests.
-        _session_context = ctx
-    else:
-        # Non-forced global context update for GET /session and default attrs.
-        _session_context = ctx
+
+    # Mirror the most recent context for GET /session. This is observability
+    # only: _set_request_attrs does not read it, so it cannot reach a span.
+    _session_context = ctx
 
     return {"ok": True, "context": ctx, "force": force, "session_key": session_key}
 
@@ -2116,25 +2108,14 @@ def _set_request_attrs(
         _explicit_session_attrs.add(schema.PROV_PARENT_SESSION_ID)
     if agent_type is not None:
         _explicit_session_attrs.add(schema.PROV_AGENT_TYPE)
-    # Session identity from the process-global is scoped to the agent that set
-    # it. The bridge POSTs /session with force:false on every main-agent turn,
-    # which writes this global; without scoping, any caller that sends no
-    # X-AgentWeave-Session-Id inherits it — Claude Code spans were being
-    # stamped with openclaw cron session ids. Project and similar defaults are
-    # not identity and still apply across agents.
-    _ctx_owner = _session_context.get(schema.PROV_AGENT_ID)
-    _owns_global = bool(_ctx_owner) and _ctx_owner == agent_id
-    for k, v in _session_context.items():
-        if k in _explicit_session_attrs:
-            continue
-        if k in _GLOBAL_IDENTITY_ATTRS and not _owns_global:
-            continue
-        span.set_attribute(k, v)
-    # The global stores prov.session.id only; mirror it onto session.id so the
-    # owning agent gets the same pair an explicit session id would produce.
-    if _owns_global and schema.PROV_SESSION_ID in _session_context:
-        if schema.SESSION_ID not in _explicit_session_attrs:
-            span.set_attribute(schema.SESSION_ID, _session_context[schema.PROV_SESSION_ID])
+    # The process-global session context is deliberately NOT applied here
+    # (#255). It is a single mutable value on a proxy serving many callers, so
+    # anything it contributed was whoever wrote it last. #254 scoped it to the
+    # writing agent, which stopped cross-caller contamination but still
+    # collided for two callers sharing an agent id. Session identity now comes
+    # only from the request: an explicit header, or the per-key forced context
+    # resolved from x-agentweave-session-key above. _session_context survives
+    # solely as a read-only mirror for GET /session.
 
     # Only fall back to cfg.agent_id if no per-request agent_id was provided via header
     if not agent_id:

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.6"
+version = "0.3.7"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -949,19 +949,19 @@ class TestProvSourceTagging:
         assert schema.SOURCE_PROXY != schema.SOURCE_NATIVE
 
 
-class TestGlobalSessionContextLeak:
-    """The process-global session context must not leak across callers.
+class TestGlobalSessionContextNotApplied:
+    """The process-global session context must never reach a span (#255).
 
-    POST /session with force:false writes a process-global _session_context.
-    _set_request_attrs then stamps every key of that global onto any span that
-    didn't set the key explicitly, so a request from an unrelated agent that
-    sends no X-AgentWeave-Session-Id inherits whoever wrote the global last.
+    #254 scoped it to the agent that wrote it, which stopped cross-caller
+    contamination but left a process-global in a multi-tenant proxy: two
+    callers sharing an agent id would still collide. The global is no longer
+    applied to spans at all. Session identity comes from the request — a
+    header, or the per-key forced context keyed by x-agentweave-session-key.
 
-    On the shared NAS proxy the openclaw bridge writes it on every main-agent
-    turn (service.ts: force is false when there's no upstream and the agent
-    isn't a subagent), so Claude Code spans were being stamped with openclaw
-    cron session ids like agent:main:cron:<uuid>:run:<uuid>.
+    _session_context survives only as a read-only mirror for GET /session.
     """
+
+    OPENCLAW_SESSION = "agent:main:cron:e2344169:run:4af17ab6"
 
     @pytest.fixture(autouse=True)
     def _restore_global(self):
@@ -970,8 +970,6 @@ class TestGlobalSessionContextLeak:
         saved = dict(proxy_mod._session_context)
         yield
         proxy_mod._session_context = saved
-
-    OPENCLAW_SESSION = "agent:main:cron:e2344169:run:4af17ab6"
 
     def _attrs(self, monkeypatch, global_ctx, **kwargs):
         from agentweave import proxy as proxy_mod
@@ -987,67 +985,98 @@ class TestGlobalSessionContextLeak:
         )
         return span.attrs
 
-    def test_session_id_does_not_leak_to_a_different_agent(self, monkeypatch):
-        """A global written by nix-v1 must not attach to claude-code-nas spans."""
-        attrs = self._attrs(
-            monkeypatch,
-            {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
-            agent_id="claude-code-nas", session_id=None,
-        )
-
-        assert attrs.get("prov.session.id") != self.OPENCLAW_SESSION
-        assert attrs.get("session.id") != self.OPENCLAW_SESSION
-
-    def test_session_id_still_applies_to_the_owning_agent(self, monkeypatch):
-        """openclaw's own spans must keep the session id it set (no regression)."""
+    def test_global_session_id_never_reaches_a_span(self, monkeypatch):
+        """Not even for the agent that wrote it — the #254 owner check is gone."""
         attrs = self._attrs(
             monkeypatch,
             {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
             agent_id="nix-v1", session_id=None,
         )
 
-        assert attrs["prov.session.id"] == self.OPENCLAW_SESSION
-        assert attrs["session.id"] == self.OPENCLAW_SESSION
+        assert attrs.get("prov.session.id") != self.OPENCLAW_SESSION
+        assert attrs.get("session.id") != self.OPENCLAW_SESSION
 
-    def test_parent_session_id_is_scoped_too(self, monkeypatch):
-        """Parent session id is identity as well and must not cross agents."""
+    def test_global_does_not_leak_to_a_different_agent(self, monkeypatch):
         attrs = self._attrs(
             monkeypatch,
-            {"prov.agent.id": "nix-v1", "prov.parent.session.id": "parent-abc"},
-            agent_id="claude-code-nas",
-        )
-
-        assert attrs.get("prov.parent.session.id") != "parent-abc"
-
-    def test_unowned_global_does_not_supply_session_identity(self, monkeypatch):
-        """With no owner recorded, ownership can't be checked — so don't apply."""
-        attrs = self._attrs(
-            monkeypatch,
-            {"prov.session.id": self.OPENCLAW_SESSION},
+            {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
             agent_id="claude-code-nas", session_id=None,
         )
 
         assert attrs.get("prov.session.id") != self.OPENCLAW_SESSION
 
-    def test_explicit_session_id_still_wins(self, monkeypatch):
-        """A caller's own session id is unaffected by the global."""
+    def test_global_project_no_longer_applied_either(self, monkeypatch):
+        """Non-identity keys came from the same global and go with it."""
+        attrs = self._attrs(
+            monkeypatch,
+            {"prov.agent.id": "nix-v1", "prov.project": "global-project"},
+            agent_id="nix-v1",
+        )
+
+        assert attrs.get("prov.project") != "global-project"
+
+    def test_explicit_request_values_are_unaffected(self, monkeypatch):
         attrs = self._attrs(
             monkeypatch,
             {"prov.agent.id": "nix-v1", "prov.session.id": self.OPENCLAW_SESSION},
             agent_id="claude-code-nas", session_id="my-own-session",
+            project="my-project",
         )
 
         assert attrs["prov.session.id"] == "my-own-session"
+        assert attrs["prov.project"] == "my-project"
 
-    def test_non_identity_globals_still_apply_across_agents(self, monkeypatch):
-        """Project is a default, not identity — it may still cross agents."""
-        attrs = self._attrs(
-            monkeypatch,
-            {"prov.agent.id": "nix-v1", "prov.project": "global-project"},
-            agent_id="claude-code-nas",
-        )
 
-        assert attrs["prov.project"] == "global-project"
+class TestSessionEndpointContract:
+    """force:false still clears the per-key entry (#189), and GET /session
+    still mirrors the last posted context.
+
+    #255 removes the global from span attribution only. Repurposing
+    force:false into a store would break the bridge, which uses it to restore
+    main-session attribution when a subagent goes idle — that half needs a
+    bridge change in the same step and is deliberately not done here.
+    """
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+
+        return TestClient(app)
+
+    def test_force_true_stores_the_context_per_key(self, client):
+        from agentweave import proxy as proxy_mod
+
+        client.post("/session", json={
+            "session_key": "k-255-b", "session_id": "sess-b",
+            "agent_id": "nix-v1", "force": True,
+        })
+
+        assert proxy_mod._forced_session_contexts["k-255-b"]["prov.session.id"] == "sess-b"
+
+    def test_force_false_clears_the_per_key_entry(self, client):
+        from agentweave import proxy as proxy_mod
+
+        client.post("/session", json={
+            "session_key": "k-255-d", "session_id": "sess-d",
+            "agent_id": "nix-v1", "force": True,
+        })
+        client.post("/session", json={
+            "session_key": "k-255-d", "session_id": "nix-main",
+            "agent_type": "main", "force": False,
+        })
+
+        assert "k-255-d" not in proxy_mod._forced_session_contexts
+
+    def test_get_session_still_mirrors_the_last_posted_context(self, client):
+        client.post("/session", json={
+            "session_key": "k-255-c", "session_id": "sess-c",
+            "agent_id": "nix-v1", "force": False,
+        })
+
+        body = client.get("/session").json()
+
+        assert body["prov.session.id"] == "sess-c"
 
 
 class TestLLMSpanParentContext:
@@ -1316,17 +1345,17 @@ class TestSessionEndpoint:
         monkeypatch.delenv("AGENTWEAVE_SESSION_ID")
         importlib.reload(proxy_module)
 
-    def test_session_context_applied_to_spans(self, monkeypatch):
-        """After POST /session, _set_request_attrs applies context attrs to spans.
+    def test_session_context_is_not_applied_to_spans(self, monkeypatch):
+        """The global no longer reaches spans at all (#255).
 
-        The context must name its owning agent for session identity to apply —
-        see TestGlobalSessionContextLeak. Previously this test set no
-        prov.agent.id and still expected the session id on an agent-1 span,
-        which is the cross-caller leak itself.
+        This test previously asserted the opposite. #254 narrowed the global to
+        the agent that wrote it; #255 removes its span attribution entirely,
+        because a single mutable value on a multi-tenant proxy attributes
+        whatever the last writer happened to set. Session identity now comes
+        only from the request.
         """
         from agentweave.config import AgentWeaveConfig
         monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
-        # Set the global context
         monkeypatch.setattr(proxy_module, "_session_context", {
             "prov.agent.id": "agent-1",
             "prov.session.id": "ctx-sess-99",
@@ -1338,9 +1367,8 @@ class TestSessionEndpoint:
             agent_id="agent-1", agent_model="test-model",
             path="v1/messages", body={},
         )
-        assert span.attrs["prov.session.id"] == "ctx-sess-99"
-        assert span.attrs["prov.task.label"] == "run tests"
-        assert "prov.parent.session.id" not in span.attrs
+        assert span.attrs.get("prov.session.id") != "ctx-sess-99"
+        assert span.attrs.get("prov.task.label") != "run tests"
         # Restore
         monkeypatch.setattr(proxy_module, "_session_context", {})
 


### PR DESCRIPTION
Closes the contamination class that #254 contained. Depends on #262 (open).

## What changed

`_session_context` is a single mutable value on a proxy serving many callers, so anything it contributed to a span was whoever wrote it last. #254 narrowed it to the agent that wrote it — that stopped OpenClaw cron session ids landing on Claude Code spans, but two callers sharing an agent id would still collide.

**The global is no longer read during span attribution at all.** Session identity comes only from the request: an explicit `X-AgentWeave-Session-Id`, or the per-key forced context resolved from `x-agentweave-session-key`. `_session_context` survives solely as a read-only mirror for `GET /session`, and `_GLOBAL_IDENTITY_ATTRS` — added by #254 purely for the scoping that just went away — is deleted.

## I measured before changing anything

Sampled proxy `llm.*` spans over 24h: **only `claude-code-nas`, and none carrying a session id.** No OpenClaw agent has proxy LLM spans at all, because OpenClaw's model calls don't traverse the proxy — its LLM data rides on `openclaw.turn` spans the bridge stamps explicitly.

So the global was being written on every bridge turn and read by effectively nothing. That's what makes removing it low-risk rather than a leap.

## One thing I nearly got wrong

My first draft also made `force:false` **store** the context per-key instead of clearing it — which reads better in isolation and is what the issue proposed.

Then I read the bridge: it posts `force:false` with a matching `session_key` specifically to *clear* the entry and restore main-session attribution when a subagent goes idle (issue #189, `service.ts:816`). Repurposing `force:false` into a store would silently break that.

Reverted. **The `/session` contract is unchanged and the bridge is untouched.** That half of #255 needs a bridge change in the same step, and it isn't done here — the issue stays open for it.

## Verification

```
572 passed, 2 failed      (the two are pre-existing test_prompts 404s)
```

`test_session_context_applied_to_spans` asserted the old behaviour. It now asserts the new one rather than being deleted, so the contract change is visible in test history rather than vanishing.

Bumps `0.3.6` → `0.3.7`. Not deployed.

## Still open on #255

The bridge sending `x-agentweave-session-key` on model calls, which would let the per-key store cover OpenClaw-proxied requests. Cross-repo, needs a bridge rebuild and gateway restart.