### PR TITLE
fix(ci): use supported Intel macOS runner (#129)

### DIFF
--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - runner: ubuntu-latest
             asset: linux-x86_64
-          - runner: macos-13
+          - runner: macos-15-intel
             asset: macos-x86_64
           - runner: macos-14
             asset: macos-arm64


### PR DESCRIPTION
## Summary
- replace the retired macOS 13 runner with the supported `macos-15-intel` label
- unblock x86_64 standalone release artifacts

Closes a release-validation gap in #129.