### PR TITLE
feat(cli): add idempotent local init command

### DIFF
--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -52,6 +52,59 @@ def _format_started_at(started_at: float) -> str:
 # ---------------------------------------------------------------------------
 
 
+@app.command("init")
+def init(
+    port: int = typer.Option(4000, "--port", "-p", help="Proxy port to listen on."),
+    host: str = typer.Option("127.0.0.1", "--host", help="Proxy host to bind to."),
+    endpoint: Optional[str] = typer.Option(
+        None,
+        "--endpoint",
+        "-e",
+        help="OTLP HTTP endpoint (e.g. http://localhost:4318).",
+    ),
+    agent_id: Optional[str] = typer.Option(
+        None, "--agent-id", help="Default agent ID tag for traced calls."
+    ),
+    capture_prompts: bool = typer.Option(
+        False,
+        "--capture-prompts",
+        help="Record the first 512 characters of prompts and responses.",
+    ),
+) -> None:
+    """Initialize a local AgentWeave proxy with safe, repeatable defaults."""
+    from agentweave.lifecycle import current_status, start_proxy_process
+
+    current, existing = current_status()
+    if current == "running" and existing:
+        state = existing
+        action = "already running"
+    else:
+        try:
+            state = start_proxy_process(
+                host=host,
+                port=port,
+                endpoint=endpoint,
+                agent_id=agent_id,
+                capture_prompts=capture_prompts,
+            )
+        except RuntimeError as exc:
+            console.print(f"[red]Initialization failed:[/red] {exc}")
+            raise typer.Exit(code=1)
+        action = "started"
+
+    console.print(f"[green]AgentWeave initialized[/green] — proxy {action}")
+    console.print(f"  Proxy    : [cyan]{state.url}[/cyan]")
+    console.print(f"  Logs     : [dim]{state.log_file}[/dim]")
+    console.print()
+    console.print("Next:")
+    console.print("  • Verify setup: [bold]agentweave doctor --check-proxy[/bold]")
+    console.print(f"  • Proxy mode: [bold]export ANTHROPIC_BASE_URL={state.url}[/bold]")
+    console.print(
+        "  • Claude Code Remote Control users: keep the Anthropic URL unchanged and "
+        "configure native OpenTelemetry export instead."
+    )
+
+
 @app.command("start")
 def start(
     port: int = typer.Option(4000, "--port", "-p", help="Port to listen on."),

--- a/sdk/python/tests/test_lifecycle.py
+++ b/sdk/python/tests/test_lifecycle.py
@@ -137,3 +137,68 @@ def test_status_cli_json_uses_state_dir(monkeypatch, tmp_path):
     payload = json.loads(result.output)
     assert payload["status"] == "running"
     assert payload["proxy"]["pid"] == 123
+
+
+def test_init_cli_starts_proxy_and_prints_next_steps(monkeypatch):
+    from typer.testing import CliRunner
+
+    import agentweave.lifecycle as lifecycle
+    from agentweave.cli import app
+
+    state = lifecycle.ProxyState(
+        pid=123,
+        host="127.0.0.1",
+        port=4100,
+        url="http://localhost:4100",
+        command=["agentweave", "proxy", "start"],
+        log_file="/tmp/agentweave.log",
+        started_at=1.0,
+    )
+    started = {}
+    monkeypatch.setattr(lifecycle, "current_status", lambda: ("stopped", None))
+
+    def fake_start_proxy_process(**kwargs):
+        started.update(kwargs)
+        return state
+
+    monkeypatch.setattr(lifecycle, "start_proxy_process", fake_start_proxy_process)
+
+    result = CliRunner().invoke(
+        app,
+        ["init", "--port", "4100", "--endpoint", "http://tempo:4318"],
+    )
+
+    assert result.exit_code == 0
+    assert started["port"] == 4100
+    assert started["endpoint"] == "http://tempo:4318"
+    assert "AgentWeave initialized" in result.output
+    assert "http://localhost:4100" in result.output
+    assert "native OpenTelemetry" in result.output
+
+
+def test_init_cli_is_idempotent_when_proxy_is_running(monkeypatch):
+    from typer.testing import CliRunner
+
+    import agentweave.lifecycle as lifecycle
+    from agentweave.cli import app
+
+    state = lifecycle.ProxyState(
+        pid=123,
+        host="127.0.0.1",
+        port=4000,
+        url="http://localhost:4000",
+        command=["agentweave", "proxy", "start"],
+        log_file="/tmp/agentweave.log",
+        started_at=1.0,
+    )
+    monkeypatch.setattr(lifecycle, "current_status", lambda: ("running", state))
+    monkeypatch.setattr(
+        lifecycle,
+        "start_proxy_process",
+        lambda **kwargs: pytest.fail("init should reuse the running proxy"),
+    )
+
+    result = CliRunner().invoke(app, ["init"])
+
+    assert result.exit_code == 0
+    assert "proxy already running" in result.output


### PR DESCRIPTION
## Summary
- add `agentweave init` as an idempotent bootstrap over the managed local proxy
- preserve native OpenTelemetry guidance for Claude Code Remote Control users
- print immediate verification and proxy-mode next steps

## Validation
- `python3 -m pytest -q` — 589 passed
- focused lifecycle suite — 6 passed

Part of #129; embedded dashboard, live trace tail, and binary distribution remain separate slices.