### PR TITLE
fix(proxy): omit unknown model cost sentinel (#266)

### DIFF
--- a/docs/DEPLOYMENT-RUNBOOK.md
+++ b/docs/DEPLOYMENT-RUNBOOK.md
@@ -208,6 +208,9 @@ Config: `~/.cloudflared/config.yml`
 ## Cost Tracking
 
 The proxy calculates `cost.usd` per span using a pricing table in `sdk/python/agentweave/pricing.py`.
+When a model has no verified price, the proxy omits `cost.usd`, sets
+`agentweave.cost.status=unknown_model`, and emits a bounded warning with the
+normalized model name. Unknown pricing is never represented as a negative cost.
 
 **Bug fixed Mar 19:** Cache token counts weren't passed to `compute_cost`, causing ~7x inflated costs for sessions with high cache hit rates (like Nix's 99% cache hit rate). Fix: both streaming and non-streaming paths now pass `cache_read_tokens` and `cache_write_tokens`.
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -49,6 +49,7 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import functools
 import hashlib
 from collections import OrderedDict
 import json
@@ -78,9 +79,43 @@ from agentweave.health import (
     _global_threshold as _health_global_threshold,
 )
 from agentweave.budget import get_tracker as _get_budget_tracker
-from agentweave.pricing import compute_cost
+from agentweave.pricing import UNKNOWN_COST, _normalize_model_name, compute_cost
 
 logger = logging.getLogger("agentweave.proxy")
+
+
+@functools.lru_cache(maxsize=256)
+def _warn_unknown_cost_model(normalized_model: str) -> None:
+    """Warn once per recently seen unknown model without unbounded state."""
+    logger.warning(
+        "No pricing available for model=%s; omitting cost.usd",
+        normalized_model,
+    )
+
+
+def _set_computed_cost(
+    span: Any,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> float | None:
+    """Set a valid cost, or mark unknown pricing without emitting a sentinel."""
+    cost_usd = compute_cost(
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+    )
+    if cost_usd == UNKNOWN_COST:
+        span.set_attribute(schema.COST_STATUS, "unknown_model")
+        _warn_unknown_cost_model(_normalize_model_name(model))
+        return None
+    span.set_attribute(schema.COST_USD, cost_usd)
+    return cost_usd
 
 # --- Upstream base URLs ---
 _ANTHROPIC_BASE = "https://api.anthropic.com"
@@ -1566,11 +1601,12 @@ async def _stream_and_trace(
         # Pass cache token breakdown so each bucket is priced at the correct rate
         # (cache_read is ~10x cheaper, cache_write slightly more than regular input).
         if input_tokens > 0 or output_tokens > 0:
-            span.set_attribute(schema.COST_USD, compute_cost(
+            _set_computed_cost(
+                span,
                 model, input_tokens, output_tokens,
                 cache_read_tokens=cache_read,
                 cache_write_tokens=cache_write,
-            ))
+            )
 
         # Warn when OpenAI streaming completes with no token usage data.
         # Chat Completions needs stream_options.include_usage=true; Responses API
@@ -1845,12 +1881,11 @@ def _set_anthropic_response_attrs(span: Any, data: dict, elapsed_ms: int, model:
     # (cache_read ~10x cheaper, cache_write slightly above regular input rate).
     cost_usd = None
     if model and (pt > 0 or ct > 0):
-        cost_usd = compute_cost(
-            model, pt, ct,
+        cost_usd = _set_computed_cost(
+            span, model, pt, ct,
             cache_read_tokens=cache_read,
             cache_write_tokens=cache_write,
         )
-        span.set_attribute(schema.COST_USD, cost_usd)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
@@ -1884,8 +1919,7 @@ def _set_google_response_attrs(span: Any, data: dict, elapsed_ms: int, model: st
     # Cost tracking
     cost_usd = None
     if model and (pt > 0 or ct > 0):
-        cost_usd = compute_cost(model, pt, ct)
-        span.set_attribute(schema.COST_USD, cost_usd)
+        cost_usd = _set_computed_cost(span, model, pt, ct)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)
@@ -1929,8 +1963,7 @@ def _set_openai_response_attrs(span: Any, data: dict, elapsed_ms: int, model: st
     # Cost tracking
     cost_usd = None
     if model and (pt > 0 or ct > 0):
-        cost_usd = compute_cost(model, pt, ct)
-        span.set_attribute(schema.COST_USD, cost_usd)
+        cost_usd = _set_computed_cost(span, model, pt, ct)
 
     # OTel gen_ai.* dual-emit
     span.set_attribute(schema.GEN_AI_USAGE_INPUT_TOKENS, pt)

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -106,6 +106,7 @@ PROV_LLM_RESPONSE_PREVIEW = "prov.llm.response_preview"  # first 512 chars of re
 # Cost tracking — USD per LLM call
 # -1.0 means model was not found in the pricing table (unknown cost)
 COST_USD = "cost.usd"
+COST_STATUS = "agentweave.cost.status"
 
 # --- Provider IDs ---
 PROVIDER_ANTHROPIC = "anthropic"

--- a/sdk/python/agentweave/schema.py
+++ b/sdk/python/agentweave/schema.py
@@ -103,8 +103,8 @@ PROV_LLM_STOP_REASON = "prov.llm.stop_reason"
 PROV_LLM_PROMPT_PREVIEW = "prov.llm.prompt_preview"    # first 512 chars of prompt
 PROV_LLM_RESPONSE_PREVIEW = "prov.llm.response_preview"  # first 512 chars of response
 
-# Cost tracking — USD per LLM call
-# -1.0 means model was not found in the pricing table (unknown cost)
+# Cost tracking — USD per LLM call. COST_USD is omitted when pricing is
+# unavailable; COST_STATUS explains why the numeric attribute is absent.
 COST_USD = "cost.usd"
 COST_STATUS = "agentweave.cost.status"
 

--- a/sdk/python/tests/test_pricing.py
+++ b/sdk/python/tests/test_pricing.py
@@ -365,13 +365,71 @@ class TestProxyCostAttrs:
         # gemini-2.5-flash corrected price: $0.075/1M input
         assert abs(span.attrs["cost.usd"] - 0.075) < 1e-9
 
-    def test_unknown_model_cost_is_sentinel(self):
-        from agentweave.proxy import _set_anthropic_response_attrs
-        from agentweave.pricing import UNKNOWN_COST
+    @pytest.mark.parametrize(
+        ("setter_name", "data"),
+        [
+            (
+                "_set_anthropic_response_attrs",
+                {"usage": {"input_tokens": 100, "output_tokens": 50}},
+            ),
+            (
+                "_set_openai_response_attrs",
+                {"usage": {"prompt_tokens": 100, "completion_tokens": 50}},
+            ),
+            (
+                "_set_google_response_attrs",
+                {"usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 50}},
+            ),
+        ],
+    )
+    def test_unknown_model_omits_numeric_cost(self, caplog, setter_name, data):
+        import agentweave.proxy as proxy
+
+        proxy._warn_unknown_cost_model.cache_clear()
         span = _FakeSpan()
-        data = {"usage": {"input_tokens": 100, "output_tokens": 50}}
-        _set_anthropic_response_attrs(span, data, elapsed_ms=10, model="my-unknown-model-xyz")
-        assert span.attrs["cost.usd"] == UNKNOWN_COST
+        with caplog.at_level("WARNING", logger="agentweave.proxy"):
+            getattr(proxy, setter_name)(
+                span,
+                data,
+                elapsed_ms=10,
+                model="Provider/My-Unknown-Model-XYZ",
+            )
+
+        assert "cost.usd" not in span.attrs
+        assert span.attrs["agentweave.cost.status"] == "unknown_model"
+        assert "model=my-unknown-model-xyz" in caplog.text
+
+    def test_streaming_cost_helper_omits_unknown_sentinel(self):
+        from agentweave.proxy import _set_computed_cost
+
+        span = _FakeSpan()
+        cost = _set_computed_cost(span, "streaming-unknown-model", 100, 50)
+
+        assert cost is None
+        assert "cost.usd" not in span.attrs
+        assert span.attrs["agentweave.cost.status"] == "unknown_model"
+
+    def test_unknown_model_warning_is_bounded(self, caplog):
+        from agentweave.proxy import _set_computed_cost, _warn_unknown_cost_model
+
+        _warn_unknown_cost_model.cache_clear()
+        with caplog.at_level("WARNING", logger="agentweave.proxy"):
+            _set_computed_cost(_FakeSpan(), "Provider/Repeat-Unknown", 1, 1)
+            _set_computed_cost(_FakeSpan(), "provider/repeat-unknown", 1, 1)
+
+        messages = [r.message for r in caplog.records if "repeat-unknown" in r.message]
+        assert len(messages) == 1
+
+    def test_claude_opus_5_emits_non_negative_cost(self):
+        from agentweave.proxy import _set_anthropic_response_attrs
+
+        span = _FakeSpan()
+        data = {"usage": {"input_tokens": 1_000_000, "output_tokens": 0}}
+        _set_anthropic_response_attrs(span, data, elapsed_ms=10, model="claude-opus-5")
+
+        assert span.attrs["cost.usd"] == 5.0
+        assert span.attrs["cost.usd"] >= 0
+        assert "agentweave.cost.status" not in span.attrs
 
     def test_no_cost_when_no_tokens(self):
         """cost.usd should not be set when token counts are zero."""


### PR DESCRIPTION
## Summary
- omit `cost.usd` when proxy pricing returns the internal unknown-model sentinel
- expose `agentweave.cost.status=unknown_model` and a normalized, once-per-model bounded warning
- use one cost-emission helper across streaming and all non-streaming providers
- retain verified positive pricing for the existing `claude-opus-5` label

## Tests
- `cd sdk/python && pytest` (579 passed)

Fixes #266