### PR TITLE
feat(cli): add constrained trace questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,25 @@ One port, all providers. Every LLM call gets a span automatically.
 
 ## Backends
 
+### Ask your traces (read-only preview)
+
+`agentweave trace ask` maps a deliberately small set of questions to reviewed
+TraceQL templates and queries Tempo without modifying data:
+
+```bash
+agentweave trace ask "Why did this session fail?" --session agent:main:run-42 \
+  --tempo-url http://localhost:3200 --verbose
+agentweave trace ask "Compare agent errors" --window 6h --json
+agentweave trace ask "Show the slowest calls" --limit 10
+agentweave trace ask "Show expensive calls" --window 1d
+```
+
+Supported questions cover failures for an explicit session or trace, agent
+errors, slow calls, and calls with recorded cost. Inputs are validated, windows
+are capped at seven days, results are capped at 100 traces, and every result is
+cited by trace ID. Ambiguous or unsupported questions fail closed; this preview
+does not execute model-generated TraceQL or perform automated actions.
+
 AgentWeave emits standard OTLP HTTP — works with any compatible backend:
 
 | Backend | Endpoint |

--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -218,6 +218,61 @@ def status(
 # ---------------------------------------------------------------------------
 
 
+@trace_app.command("ask")
+def trace_ask(
+    question: str = typer.Argument(help="A supported natural-language trace question."),
+    tempo_url: str = typer.Option(
+        "http://localhost:3200", "--tempo-url", help="Tempo query base URL."
+    ),
+    session_id: Optional[str] = typer.Option(None, "--session", help="Session identifier."),
+    trace_id: Optional[str] = typer.Option(None, "--trace-id", help="32-character trace ID."),
+    window: str = typer.Option("24h", "--window", help="Bounded window such as 15m, 6h, or 1d."),
+    limit: int = typer.Option(20, "--limit", min=1, max=100, help="Maximum matching traces."),
+    timeout: float = typer.Option(10.0, "--timeout", min=0.1, help="Tempo timeout in seconds."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+    verbose: bool = typer.Option(False, "--verbose", help="Show the rendered TraceQL query."),
+) -> None:
+    """Ask a constrained, read-only question about traces in Tempo."""
+    from agentweave.trace_analysis import (
+        TempoQueryError,
+        TraceQuestionError,
+        answer_payload,
+        parse_window,
+        plan_question,
+        query_tempo,
+    )
+
+    try:
+        plan = plan_question(question, session_id=session_id, trace_id=trace_id)
+        citations = query_tempo(
+            tempo_url,
+            plan,
+            window_seconds=parse_window(window),
+            limit=limit,
+            timeout_seconds=timeout,
+        )
+    except TraceQuestionError as exc:
+        console.print(f"[red]Unsupported trace question:[/red] {exc}")
+        raise typer.Exit(code=2)
+    except TempoQueryError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
+
+    payload = answer_payload(plan, citations)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    console.print(payload["summary"])
+    if verbose:
+        console.print(f"[dim]TraceQL: {plan.traceql}[/dim]")
+    for citation in citations:
+        duration = f" ({citation.duration_ms:.1f} ms)" if citation.duration_ms is not None else ""
+        console.print(
+            f"  [cyan]{citation.trace_id}[/cyan]  {citation.root_service} / "
+            f"{citation.root_span}{duration}"
+        )
+
+
 @trace_app.command("show")
 def trace_show(
     trace_id: str = typer.Argument(help="The trace ID to display."),

--- a/sdk/python/agentweave/trace_analysis.py
+++ b/sdk/python/agentweave/trace_analysis.py
@@ -1,0 +1,237 @@
+"""Constrained, read-only Tempo queries for ``agentweave trace ask``."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+class TraceQuestionError(ValueError):
+    """Raised when a question cannot be mapped safely to an allowlisted query."""
+
+
+class TempoQueryError(RuntimeError):
+    """Raised when Tempo cannot execute a query."""
+
+
+_TRACE_ID = re.compile(r"^[0-9a-fA-F]{32}$")
+_SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$")
+_WINDOW = re.compile(r"^(\d+)([mhd])$")
+_WINDOW_MULTIPLIERS = {"m": 60, "h": 3600, "d": 86400}
+MAX_WINDOW_SECONDS = 7 * 86400
+MAX_RESULTS = 100
+
+
+@dataclass(frozen=True)
+class QueryPlan:
+    family: str
+    traceql: str
+    explanation: str
+
+
+@dataclass(frozen=True)
+class TraceCitation:
+    trace_id: str
+    root_service: str
+    root_span: str
+    duration_ms: float | None
+    start_time_unix_nano: str | None
+    agent_id: str | None = None
+    cost_usd: float | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def parse_window(value: str) -> int:
+    match = _WINDOW.fullmatch(value.strip().lower())
+    if not match:
+        raise TraceQuestionError("window must look like 15m, 6h, or 1d")
+    seconds = int(match.group(1)) * _WINDOW_MULTIPLIERS[match.group(2)]
+    if seconds < 60 or seconds > MAX_WINDOW_SECONDS:
+        raise TraceQuestionError("window must be between 1m and 7d")
+    return seconds
+
+
+def validate_limit(value: int) -> int:
+    if value < 1 or value > MAX_RESULTS:
+        raise TraceQuestionError(f"limit must be between 1 and {MAX_RESULTS}")
+    return value
+
+
+def _validate_trace_id(value: str) -> str:
+    if not _TRACE_ID.fullmatch(value):
+        raise TraceQuestionError("trace ID must be exactly 32 hexadecimal characters")
+    return value.lower()
+
+
+def _validate_session_id(value: str) -> str:
+    if not _SESSION_ID.fullmatch(value):
+        raise TraceQuestionError(
+            "session ID must be 1-128 characters using letters, numbers, '.', '_', ':', '/', or '-'"
+        )
+    return value
+
+
+def plan_question(
+    question: str,
+    *,
+    session_id: str | None = None,
+    trace_id: str | None = None,
+) -> QueryPlan:
+    """Map a question to exactly one allowlisted TraceQL template."""
+
+    normalized = " ".join(question.lower().split())
+    families: list[str] = []
+    if any(word in normalized for word in ("fail", "error", "why did")) and (
+        session_id or trace_id
+    ):
+        families.append("failures")
+    if "agent" in normalized and any(word in normalized for word in ("fail", "error")):
+        families.append("agent-errors")
+    if any(word in normalized for word in ("slow", "latency", "duration")):
+        families.append("slow-calls")
+    if any(word in normalized for word in ("expensive", "cost", "spend")):
+        families.append("expensive-calls")
+
+    families = list(dict.fromkeys(families))
+    if len(families) != 1:
+        raise TraceQuestionError(
+            "question must match exactly one supported family: failures for --session/--trace-id, "
+            "agent error comparison, slow calls, or expensive calls"
+        )
+
+    family = families[0]
+    if family == "failures":
+        if trace_id:
+            value = _validate_trace_id(trace_id)
+            return QueryPlan(family, f'{{ trace:id = "{value}" && status = error }}', "errors in trace")
+        value = _validate_session_id(session_id or "")
+        return QueryPlan(
+            family,
+            f'{{ span.prov.session.id = "{value}" && status = error }}',
+            "errors in session",
+        )
+    if session_id or trace_id:
+        raise TraceQuestionError("--session and --trace-id are only valid for failure questions")
+    if family == "agent-errors":
+        return QueryPlan(
+            family,
+            "{ status = error && span.prov.agent.id != nil } | select(span.prov.agent.id)",
+            "error traces grouped for comparison by agent",
+        )
+    if family == "slow-calls":
+        return QueryPlan(
+            family,
+            "{ duration > 1s }",
+            "traces containing spans slower than one second",
+        )
+    return QueryPlan(
+        family,
+        "{ span.cost.usd > 0 } | select(span.cost.usd, span.prov.agent.id)",
+        "LLM calls with recorded cost",
+    )
+
+
+def _citation(item: dict[str, Any]) -> TraceCitation | None:
+    trace_id = str(item.get("traceID") or "")
+    if not _TRACE_ID.fullmatch(trace_id):
+        return None
+    duration = item.get("durationMs")
+    try:
+        duration_ms = float(duration) if duration is not None else None
+    except (TypeError, ValueError):
+        duration_ms = None
+    attributes: dict[str, object] = {}
+    for span_set in item.get("spanSets") or [item.get("spanSet") or {}]:
+        for span in span_set.get("spans") or []:
+            for attribute in span.get("attributes") or []:
+                value = attribute.get("value") or {}
+                scalar = next(
+                    (value[key] for key in ("stringValue", "doubleValue", "intValue") if key in value),
+                    None,
+                )
+                attributes[str(attribute.get("key") or "")] = scalar
+    raw_cost = attributes.get("cost.usd")
+    try:
+        cost_usd = float(raw_cost) if raw_cost is not None else None
+    except (TypeError, ValueError):
+        cost_usd = None
+    return TraceCitation(
+        trace_id=trace_id.lower(),
+        root_service=str(item.get("rootServiceName") or "unknown"),
+        root_span=str(item.get("rootTraceName") or "unknown"),
+        duration_ms=duration_ms,
+        start_time_unix_nano=(
+            str(item["startTimeUnixNano"]) if item.get("startTimeUnixNano") is not None else None
+        ),
+        agent_id=str(attributes["prov.agent.id"]) if attributes.get("prov.agent.id") else None,
+        cost_usd=cost_usd,
+    )
+
+
+def query_tempo(
+    tempo_url: str,
+    plan: QueryPlan,
+    *,
+    window_seconds: int,
+    limit: int,
+    timeout_seconds: float = 10.0,
+    now: int | None = None,
+) -> list[TraceCitation]:
+    """Execute a bounded Tempo search and return validated trace citations."""
+
+    validate_limit(limit)
+    if window_seconds < 60 or window_seconds > MAX_WINDOW_SECONDS:
+        raise TraceQuestionError("window must be between 1m and 7d")
+    end = int(time.time()) if now is None else now
+    query = urllib.parse.urlencode(
+        {
+            "q": plan.traceql,
+            "start": str(end - window_seconds),
+            "end": str(end),
+            "limit": str(limit),
+        }
+    )
+    request = urllib.request.Request(
+        f"{tempo_url.rstrip('/')}/api/search?{query}",
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise TempoQueryError(f"Tempo query failed: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("traces", []), list):
+        raise TempoQueryError("Tempo returned an unexpected search response")
+    return [citation for item in payload.get("traces", []) if (citation := _citation(item))]
+
+
+def answer_payload(plan: QueryPlan, citations: list[TraceCitation]) -> dict[str, object]:
+    if citations:
+        if plan.family == "agent-errors":
+            counts: dict[str, int] = {}
+            for citation in citations:
+                agent = citation.agent_id or "unknown"
+                counts[agent] = counts.get(agent, 0) + 1
+            comparison = ", ".join(
+                f"{agent}: {count}" for agent, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+            )
+            summary = f"Found {len(citations)} error trace(s) by agent ({comparison})."
+        else:
+            summary = f"Found {len(citations)} matching trace(s) for {plan.explanation}."
+    else:
+        summary = f"No matching data found for {plan.explanation}."
+    return {
+        "family": plan.family,
+        "summary": summary,
+        "traceql": plan.traceql,
+        "citations": [citation.to_dict() for citation in citations],
+    }

--- a/sdk/python/tests/test_trace_analysis.py
+++ b/sdk/python/tests/test_trace_analysis.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+from agentweave.trace_analysis import (
+    TempoQueryError,
+    TraceQuestionError,
+    answer_payload,
+    parse_window,
+    plan_question,
+    query_tempo,
+)
+
+
+def test_plans_session_failure_with_validated_template():
+    plan = plan_question("Why did this session fail?", session_id="agent:main:run-42")
+    assert plan.family == "failures"
+    assert plan.traceql == '{ span.prov.session.id = "agent:main:run-42" && status = error }'
+
+
+def test_rejects_unsafe_identifier_and_ambiguous_question():
+    with pytest.raises(TraceQuestionError, match="session ID"):
+        plan_question("Why did it fail?", session_id='x" } || { true')
+    with pytest.raises(TraceQuestionError, match="exactly one"):
+        plan_question("Which agent errors were slow?")
+
+
+def test_rejects_unsupported_question_and_out_of_range_window():
+    with pytest.raises(TraceQuestionError, match="supported family"):
+        plan_question("Tell me something interesting")
+    assert parse_window("6h") == 21600
+    with pytest.raises(TraceQuestionError, match="between 1m and 7d"):
+        parse_window("8d")
+
+
+def test_query_tempo_returns_only_valid_trace_citations(monkeypatch):
+    payload = {
+        "traces": [
+            {
+                "traceID": "a" * 32,
+                "rootServiceName": "agentweave-proxy",
+                "rootTraceName": "anthropic.messages",
+                "durationMs": 12.5,
+                "startTimeUnixNano": "123",
+                "spanSets": [{"spans": [{"attributes": [{
+                    "key": "prov.agent.id", "value": {"stringValue": "nix"}
+                }]}]}],
+            },
+            {"traceID": "not-a-trace"},
+        ]
+    }
+
+    class Response(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        return Response(json.dumps(payload).encode())
+
+    monkeypatch.setattr("agentweave.trace_analysis.urllib.request.urlopen", fake_urlopen)
+    plan = plan_question("Show the slowest calls")
+    citations = query_tempo(
+        "http://tempo:3200", plan, window_seconds=3600, limit=5, now=10000
+    )
+    assert [item.trace_id for item in citations] == ["a" * 32]
+    assert citations[0].agent_id == "nix"
+    assert "limit=5" in captured["url"]
+    assert "start=6400" in captured["url"]
+
+
+def test_query_tempo_distinguishes_backend_failure(monkeypatch):
+    def fail(*args, **kwargs):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("agentweave.trace_analysis.urllib.request.urlopen", fail)
+    with pytest.raises(TempoQueryError, match="offline"):
+        query_tempo(
+            "http://tempo:3200",
+            plan_question("Show expensive calls"),
+            window_seconds=3600,
+            limit=5,
+        )
+
+
+def test_empty_answer_is_not_reported_as_failure_and_citations_are_complete():
+    plan = plan_question("Compare agent error rates")
+    empty = answer_payload(plan, [])
+    assert empty["summary"].startswith("No matching data")
+    assert empty["citations"] == []
+    assert empty["traceql"] == plan.traceql


### PR DESCRIPTION
## Summary
- add read-only `agentweave trace ask` backed by allowlisted TraceQL templates
- validate identifiers, query windows, and result limits; ambiguous questions fail closed
- distinguish empty results from Tempo failures and cite every returned trace ID
- document supported questions and limitations

## Validation
- `python3 -m pytest -q` — 595 passed
- live bounded query against deployed Tempo completed successfully

Closes #271
Part of #117