### PR TITLE
chore(k8s): deploy proxy version 0.3.8

### DIFF
--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           # Pinned so the running build is identifiable from the cluster alone.
           # scripts/deploy.sh cross-checks this against the SDK version and
           # refuses to deploy on mismatch. Bump both together.
-          image: localhost:5000/agentweave-proxy:0.3.7
+          image: localhost:5000/agentweave-proxy:0.3.8
           imagePullPolicy: Always
           ports:
             - containerPort: 4000


### PR DESCRIPTION
Align the pinned proxy image with the 0.3.8 SDK/release version from PR #276 so the deployment drift guard passes.

Part of #129.