### PR TITLE
feat(proxy): add deterministic anomaly and optimization analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,18 @@ are capped at seven days, results are capped at 100 traces, and every result is
 cited by trace ID. Ambiguous or unsupported questions fail closed; this preview
 does not execute model-generated TraceQL or perform automated actions.
 
+For deterministic analysis of traffic observed by a running proxy:
+
+```bash
+agentweave trace analyze --proxy-url http://localhost:4000
+```
+
+The proxy's read-only `GET /v1/analysis` endpoint compares error rate, P95
+latency, and average cost with the immediately preceding window. It also flags
+per-session tool retry loops and cost spikes. Results use
+`diagnostic.anomaly` and `diagnostic.optimization` event names, include the
+supporting session IDs, and are directly consumable by OpenClaw or dashboards.
+
 AgentWeave emits standard OTLP HTTP — works with any compatible backend:
 
 | Backend | Endpoint |

--- a/sdk/python/agentweave/analysis.py
+++ b/sdk/python/agentweave/analysis.py
@@ -1,0 +1,161 @@
+"""Deterministic anomaly detection and session optimization suggestions."""
+
+from __future__ import annotations
+
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from typing import Iterable
+
+from agentweave.health import SpanRecord
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    event: str
+    signal: str
+    severity: str
+    message: str
+    agent_id: str
+    session_ids: tuple[str, ...]
+    current: float
+    baseline: float
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["session_ids"] = list(self.session_ids)
+        return payload
+
+
+def _p95(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[min(int(len(ordered) * 0.95), len(ordered) - 1)]
+
+
+def _error_rate(spans: list[SpanRecord]) -> float:
+    return sum(span.is_error for span in spans) / len(spans) if spans else 0.0
+
+
+def _average_cost(spans: list[SpanRecord]) -> float:
+    return sum(span.cost_usd for span in spans) / len(spans) if spans else 0.0
+
+
+def _severity(ratio: float) -> str:
+    return "critical" if ratio >= 3 else "warning"
+
+
+def detect_anomalies(
+    spans: Iterable[SpanRecord],
+    *,
+    now_ms: float | None = None,
+    current_window_seconds: int = 1800,
+    minimum_samples: int = 3,
+) -> list[Diagnostic]:
+    """Compare the current window with the immediately preceding baseline."""
+
+    now = time.time() * 1000 if now_ms is None else now_ms
+    split = now - current_window_seconds * 1000
+    start = split - current_window_seconds * 1000
+    by_agent: dict[str, list[SpanRecord]] = {}
+    for span in spans:
+        if span.timestamp_ms >= start:
+            by_agent.setdefault(span.agent_id, []).append(span)
+
+    findings: list[Diagnostic] = []
+    for agent_id, agent_spans in by_agent.items():
+        baseline = [span for span in agent_spans if start <= span.timestamp_ms < split]
+        current = [span for span in agent_spans if span.timestamp_ms >= split]
+        if len(baseline) < minimum_samples or len(current) < minimum_samples:
+            continue
+        session_ids = tuple(sorted({span.session_id for span in current})[:20])
+        metrics = (
+            ("error_rate", _error_rate(current), _error_rate(baseline), 0.10),
+            (
+                "p95_latency_ms",
+                _p95([span.duration_ms for span in current]),
+                _p95([span.duration_ms for span in baseline]),
+                100.0,
+            ),
+            ("avg_cost_usd", _average_cost(current), _average_cost(baseline), 0.000001),
+        )
+        for signal, current_value, baseline_value, floor in metrics:
+            if current_value <= baseline_value or current_value - baseline_value < floor:
+                continue
+            ratio = current_value / max(baseline_value, floor)
+            if ratio < 1.5:
+                continue
+            findings.append(
+                Diagnostic(
+                    event="diagnostic.anomaly",
+                    signal=signal,
+                    severity=_severity(ratio),
+                    message=(
+                        f"{agent_id} {signal} is {ratio:.1f}x its preceding-window baseline"
+                    ),
+                    agent_id=agent_id,
+                    session_ids=session_ids,
+                    current=round(current_value, 6),
+                    baseline=round(baseline_value, 6),
+                )
+            )
+    return findings
+
+
+def suggest_optimizations(spans: Iterable[SpanRecord]) -> list[Diagnostic]:
+    """Return evidence-backed suggestions for retry loops and session cost spikes."""
+
+    sessions: dict[tuple[str, str], list[SpanRecord]] = {}
+    for span in spans:
+        sessions.setdefault((span.agent_id, span.session_id), []).append(span)
+    session_costs = [sum(span.cost_usd for span in values) for values in sessions.values()]
+    median_cost = statistics.median(session_costs) if session_costs else 0.0
+    findings: list[Diagnostic] = []
+    for (agent_id, session_id), values in sessions.items():
+        tool_counts: dict[str, int] = {}
+        for span in values:
+            if span.tool_name:
+                tool_counts[span.tool_name] = tool_counts.get(span.tool_name, 0) + 1
+        repeated = sorted((name, count) for name, count in tool_counts.items() if count > 2)
+        if repeated:
+            tool, count = max(repeated, key=lambda item: item[1])
+            findings.append(
+                Diagnostic(
+                    event="diagnostic.optimization",
+                    signal="tool_retry_loop",
+                    severity="warning",
+                    message=f"Session {session_id} called {tool} {count} times; inspect retry termination",
+                    agent_id=agent_id,
+                    session_ids=(session_id,),
+                    current=float(count),
+                    baseline=2.0,
+                )
+            )
+        cost = sum(span.cost_usd for span in values)
+        if median_cost > 0 and cost >= median_cost * 2 and cost - median_cost >= 0.001:
+            findings.append(
+                Diagnostic(
+                    event="diagnostic.optimization",
+                    signal="session_cost_spike",
+                    severity="warning",
+                    message=f"Session {session_id} cost is {cost / median_cost:.1f}x the median session",
+                    agent_id=agent_id,
+                    session_ids=(session_id,),
+                    current=round(cost, 6),
+                    baseline=round(median_cost, 6),
+                )
+            )
+    return findings
+
+
+def analysis_payload(spans: Iterable[SpanRecord], *, now_ms: float | None = None) -> dict[str, object]:
+    records = list(spans)
+    anomalies = detect_anomalies(records, now_ms=now_ms)
+    suggestions = suggest_optimizations(records)
+    return {
+        "read_only": True,
+        "anomalies": [finding.to_dict() for finding in anomalies],
+        "suggestions": [finding.to_dict() for finding in suggestions],
+        "span_count": len(records),
+    }

--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -273,6 +273,47 @@ def trace_ask(
         )
 
 
+@trace_app.command("analyze")
+def trace_analyze(
+    proxy_url: str = typer.Option(
+        "http://localhost:4000", "--proxy-url", help="AgentWeave proxy base URL."
+    ),
+    timeout: float = typer.Option(5.0, "--timeout", min=0.1, help="Request timeout in seconds."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+) -> None:
+    """Show deterministic anomaly and session optimization diagnostics."""
+    import urllib.error
+    import urllib.request
+
+    request = urllib.request.Request(
+        f"{proxy_url.rstrip('/')}/v1/analysis",
+        headers={"Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        console.print(f"[red]Analysis query failed:[/red] {exc}")
+        raise typer.Exit(code=1)
+    if json_output:
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    anomalies = payload.get("anomalies") or []
+    suggestions = payload.get("suggestions") or []
+    console.print(f"[bold]Anomalies[/bold] ({len(anomalies)})")
+    for finding in anomalies:
+        console.print(f"  [{finding.get('severity', 'warning')}]{finding.get('message', '')}[/]")
+        console.print(f"    sessions: {', '.join(finding.get('session_ids') or [])}")
+    console.print(f"[bold]Optimization suggestions[/bold] ({len(suggestions)})")
+    for finding in suggestions:
+        console.print(f"  {finding.get('message', '')}")
+        console.print(f"    sessions: {', '.join(finding.get('session_ids') or [])}")
+    if not anomalies and not suggestions:
+        console.print("[green]No evidence-backed findings in the current in-memory window.[/green]")
+
+
 @trace_app.command("show")
 def trace_show(
     trace_id: str = typer.Argument(help="The trace ID to display."),

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -788,6 +788,17 @@ async def get_agent_health_config():
     }
 
 
+@app.get("/v1/analysis", include_in_schema=True)
+async def get_trace_analysis():
+    """Return read-only anomaly and session optimization diagnostics."""
+    from agentweave.analysis import analysis_payload
+    from agentweave.health import _spans, _spans_lock
+
+    with _spans_lock:
+        spans = list(_spans)
+    return analysis_payload(spans)
+
+
 # ---------------------------------------------------------------------------
 # Claude Code hooks endpoints
 # ---------------------------------------------------------------------------

--- a/sdk/python/tests/test_analysis.py
+++ b/sdk/python/tests/test_analysis.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+
+from agentweave.analysis import analysis_payload, detect_anomalies, suggest_optimizations
+from agentweave.health import SpanRecord
+
+
+def span(*, timestamp, duration=100, error=False, cost=0.001, tool=None, session="s1"):
+    return SpanRecord("nix", session, timestamp, duration, error, cost, tool)
+
+
+def test_detects_window_over_window_latency_error_and_cost_anomalies():
+    now = 4_000_000.0
+    records = [span(timestamp=1_000_000 + index) for index in range(4)]
+    records += [
+        span(timestamp=3_000_000 + index, duration=1000, error=True, cost=0.01, session="hot")
+        for index in range(4)
+    ]
+    findings = detect_anomalies(records, now_ms=now, current_window_seconds=2000)
+    assert {finding.signal for finding in findings} == {
+        "error_rate",
+        "p95_latency_ms",
+        "avg_cost_usd",
+    }
+    assert all(finding.event == "diagnostic.anomaly" for finding in findings)
+    assert all(finding.session_ids == ("hot",) for finding in findings)
+
+
+def test_requires_enough_baseline_and_current_samples():
+    assert detect_anomalies([span(timestamp=1000)], now_ms=2000) == []
+
+
+def test_suggests_retry_loop_and_cost_spike_with_session_evidence():
+    records = [
+        span(timestamp=1, session="normal-1", cost=0.001),
+        span(timestamp=1, session="normal-2", cost=0.001),
+        span(timestamp=1, session="normal-3", cost=0.001),
+    ]
+    records += [
+        span(timestamp=2 + index, session="hot", cost=0.002, tool="bash")
+        for index in range(4)
+    ]
+    findings = suggest_optimizations(records)
+    assert {finding.signal for finding in findings} == {"tool_retry_loop", "session_cost_spike"}
+    assert all(finding.session_ids == ("hot",) for finding in findings)
+    assert all(finding.event == "diagnostic.optimization" for finding in findings)
+
+
+def test_payload_is_explicitly_read_only():
+    payload = analysis_payload([])
+    assert payload == {"read_only": True, "anomalies": [], "suggestions": [], "span_count": 0}
+
+
+def test_proxy_analysis_endpoint_returns_diagnostic_payload(monkeypatch):
+    import agentweave.health as health
+    from agentweave.proxy import get_trace_analysis
+
+    monkeypatch.setattr(health, "_spans", [])
+    payload = asyncio.run(get_trace_analysis())
+    assert payload["read_only"] is True
+    assert payload["anomalies"] == []
+    assert payload["suggestions"] == []


### PR DESCRIPTION
## Summary
- detect error-rate, P95-latency, and average-cost regressions against the preceding window
- produce evidence-backed per-session retry-loop and cost-spike suggestions
- expose read-only `diagnostic.anomaly` and `diagnostic.optimization` records at `/v1/analysis`
- add `agentweave trace analyze` for CLI/OpenClaw/dashboard consumption

## Validation
- `python3 -m pytest -q` — 606 passed
- focused analysis/proxy suite — 209 passed

Part of #117