### PR TITLE
feat(ci): ship standalone CLI distributions

### DIFF
--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -1,0 +1,64 @@
+name: Standalone release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Optional release tag to create (for example v0.3.8)
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            asset: linux-x86_64
+          - runner: macos-13
+            asset: macos-x86_64
+          - runner: macos-14
+            asset: macos-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build standalone executable
+        run: |
+          python -m pip install pyinstaller
+          python -m pip install -e "sdk/python[proxy]"
+          pyinstaller --onefile --name agentweave \
+            --collect-all agentweave \
+            sdk/python/agentweave/standalone.py
+          tar -czf "agentweave-${{ matrix.asset }}.tar.gz" -C dist agentweave
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agentweave-${{ matrix.asset }}
+          path: agentweave-${{ matrix.asset }}.tar.gz
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: agentweave-*
+          merge-multiple: true
+      - name: Generate checksums
+        run: sha256sum agentweave-*.tar.gz > SHA256SUMS
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.release_tag || github.ref_name }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: |
+            agentweave-*.tar.gz
+            SHA256SUMS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,4 +114,5 @@ jobs:
       - name: Validate standalone distribution entry points
         run: |
           bash -n scripts/install.sh
+          python -m pip install -e sdk/python
           PYTHONPATH=sdk/python python sdk/python/agentweave/standalone.py version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,3 +110,8 @@ jobs:
           python -m pip install pytest
           python -m py_compile scripts/trace_quality_gate.py tests/test_trace_quality_gate.py
           python -m pytest tests/test_trace_quality_gate.py
+
+      - name: Validate standalone distribution entry points
+        run: |
+          bash -n scripts/install.sh
+          PYTHONPATH=sdk/python python sdk/python/agentweave/standalone.py version

--- a/README.md
+++ b/README.md
@@ -146,17 +146,26 @@ quickstart.
 ### Local proxy path
 
 ```bash
-pip install "agentweave-sdk[proxy]"
-agentweave start --port 4000 --endpoint http://localhost:4318
-export ANTHROPIC_BASE_URL=http://localhost:4000/v1
+curl -sSfL https://raw.githubusercontent.com/Arniesaha/agentweave/main/scripts/install.sh | sh
+agentweave init --endpoint http://localhost:4318
+# Dashboard: http://localhost:4000/dashboard/
 ```
 
-Use `agentweave status` to inspect the local proxy and `agentweave stop` when
-you are done. `agentweave proxy start` remains available for foreground runs.
+Homebrew users can install the same standalone executable with
+`brew install arniesaha/tap/agentweave`. Python users may instead run
+`pip install "agentweave-sdk[proxy]"`.
+
+Use `agentweave status` to inspect the local proxy, `agentweave trace tail` to
+follow calls, and `agentweave stop` when you are done. `agentweave proxy start`
+remains available for foreground runs.
 
 Use your normal provider API key in the client environment. Proxy-side key
 injection and private NodePort URLs are dogfood-only conveniences, not required
 for the public developer-preview path.
+
+Proxy mode is optional. Claude Code Remote Control users should keep the normal
+Anthropic endpoint and configure Claude Code's native OpenTelemetry export so
+Remote Control remains available.
 
 ## Quickstart (Python)
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+repo="${AGENTWEAVE_REPOSITORY:-Arniesaha/agentweave}"
+version="${AGENTWEAVE_VERSION:-latest}"
+install_dir="${AGENTWEAVE_INSTALL_DIR:-/usr/local/bin}"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) asset="linux-x86_64" ;;
+  Darwin-x86_64) asset="macos-x86_64" ;;
+  Darwin-arm64) asset="macos-arm64" ;;
+  *) echo "Unsupported platform: $(uname -s) $(uname -m)" >&2; exit 1 ;;
+esac
+
+if [ "$version" = "latest" ]; then
+  base="https://github.com/${repo}/releases/latest/download"
+else
+  base="https://github.com/${repo}/releases/download/${version}"
+fi
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/agentweave-install.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+archive="agentweave-${asset}.tar.gz"
+
+curl -fsSL "${base}/${archive}" -o "${tmp_dir}/${archive}"
+curl -fsSL "${base}/SHA256SUMS" -o "${tmp_dir}/SHA256SUMS"
+(
+  cd "$tmp_dir"
+  expected=$(grep "  ${archive}$" SHA256SUMS || true)
+  [ -n "$expected" ] || { echo "Checksum missing for ${archive}" >&2; exit 1; }
+  printf '%s\n' "$expected" | shasum -a 256 -c -
+  tar -xzf "$archive"
+)
+
+mkdir -p "$install_dir" 2>/dev/null || true
+if [ -w "$install_dir" ]; then
+  install -m 0755 "${tmp_dir}/agentweave" "${install_dir}/agentweave"
+else
+  sudo install -m 0755 "${tmp_dir}/agentweave" "${install_dir}/agentweave"
+fi
+
+echo "Installed agentweave to ${install_dir}/agentweave"
+"${install_dir}/agentweave" version

--- a/sdk/python/agentweave/__init__.py
+++ b/sdk/python/agentweave/__init__.py
@@ -7,7 +7,7 @@ from agentweave.exporter import add_console_exporter, get_tracer, shutdown
 from agentweave.instrument import auto_instrument, uninstrument
 from agentweave.prompts import fetch_prompt as prompt, PromptHandle
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 __all__ = [
     "AgentWeaveConfig",

--- a/sdk/python/agentweave/normalizer_service.py
+++ b/sdk/python/agentweave/normalizer_service.py
@@ -36,7 +36,7 @@ from fastapi.responses import JSONResponse
 
 from agentweave.normalizer import normalize_payload
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"
 
 logger = logging.getLogger("agentweave.normalizer")
 

--- a/sdk/python/agentweave/proxy.py
+++ b/sdk/python/agentweave/proxy.py
@@ -348,7 +348,7 @@ _GEMINI_MODEL_RE = re.compile(r"/models/([^/:]+)")
 app = FastAPI(
     title="AgentWeave Proxy",
     description="Multi-provider AI observability proxy (Anthropic + Google Gemini + OpenAI)",
-    version="0.3.7",
+    version="0.3.8",
 )
 
 _EMBEDDED_DASHBOARD = os.getenv("AGENTWEAVE_EMBEDDED_DASHBOARD") == "1"

--- a/sdk/python/agentweave/standalone.py
+++ b/sdk/python/agentweave/standalone.py
@@ -1,0 +1,7 @@
+"""PyInstaller entry point for the standalone AgentWeave executable."""
+
+from agentweave.cli import app
+
+
+if __name__ == "__main__":
+    app()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentweave-sdk"
-version = "0.3.7"
+version = "0.3.8"
 description = "Observability and mesh layer for multi-agent AI systems — track what your agents decided, why they decided it, and how they're connected."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- add PyInstaller builds for Linux x86_64 and macOS x86_64/arm64
- attach checksummed archives to tagged or manually dispatched releases
- add a checksum-verifying Linux/macOS installer
- update the public quickstart for `agentweave init`, embedded dashboard, trace tail, and native OTel guidance
- bump the standalone/Python release to 0.3.8

## Validation
- `python3 -m pytest -q` — 608 passed
- `bash -n scripts/install.sh`
- standalone entry point reports v0.3.8

Part of #129