### PR TITLE
fix(proxy): propagate harness attribution (#267)

### DIFF
--- a/docs/claude-code-proxy.md
+++ b/docs/claude-code-proxy.md
@@ -18,7 +18,7 @@ Add the `env` block to `~/.claude/settings.json`:
 {
   "env": {
     "ANTHROPIC_BASE_URL": "http://192.168.1.70:30400",
-    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-mac\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code"
+    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-mac\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code\nX-AgentWeave-Harness: claude-code"
   }
 }
 ```
@@ -33,7 +33,7 @@ Add the `env` block to `~/.claude/settings.json`:
 {
   "env": {
     "ANTHROPIC_BASE_URL": "http://192.168.1.70:30400",
-    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-nas\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code"
+    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-nas\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code\nX-AgentWeave-Harness: claude-code"
   }
 }
 ```
@@ -45,6 +45,7 @@ All Claude Code instances share the single proxy on port 30400. Attribution is d
 - `X-AgentWeave-Agent-Id` — identifies the Claude Code instance (e.g., `claude-code-mac`, `claude-code-nas`)
 - `X-AgentWeave-Session-Id` — groups spans into a session
 - `X-AgentWeave-Project` — project-level grouping
+- `X-AgentWeave-Harness` — stable caller type (`claude-code` here)
 
 Multiple headers are `\n`-separated in the JSON string.
 
@@ -53,8 +54,8 @@ Changes take effect on **new** Claude Code sessions only.
 ## How it works
 
 - `ANTHROPIC_BASE_URL` redirects API calls from `api.anthropic.com` to the proxy
-- `ANTHROPIC_CUSTOM_HEADERS` sends `X-AgentWeave-Agent-Id`, `X-AgentWeave-Session-Id`,
-  and `X-AgentWeave-Project` with every request so the proxy tags spans correctly
+- `ANTHROPIC_CUSTOM_HEADERS` sends the agent, session, project, and harness
+  headers with every request so the proxy tags spans correctly
 - The proxy forwards requests to Anthropic, emits OTel spans to Tempo,
   and returns the response transparently
 - The proxy is pass-through — OAuth tokens from the Claude Code SDK pass through untouched

--- a/docs/proxy-setup.md
+++ b/docs/proxy-setup.md
@@ -58,6 +58,8 @@ Restart=always
 RestartSec=5
 Environment=HOME=/home/youruser
 Environment=PATH=/home/youruser/.local/bin:/usr/local/bin:/usr/bin:/bin
+# Dedicated OpenClaw proxy only; omit this on a shared proxy.
+Environment=AGENTWEAVE_HARNESS=openclaw
 
 [Install]
 WantedBy=default.target
@@ -82,7 +84,8 @@ Add to `~/.openclaw/openclaw.json`:
         "baseUrl": "http://localhost:4000",
         "headers": {
           "X-AgentWeave-Agent-Id": "nix-v1",
-          "X-AgentWeave-Agent-Type": "main"
+          "X-AgentWeave-Agent-Type": "main",
+          "X-AgentWeave-Harness": "openclaw"
         },
         "models": []
       }
@@ -101,7 +104,7 @@ Add to `~/.claude/settings.json`:
 {
   "env": {
     "ANTHROPIC_BASE_URL": "http://localhost:4000",
-    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-mac\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code"
+    "ANTHROPIC_CUSTOM_HEADERS": "X-AgentWeave-Agent-Id: claude-code-mac\nX-AgentWeave-Session-Id: claude-code-main\nX-AgentWeave-Project: claude-code\nX-AgentWeave-Harness: claude-code"
   }
 }
 ```
@@ -136,11 +139,20 @@ With the single-proxy architecture, the `X-AgentWeave-Agent-Id` header is how ev
 ```python
 client = anthropic.Anthropic(
     base_url="http://localhost:4000",
-    default_headers={"X-AgentWeave-Agent-Id": "my-agent-v1"},
+    default_headers={
+        "X-AgentWeave-Agent-Id": "my-agent-v1",
+        "X-AgentWeave-Harness": "my-harness",
+    },
 )
 ```
 
 If no `X-AgentWeave-Agent-Id` header is sent, spans are attributed to `unattributed`.
+
+`X-AgentWeave-Harness` takes precedence over `AGENTWEAVE_HARNESS`. Empty or
+whitespace-only header values fall back to the environment value. If neither is
+set, `prov.harness` is omitted for backward compatibility. Use the environment
+fallback only for a dedicated single-harness proxy; shared proxies should send
+the per-request header and must not infer harness identity from model/provider.
 
 ## OpenAI / Codex streaming note
 

--- a/plugins/openclaw-agentweave-bridge/src/service.ts
+++ b/plugins/openclaw-agentweave-bridge/src/service.ts
@@ -458,6 +458,7 @@ function startUpstreamRootSpanFromSessionState(
       session_key: sessionKey,
       agent_id: agentId,
       agent_type: agentType,
+      harness: "openclaw",
       // Force the proxy to attribute LLM calls to the upstream identity.
       force: true,
     }
@@ -668,6 +669,7 @@ export function createAgentWeaveBridgeService() {
                   session_key: sessionKey,
                   agent_id: effectiveAgentId,
                   agent_type: effectiveAgentType,
+                  harness: "openclaw",
                   // Force the proxy to attribute LLM calls to upstream identity
                   // (same as sub-agents) so codex/model spans match the run.
                   force: Boolean(upstream) || effectiveAgentType === "subagent",
@@ -795,6 +797,7 @@ export function createAgentWeaveBridgeService() {
                       parent_session_id: mainSessionId,
                       agent_id: subagentId,
                       agent_type: "subagent",
+                      harness: "openclaw",
                       task_label: taskLabel ?? `subagent ${sessionKey.split(":")[1] || "unknown"}`,
                       force: true,
                     }),

--- a/scripts/claude-delegate.sh
+++ b/scripts/claude-delegate.sh
@@ -97,7 +97,8 @@ fi
 
 # Build the multiline ANTHROPIC_CUSTOM_HEADERS block.
 headers="X-AgentWeave-Agent-Id: ${agent_id}
-X-AgentWeave-Session-Id: ${session_id}"
+X-AgentWeave-Session-Id: ${session_id}
+X-AgentWeave-Harness: claude-code"
 [[ -n "$parent"     ]] && headers+=$'\n'"X-AgentWeave-Parent-Session-Id: ${parent}"
 [[ -n "$project"    ]] && headers+=$'\n'"X-AgentWeave-Project: ${project}"
 [[ -n "$task_label" ]] && headers+=$'\n'"X-AgentWeave-Task-Label: ${task_label}"

--- a/scripts/validate-claude-delegate.sh
+++ b/scripts/validate-claude-delegate.sh
@@ -113,5 +113,6 @@ want "prov.session.id"        "$SESSION_ID"
 want "prov.parent.session.id" "$PARENT"
 want "prov.project"           "$PROJECT"
 want "prov.task.label"        "$TASK"
+want "prov.harness"           "claude-code"
 
 ts "PASS — delegated attribution propagated end-to-end"

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -102,6 +102,7 @@ _SKIP_HEADERS_ALWAYS = {
     "x-agentweave-turn-depth",
     "x-agentweave-session-key",
     "x-agentweave-task-label",
+    "x-agentweave-harness",
     "x-agentweave-parent-span-id",
     "x-agentweave-parent-trace-id",
 }
@@ -127,6 +128,24 @@ def _normalize_trace_id(raw: str) -> int | None:
     if _TRACE_ID_RE.match(raw):
         return int(raw, 16)
     return int(hashlib.sha256(raw.encode()).hexdigest()[:32], 16)
+
+
+def _resolve_harness(
+    header_value: str | None,
+    keyed_context_value: str | None,
+    env_value: str | None,
+) -> str | None:
+    """Resolve explicit harness identity without inferring it from traffic.
+
+    The first non-empty value wins in header, keyed bridge context, environment
+    order. Values are stripped so an empty/whitespace-only header falls through
+    instead of suppressing a dedicated proxy's environment default.
+    """
+    for value in (header_value, keyed_context_value, env_value):
+        cleaned = value.strip() if value else ""
+        if cleaned:
+            return cleaned
+    return None
 
 
 def _context_for_trace_id(trace_id_int: int):
@@ -283,6 +302,7 @@ _session_context: dict[str, str] = {
         "prov.task.label": os.getenv("AGENTWEAVE_TASK_LABEL", ""),
         "prov.agent.type": os.getenv("AGENTWEAVE_AGENT_TYPE", ""),
         "prov.project": os.getenv("AGENTWEAVE_PROJECT", ""),
+        "prov.harness": os.getenv("AGENTWEAVE_HARNESS", ""),
     }.items() if v
 }
 
@@ -498,6 +518,7 @@ async def set_session_context(body: dict):
         "prov.agent.type": body.get("agent_type", ""),
         "prov.agent.id": body.get("agent_id", ""),
         "prov.project": body.get("project", ""),
+        "prov.harness": body.get("harness", ""),
     }.items() if v}
 
     force = bool(body.get("force", False))
@@ -1155,6 +1176,12 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         or os.getenv("AGENTWEAVE_TASK_LABEL")
         or None
     )
+    # Harness identity is always explicit; never infer it from model/provider.
+    harness: str | None = _resolve_harness(
+        request.headers.get("x-agentweave-harness"),
+        _active_ctx.get("prov.harness"),
+        os.getenv("AGENTWEAVE_HARNESS"),
+    )
     turn: int | None = None
     turn_raw = request.headers.get("x-agentweave-turn")
     if turn_raw is not None:
@@ -1283,6 +1310,7 @@ async def proxy(path: str, request: Request) -> StreamingResponse | JSONResponse
         parent_span_id_raw=parent_span_id_raw,
         parent_trace_id_raw=parent_trace_id_raw,
         task_label=task_label,
+        harness=harness,
     )
 
     try:
@@ -1367,6 +1395,7 @@ async def _request_and_trace(
     parent_span_id_raw: str | None = None,
     parent_trace_id_raw: str | None = None,
     task_label: str | None = None,
+    harness: str | None = None,
 ) -> Response:
     tracer = get_tracer()
     _span_ctx = _llm_parent_context(det_trace_id_int, traceparent)
@@ -1380,7 +1409,8 @@ async def _request_and_trace(
                            parent_session_id=parent_session_id,
                            agent_type=agent_type, turn_depth=turn_depth,
                            traceparent=traceparent,
-                           task_label=task_label)
+                           task_label=task_label,
+                           harness=harness)
         if turn_count is not None:
             span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
         start = time.perf_counter()
@@ -1476,6 +1506,7 @@ async def _stream_and_trace(
     parent_span_id_raw: str | None = None,
     parent_trace_id_raw: str | None = None,
     task_label: str | None = None,
+    harness: str | None = None,
 ) -> AsyncIterator[bytes]:
     tracer = get_tracer()
     _span_ctx = _llm_parent_context(det_trace_id_int, traceparent)
@@ -1489,7 +1520,8 @@ async def _stream_and_trace(
                        parent_session_id=parent_session_id,
                        agent_type=agent_type, turn_depth=turn_depth,
                        traceparent=traceparent,
-                       task_label=task_label)
+                       task_label=task_label,
+                       harness=harness)
     if turn_count is not None:
         span.set_attribute(schema.AGENT_TURN_COUNT, turn_count)
 
@@ -2025,6 +2057,7 @@ def _set_request_attrs(
     turn_depth: int | None = None,
     traceparent: str | None = None,
     task_label: str | None = None,
+    harness: str | None = None,
 ) -> None:
     span.set_attribute(schema.PROV_ACTIVITY_TYPE, schema.ACTIVITY_LLM_CALL)
     span.set_attribute(schema.PROV_LLM_PROVIDER, provider)
@@ -2048,6 +2081,8 @@ def _set_request_attrs(
     if project is not None:
         span.set_attribute(schema.PROV_PROJECT, project)
         span.set_attribute(schema.LANGFUSE_TRACE_METADATA_PROJECT, project)
+    if harness is not None:
+        span.set_attribute(schema.PROV_HARNESS, harness)
     if turn is not None:
         span.set_attribute(schema.PROV_SESSION_TURN, turn)
     if det_trace_id_raw is not None:

--- a/sdk/python/tests/test_proxy.py
+++ b/sdk/python/tests/test_proxy.py
@@ -29,6 +29,7 @@ from agentweave.proxy import (
     _set_openai_response_attrs,
     _set_request_attrs,
     _detect_repository_name,
+    _resolve_harness,
     _anthropic_response_text,
     _google_response_text,
     _SKIP_HEADERS_ALWAYS,
@@ -2225,6 +2226,98 @@ class TestAttributeResolution:
             or os.getenv("AGENTWEAVE_SESSION_ID")
         )
         assert session_id == "env-session"
+
+
+class TestHarnessAttribution:
+    """Explicit harness identity reaches every proxy-generated LLM span (#267)."""
+
+    def test_header_precedes_keyed_context_and_env(self):
+        assert _resolve_harness(" claude-code ", "openclaw", "env-harness") == "claude-code"
+
+    def test_empty_header_falls_back_to_keyed_context_then_env(self):
+        assert _resolve_harness("   ", " openclaw ", "env-harness") == "openclaw"
+        assert _resolve_harness("", None, " dedicated-proxy ") == "dedicated-proxy"
+
+    def test_missing_harness_remains_absent(self, monkeypatch):
+        assert _resolve_harness(None, None, None) is None
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={},
+        )
+        assert "prov.harness" not in span.attrs
+
+    def test_harness_sets_span_attribute(self):
+        span = _FakeSpan()
+        _set_request_attrs(
+            span, model="test-model", provider="anthropic",
+            agent_id="agent-1", agent_model="test-model",
+            path="v1/messages", body={}, harness="claude-code",
+        )
+        assert span.attrs["prov.harness"] == "claude-code"
+
+    def test_harness_header_is_not_forwarded_upstream(self):
+        assert "x-agentweave-harness" in _SKIP_HEADERS_ALWAYS
+
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_streaming_and_non_streaming_pass_resolved_harness(
+        self, monkeypatch, stream,
+    ):
+        from unittest.mock import AsyncMock, patch
+        from fastapi.responses import JSONResponse
+        from fastapi.testclient import TestClient
+        from agentweave.config import AgentWeaveConfig
+        from agentweave.proxy import app
+
+        monkeypatch.setattr(proxy_module, "_PROXY_TOKEN", None)
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
+        monkeypatch.setattr(AgentWeaveConfig, "get_or_none", staticmethod(lambda: None))
+        monkeypatch.setenv("AGENTWEAVE_HARNESS", "env-harness")
+        captured: list[str | None] = []
+
+        async def fake_request(**kwargs):
+            captured.append(kwargs.get("harness"))
+            return JSONResponse({"ok": True})
+
+        async def fake_stream(**kwargs):
+            captured.append(kwargs.get("harness"))
+            yield b"data: [DONE]\n\n"
+
+        with patch.object(proxy_module, "_request_and_trace", side_effect=fake_request), \
+             patch.object(proxy_module, "_stream_and_trace", side_effect=fake_stream), \
+             patch.object(proxy_module, "_stream_preflight", new=AsyncMock(return_value=None)):
+            response = TestClient(app).post(
+                "/v1/messages",
+                json={
+                    "model": "claude-3-haiku-20240307",
+                    "max_tokens": 1,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={
+                    "x-api-key": "sk-ant-test",
+                    "x-agentweave-harness": "claude-code",
+                },
+            )
+
+        assert response.status_code == 200
+        assert captured == ["claude-code"]
+
+    def test_session_context_accepts_openclaw_harness(self, monkeypatch):
+        from fastapi.testclient import TestClient
+        from agentweave.proxy import app
+
+        monkeypatch.setattr(proxy_module, "_forced_session_contexts", OrderedDict())
+        response = TestClient(app).post("/session", json={
+            "session_key": "agent:main:harness",
+            "session_id": "session-1",
+            "harness": "openclaw",
+            "force": True,
+        })
+
+        assert response.status_code == 200
+        assert proxy_module._forced_session_contexts["agent:main:harness"]["prov.harness"] == "openclaw"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- resolve `X-AgentWeave-Harness` with keyed bridge context and `AGENTWEAVE_HARNESS` fallbacks
- stamp `prov.harness` on streaming and non-streaming proxy LLM spans while preserving omission for legacy clients
- configure stable `claude-code` and `openclaw` values in delegation/bridge paths and document precedence/empty-value behavior

## Tests
- `cd sdk/python && pytest` (582 passed)
- `bash -n scripts/claude-delegate.sh scripts/validate-claude-delegate.sh`
- Bridge npm tests not run: npm is unavailable in the execution image

Fixes #267