### PR TITLE
fix(ci): lower standalone Linux glibc baseline (#129)

### DIFF
--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             asset: linux-x86_64
           - runner: macos-15-intel
             asset: macos-x86_64


### PR DESCRIPTION
Build the standalone Linux executable on Ubuntu 22.04 so it runs on Debian 12 and other systems with glibc older than 2.38. Found by installing and executing the published v0.3.8 artifact.