### PR TITLE
feat(cli): add live Tempo trace tail

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+**/node_modules
+**/__pycache__
+**/.pytest_cache

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ agentweave trace ask "Why did this session fail?" --session agent:main:run-42 \
 agentweave trace ask "Compare agent errors" --window 6h --json
 agentweave trace ask "Show the slowest calls" --limit 10
 agentweave trace ask "Show expensive calls" --window 1d
+agentweave trace tail --tempo-url http://localhost:3200 --session agent:main:run-42
 ```
 
 Supported questions cover failures for an explicit session or trace, agent

--- a/sdk/python/agentweave/cli.py
+++ b/sdk/python/agentweave/cli.py
@@ -317,6 +317,75 @@ def trace_analyze(
         console.print("[green]No evidence-backed findings in the current in-memory window.[/green]")
 
 
+@trace_app.command("tail")
+def trace_tail(
+    tempo_url: str = typer.Option(
+        "http://localhost:3200", "--tempo-url", help="Tempo query base URL."
+    ),
+    session_id: Optional[str] = typer.Option(None, "--session", help="Follow one session."),
+    since: str = typer.Option("5m", "--since", help="Initial lookback such as 5m or 1h."),
+    interval: float = typer.Option(2.0, "--interval", min=0.2, help="Polling interval in seconds."),
+    limit: int = typer.Option(50, "--limit", min=1, max=100, help="Maximum traces per poll."),
+    once: bool = typer.Option(False, "--once", help="Poll once and exit."),
+    json_output: bool = typer.Option(False, "--json", help="Emit one JSON object per trace."),
+) -> None:
+    """Live-tail LLM traces from Tempo."""
+    from agentweave.trace_analysis import (
+        TempoQueryError,
+        TraceQuestionError,
+        parse_window,
+        plan_tail,
+        query_tempo,
+    )
+
+    try:
+        plan = plan_tail(session_id=session_id)
+        window_seconds = parse_window(since)
+    except TraceQuestionError as exc:
+        console.print(f"[red]Invalid tail options:[/red] {exc}")
+        raise typer.Exit(code=2)
+    seen: set[str] = set()
+    if not json_output:
+        console.print("[dim]Following LLM traces; press Ctrl-C to stop.[/dim]")
+    try:
+        while True:
+            try:
+                citations = query_tempo(
+                    tempo_url,
+                    plan,
+                    window_seconds=window_seconds,
+                    limit=limit,
+                    timeout_seconds=max(5.0, interval * 2),
+                )
+            except TempoQueryError as exc:
+                console.print(f"[red]{exc}[/red]")
+                if once:
+                    raise typer.Exit(code=1)
+                time.sleep(interval)
+                continue
+            fresh = sorted(
+                (item for item in citations if item.trace_id not in seen),
+                key=lambda item: item.start_time_unix_nano or "",
+            )
+            for item in fresh:
+                seen.add(item.trace_id)
+                if json_output:
+                    typer.echo(json.dumps(item.to_dict(), sort_keys=True))
+                    continue
+                tokens = (item.prompt_tokens or 0) + (item.completion_tokens or 0)
+                cost = f"${item.cost_usd:.4f}" if item.cost_usd is not None else "—"
+                latency = f"{item.duration_ms:.0f}ms" if item.duration_ms is not None else "—"
+                console.print(
+                    f"[cyan]{item.trace_id}[/cyan]  {item.agent_id or 'unknown'}  "
+                    f"{item.model or 'unknown'}  tokens={tokens or '—'}  cost={cost}  {latency}"
+                )
+            if once:
+                return
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        return
+
+
 @trace_app.command("show")
 def trace_show(
     trace_id: str = typer.Argument(help="The trace ID to display."),

--- a/sdk/python/agentweave/trace_analysis.py
+++ b/sdk/python/agentweave/trace_analysis.py
@@ -44,6 +44,9 @@ class TraceCitation:
     start_time_unix_nano: str | None
     agent_id: str | None = None
     cost_usd: float | None = None
+    model: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -139,6 +142,23 @@ def plan_question(
     )
 
 
+def plan_tail(*, session_id: str | None = None) -> QueryPlan:
+    """Build the allowlisted live-tail query, optionally scoped to a session."""
+
+    filters = ["span.prov.llm.model != nil"]
+    if session_id:
+        filters.append(f'span.prov.session.id = "{_validate_session_id(session_id)}"')
+    selected = (
+        "span.prov.agent.id, span.prov.llm.model, span.prov.llm.prompt_tokens, "
+        "span.prov.llm.completion_tokens, span.cost.usd"
+    )
+    return QueryPlan(
+        "tail",
+        f"{{ {' && '.join(filters)} }} | select({selected})",
+        "recent LLM calls",
+    )
+
+
 def _citation(item: dict[str, Any]) -> TraceCitation | None:
     trace_id = str(item.get("traceID") or "")
     if not _TRACE_ID.fullmatch(trace_id):
@@ -163,6 +183,11 @@ def _citation(item: dict[str, Any]) -> TraceCitation | None:
         cost_usd = float(raw_cost) if raw_cost is not None else None
     except (TypeError, ValueError):
         cost_usd = None
+    def integer_attribute(name: str) -> int | None:
+        try:
+            return int(attributes[name]) if attributes.get(name) is not None else None
+        except (TypeError, ValueError):
+            return None
     return TraceCitation(
         trace_id=trace_id.lower(),
         root_service=str(item.get("rootServiceName") or "unknown"),
@@ -173,6 +198,9 @@ def _citation(item: dict[str, Any]) -> TraceCitation | None:
         ),
         agent_id=str(attributes["prov.agent.id"]) if attributes.get("prov.agent.id") else None,
         cost_usd=cost_usd,
+        model=str(attributes["prov.llm.model"]) if attributes.get("prov.llm.model") else None,
+        prompt_tokens=integer_attribute("prov.llm.prompt_tokens"),
+        completion_tokens=integer_attribute("prov.llm.completion_tokens"),
     )
 
 

--- a/sdk/python/tests/test_trace_analysis.py
+++ b/sdk/python/tests/test_trace_analysis.py
@@ -11,6 +11,7 @@ from agentweave.trace_analysis import (
     TraceQuestionError,
     answer_payload,
     parse_window,
+    plan_tail,
     plan_question,
     query_tempo,
 )
@@ -48,6 +49,12 @@ def test_query_tempo_returns_only_valid_trace_citations(monkeypatch):
                 "startTimeUnixNano": "123",
                 "spanSets": [{"spans": [{"attributes": [{
                     "key": "prov.agent.id", "value": {"stringValue": "nix"}
+                }, {
+                    "key": "prov.llm.model", "value": {"stringValue": "gpt-test"}
+                }, {
+                    "key": "prov.llm.prompt_tokens", "value": {"intValue": "10"}
+                }, {
+                    "key": "prov.llm.completion_tokens", "value": {"intValue": "5"}
                 }]}]}],
             },
             {"traceID": "not-a-trace"},
@@ -75,6 +82,9 @@ def test_query_tempo_returns_only_valid_trace_citations(monkeypatch):
     )
     assert [item.trace_id for item in citations] == ["a" * 32]
     assert citations[0].agent_id == "nix"
+    assert citations[0].model == "gpt-test"
+    assert citations[0].prompt_tokens == 10
+    assert citations[0].completion_tokens == 5
     assert "limit=5" in captured["url"]
     assert "start=6400" in captured["url"]
 
@@ -99,3 +109,11 @@ def test_empty_answer_is_not_reported_as_failure_and_citations_are_complete():
     assert empty["summary"].startswith("No matching data")
     assert empty["citations"] == []
     assert empty["traceql"] == plan.traceql
+
+
+def test_tail_plan_is_allowlisted_and_validates_session():
+    plan = plan_tail(session_id="agent:main:run-42")
+    assert "span.prov.llm.model != nil" in plan.traceql
+    assert 'span.prov.session.id = "agent:main:run-42"' in plan.traceql
+    with pytest.raises(TraceQuestionError, match="session ID"):
+        plan_tail(session_id='bad" }')


### PR DESCRIPTION
## Summary
- add continuous `agentweave trace tail` polling with optional session filter
- display trace ID, agent, model, tokens, cost, and latency when recorded
- support JSON-lines and one-shot modes for automation
- validate session IDs and lookback windows
- exclude local build caches from Docker contexts

## Validation
- `python3 -m pytest -q` — 601 passed
- live one-shot tail returned current deployed traces

Part of #129